### PR TITLE
Move support items to navbar icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ next-env.d.ts
 ## Lock files
 package-lock.json
 yarn.lock
+
+.idea/

--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -80,24 +80,5 @@
   "glossary": "Glossary (coming soon)",
   "security": {
     "title": "Security (coming soon)"
-  },
-  "Support": {
-    "title": "Support",
-    "type": "separator"
-  },
-  "discord": {
-    "title": "Discord ↗",
-    "href": "https://discord.com/invite/b5rXHjAg7A",
-    "newWindow": true
-  },
-  "twitter": {
-    "title": "Twitter ↗",
-    "href": "https://twitter.com/clerkdev",
-    "newWindow": true
-  },
-  "email": {
-    "title": "Email Us ↗",
-    "href": "mailto:support@clerk.dev",
-    "newWindow": true
   }
 }

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,12 +1,11 @@
-
-import type { DocsThemeConfig } from 'nextra-theme-docs';
-import { useConfig } from 'nextra-theme-docs'
-import { useRouter } from 'next/router'
+import type {DocsThemeConfig} from 'nextra-theme-docs';
+import {useConfig} from 'nextra-theme-docs'
+import {useRouter} from 'next/router'
 
 const config: DocsThemeConfig = {
 
   useNextSeoProps() {
-    const { asPath } = useRouter()
+    const {asPath} = useRouter()
     if (asPath !== '/') {
       return {
         titleTemplate: '%s | Clerk'
@@ -15,8 +14,8 @@ const config: DocsThemeConfig = {
     return {}
   },
   head: function useHead() {
-    const { title } = useConfig()
-    const { route } = useRouter()
+    const {title} = useConfig()
+    const {route} = useRouter()
     const socialCard =
       route === '/' || !title
         ? 'clerk-docs.clerkpreview.com/clerk-og.png'
@@ -24,10 +23,10 @@ const config: DocsThemeConfig = {
 
     return (
       <>
-        <meta name="msapplication-TileColor" content="#fff" />
-        <meta name="theme-color" content="#fff" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta httpEquiv="Content-Language" content="en" />
+        <meta name="msapplication-TileColor" content="#fff"/>
+        <meta name="theme-color" content="#fff"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta httpEquiv="Content-Language" content="en"/>
         <meta
           name="description"
           content="Authentication and User management for the modern web"
@@ -36,11 +35,11 @@ const config: DocsThemeConfig = {
           name="og:description"
           content="Authentication and User management for the modern web"
         />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content={socialCard} />
-        <meta name="twitter:site:domain" content="clerk.dev" />
-        <meta name="twitter:url" content="https://clerk.dev" />
-        <meta name="og:image" content={socialCard} />
+        <meta name="twitter:card" content="summary_large_image"/>
+        <meta name="twitter:image" content={socialCard}/>
+        <meta name="twitter:site:domain" content="clerk.dev"/>
+        <meta name="twitter:url" content="https://clerk.dev"/>
+        <meta name="og:image" content={socialCard}/>
       </>
     )
   },
@@ -74,9 +73,9 @@ const config: DocsThemeConfig = {
             y2="22.5365"
             gradientUnits="userSpaceOnUse"
           >
-            <stop stopColor="#17CCFC" />
-            <stop offset="0.5" stopColor="#5D31FF" />
-            <stop offset="1" stopColor="#F35AFF" />
+            <stop stopColor="#17CCFC"/>
+            <stop offset="0.5" stopColor="#5D31FF"/>
+            <stop offset="1" stopColor="#F35AFF"/>
           </linearGradient>
         </defs>
       </svg>
@@ -94,16 +93,53 @@ const config: DocsThemeConfig = {
     </>
   ),
   docsRepositoryBase: "https://github.com/clerkinc/clerk-docs/tree/main",
-  project: {
-    link: "https://github.com/clerkinc/clerk-docs/",
+  navbar: {
+    extraContent: () => {
+      return <>
+        <a href="https://discord.com/invite/b5rXHjAg7A" target="_blank" rel="noreferrer"
+           className="nx-p-2 nx-text-current">
+          <svg height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36">
+            <g id="图层_2" data-name="图层 2">
+              <g id="Discord_Logos" data-name="Discord Logos">
+                <g id="Discord_Logo_-_Large_-_White" data-name="Discord Logo - Large - White">
+                  <path
+                    d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
+                </g>
+              </g>
+            </g>
+          </svg>
+          <span className="nx-sr-only">GitHub</span>
+          <span className="nx-sr-only"> (opens in a new tab)</span>
+        </a>
+        <a href="https://twitter.com/clerkdev" target="_blank" rel="noreferrer"
+           className="nx-p-2 nx-text-current">
+          <svg height="24" width="24" version="1.1" id="Logo" xmlns="http://www.w3.org/2000/svg"
+               x="0px" y="0px" viewBox="0 0 248 204">
+            <g id="Logo_1_">
+              <path id="white_background"
+                    d="M221.95,51.29c0.15,2.17,0.15,4.34,0.15,6.53c0,66.73-50.8,143.69-143.69,143.69v-0.04   C50.97,201.51,24.1,193.65,1,178.83c3.99,0.48,8,0.72,12.02,0.73c22.74,0.02,44.83-7.61,62.72-21.66   c-21.61-0.41-40.56-14.5-47.18-35.07c7.57,1.46,15.37,1.16,22.8-0.87C27.8,117.2,10.85,96.5,10.85,72.46c0-0.22,0-0.43,0-0.64   c7.02,3.91,14.88,6.08,22.92,6.32C11.58,63.31,4.74,33.79,18.14,10.71c25.64,31.55,63.47,50.73,104.08,52.76   c-4.07-17.54,1.49-35.92,14.61-48.25c20.34-19.12,52.33-18.14,71.45,2.19c11.31-2.23,22.15-6.38,32.07-12.26   c-3.77,11.69-11.66,21.62-22.2,27.93c10.01-1.18,19.79-3.86,29-7.95C240.37,35.29,231.83,44.14,221.95,51.29z"/>
+            </g>
+          </svg>
+          <span className="nx-sr-only">Twitter</span>
+          <span className="nx-sr-only"> (opens in a new tab)</span>
+        </a>
+        <a href="https://github.com/clerkinc/clerk-docs/" target="_blank" rel="noreferrer"
+           className="nx-p-2 nx-text-current">
+          <svg width="24" height="24" fill="currentColor" viewBox="3 3 18 18"><title>GitHub</title>
+            <path
+              d="M12 3C7.0275 3 3 7.12937 3 12.2276C3 16.3109 5.57625 19.7597 9.15374 20.9824C9.60374 21.0631 9.77249 20.7863 9.77249 20.5441C9.77249 20.3249 9.76125 19.5982 9.76125 18.8254C7.5 19.2522 6.915 18.2602 6.735 17.7412C6.63375 17.4759 6.19499 16.6569 5.8125 16.4378C5.4975 16.2647 5.0475 15.838 5.80124 15.8264C6.51 15.8149 7.01625 16.4954 7.18499 16.7723C7.99499 18.1679 9.28875 17.7758 9.80625 17.5335C9.885 16.9337 10.1212 16.53 10.38 16.2993C8.3775 16.0687 6.285 15.2728 6.285 11.7432C6.285 10.7397 6.63375 9.9092 7.20749 9.26326C7.1175 9.03257 6.8025 8.08674 7.2975 6.81794C7.2975 6.81794 8.05125 6.57571 9.77249 7.76377C10.4925 7.55615 11.2575 7.45234 12.0225 7.45234C12.7875 7.45234 13.5525 7.55615 14.2725 7.76377C15.9937 6.56418 16.7475 6.81794 16.7475 6.81794C17.2424 8.08674 16.9275 9.03257 16.8375 9.26326C17.4113 9.9092 17.76 10.7281 17.76 11.7432C17.76 15.2843 15.6563 16.0687 13.6537 16.2993C13.98 16.5877 14.2613 17.1414 14.2613 18.0065C14.2613 19.2407 14.25 20.2326 14.25 20.5441C14.25 20.7863 14.4188 21.0746 14.8688 20.9824C16.6554 20.364 18.2079 19.1866 19.3078 17.6162C20.4077 16.0457 20.9995 14.1611 21 12.2276C21 7.12937 16.9725 3 12 3Z"></path>
+          </svg>
+          <span className="nx-sr-only">GitHub</span><span className="nx-sr-only"> (opens in a new tab)</span></a>
+      </>
+    }
   },
   sidebar: {
     defaultMenuCollapseLevel: 1,
     toggleButton: true,
-    titleComponent: ({ title, type }) => {
+    titleComponent: ({title, type}) => {
       if (type === 'separator') {
         return (
-          <div style={{ fontSize: '1.2rem' }}>{title}</div>
+          <div style={{fontSize: '1.2rem'}}>{title}</div>
         );
       }
       return <>{title}</>;
@@ -118,7 +154,7 @@ const config: DocsThemeConfig = {
           Clerk
         </a>
         .
-      </span >
+      </span>
     ),
   },
   feedback: {


### PR DESCRIPTION
This PR moves the following support sidebar items:

- Discord
- Twitter

To the top navbar in the form of icons.

It also removes the support email from the sidebar, which can be added to the footer in the near future if we like this idea.