### PR TITLE
Add a recommendation to wrap the body tag with the ClerkProvider

### DIFF
--- a/src/pages/quickstarts/nextjs/app-router.mdx
+++ b/src/pages/quickstarts/nextjs/app-router.mdx
@@ -35,7 +35,7 @@ CLERK_SECRET_KEY=sk_test_••••••••••••••••••�
 
 ## Mount `<ClerkProvider>`
 
-Update your root layout to include the `<ClerkProvider>` wrapper. The `<ClerkProvider>` component wraps your Next.js application to provide active session and user context to Clerk's hooks and other components.
+Update your root layout to include the `<ClerkProvider>` wrapper. The `<ClerkProvider>` component wraps your Next.js application to provide active session and user context to Clerk's hooks and other components. It is recommended that the `<ClerkProvider>` wraps the `<body>` to enable the context to be accessible anywhere within the app.
 
 ```tsx copy filename="app/layout.tsx"
 import React from "react";


### PR DESCRIPTION
While it is shown in the example as such there is no explicit recommendation to wrap the `<body>` with the `<ClerkProvider>`, this PR aims to add that recommendation and remove any potential ambiguity.