### PR TITLE
fix: file name typo

### DIFF
--- a/src/pages/quickstarts/nextjs/app-router.mdx
+++ b/src/pages/quickstarts/nextjs/app-router.mdx
@@ -100,7 +100,7 @@ export default function Page() {
 
 To use server side functionality, you need to add the Clerk middleware to your Next.js application. This allows you to access the session in your Next.js API routes and server-side rendered pages. Middleware should be placed at the root of your project.
 
-```tsx copy filename="middeware.ts"
+```tsx copy filename="middleware.ts"
 import { withClerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
@@ -124,7 +124,7 @@ Clerk offers two ways to protect your Next.js application, you can use Next.js M
 
 Using Middleware is the most comprehensive way to implement page protection in your app. Below is an example of page protection using Middleware.
 
-```ts copy filename="middeware.ts"
+```ts copy filename="middleware.ts"
 import { withClerkMiddleware, getAuth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";

--- a/src/pages/quickstarts/nextjs/stable.mdx
+++ b/src/pages/quickstarts/nextjs/stable.mdx
@@ -108,7 +108,7 @@ To make sure you are using the embedded components you will need to update your 
 
 To use server side functionality, you need to add the Clerk middleware to your Next.js application. This allows you to access the session in your Next.js API routes and server-side rendered pages.
 
-```tsx filename="middeware.ts" copy
+```tsx filename="middleware.ts" copy
 import { withClerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";

--- a/src/pages/sdk/next/with-clerk-middleware.mdx
+++ b/src/pages/sdk/next/with-clerk-middleware.mdx
@@ -12,7 +12,7 @@ The `withClerkMiddleware` wrapper allows Clerk to access session data on the ser
 
 This is the minimal amount of code needed to use Clerk Server Side helpers.
 
-```tsx filename="middeware.ts" copy
+```tsx filename="middleware.ts" copy
 import { withClerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
@@ -29,7 +29,7 @@ export const config = {
 
 #### Usage with page protection
 
-```tsx filename="middeware.ts" copy
+```tsx filename="middleware.ts" copy
 import { withClerkMiddleware, getAuth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";


### PR DESCRIPTION
This is very trivial, but the file name of the sample code in the heading(Add Middleware, Protecting Your Pages) is incorrect.

Middleware will not work properly if the file name is wrong.
It would be much appriciated if you could modify them.