### PR TITLE
Remove org Components from Authentication section

### DIFF
--- a/src/pages/components/authentication/_meta.json
+++ b/src/pages/components/authentication/_meta.json
@@ -5,8 +5,5 @@
     "sign-up": "<SignUp />",
     "sign-up-button": "<SignUpButton />",
     "user-button": "<UserButton />",
-    "user-profile": "<UserProfile />",
-    "create-organization" : "<CreateOrganization/>",
-    "organization-profile": "<OrganizationProfile>/",
-    "organization-switcher": "<OrganizationSwitcher/>"
+    "user-profile": "<UserProfile />"
 }


### PR DESCRIPTION
These three links point to nowhere when clicked:
![image](https://user-images.githubusercontent.com/329419/224066659-f4ae87b5-dd42-4007-9d2f-d5fab69e8e9f.png)
and since they're repeated a bit lower in the menu, under "Organization Management", my guess is that they're left over there.

This PR removes them.