### PR TITLE
docs: use recommended practices of expo guides -- for EAS

### DIFF
--- a/src/pages/quickstarts/native/expo.mdx
+++ b/src/pages/quickstarts/native/expo.mdx
@@ -39,11 +39,7 @@ Once you have a Expo application ready, you need to install Clerk's Expo SDK.
 
 ## Set Environment Variables
 
-Below is an example of an `.env.local` and `app.config.js` files. To get your keys go to the API Keys page on the [Clerk dashboard](https://dashboard.clerk.com).
-
-```sh copy filename=".env.local"
-CLERK_PUBLISHABLE_KEY=pk_test_••••••••••••••••••••••••••••••••••
-```
+Below is an example of an `app.config.js` file. To get your keys go to the API Keys page on the [Clerk dashboard](https://dashboard.clerk.com).
 
 ```sh copy filename="app.config.js"
 module.exports = {
@@ -54,6 +50,10 @@ module.exports = {
   },
 };
 ```
+
+<Callout type="info">
+  For further information, check [Environment variables in Expo](https://docs.expo.dev/guides/environment-variables)
+</Callout>
 
 
 ## Mount `<ClerkProvider>`

--- a/src/pages/quickstarts/native/expo.mdx
+++ b/src/pages/quickstarts/native/expo.mdx
@@ -33,10 +33,6 @@ Once you have a Expo application ready, you need to install Clerk's Expo SDK.
   </Tab>
 </Tabs>
 
-<Callout type="warning">
-  Ensure you also setup [Expo AuthSession](https://docs.expo.dev/versions/latest/sdk/auth-session/) installed before continuing, as it is a required dependency.
-</Callout>
-
 ## Set Environment Variables
 
 Below is an example of an `app.config.js` file. To get your keys go to the API Keys page on the [Clerk dashboard](https://dashboard.clerk.com).

--- a/src/pages/quickstarts/native/expo.mdx
+++ b/src/pages/quickstarts/native/expo.mdx
@@ -33,21 +33,42 @@ Once you have a Expo application ready, you need to install Clerk's Expo SDK.
   </Tab>
 </Tabs>
 
+<Callout type="warning">
+  Ensure you also setup [Expo AuthSession](https://docs.expo.dev/versions/latest/sdk/auth-session/) installed before continuing, as it is a required dependency.
+</Callout>
+
+## Set Environment Variables
+
+Below is an example of an `.env.local` and `app.config.js` files. To get your keys go to the API Keys page on the [Clerk dashboard](https://dashboard.clerk.com).
+
+```sh copy filename=".env.local"
+CLERK_PUBLISHABLE_KEY=pk_test_••••••••••••••••••••••••••••••••••
+```
+
+```sh copy filename="app.config.js"
+module.exports = {
+  name: 'MyApp',
+  version: '1.0.0',
+  extra: {
+    clerkPublishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  },
+};
+```
+
+
 ## Mount `<ClerkProvider>`
 
-Clerk requires your Expo application to be wrapped in the `<ClerkProvider/>` component. The `<ClerkProvider />` component provides active session and user context to Clerk's hooks and other components.
-
-The `CLERK_PUBLISHABLE_KEY` can be obtained from the API Keys page in the [Clerk dashboard](https://dashboard.clerk.dev).
+Update your app entry file to include the `<ClerkProvider>` wrapper. The `<ClerkProvider>` component wraps your Expo application to provide active session and user context to Clerk's hooks and other components. It is recommended that the `<ClerkProvider>` wraps everything else to enable the context to be accessible anywhere within the app.
 
 ```tsx filename="app.tsx" copy
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider } from "@clerk/clerk-expo";
+import Constants from "expo-constants"
 
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••"
 export default function App() {
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    <ClerkProvider publishableKey={Constants.expoConfig.extra.clerkPublishableKey}>
       <SafeAreaView style={styles.container}>
         <Text>Hello world!</Text>
       </SafeAreaView>
@@ -73,11 +94,11 @@ Clerk offers Control Components that allow you to protect your pages. In the exa
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
+import Constants from "expo-constants"
 
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••"
 export default function App() {
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    <ClerkProvider publishableKey={Constants.expoConfig.extra.clerkPublishableKey}>
       <SafeAreaView style={styles.container}>
         <SignedIn>
           <Text>You are Signed in</Text>
@@ -219,12 +240,12 @@ Make sure you update your `app` file to use the component that you have created,
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
+import Constants from "expo-constants"
 import SignUpScreen from "./components/SignUpScreen";
 
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••";
 export default function App() {
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    <ClerkProvider publishableKey={Constants.expoConfig.extra.clerkPublishableKey}>
       <SafeAreaView styles={styles.container}>
         <SignedIn>
           <Text>You are Signed in</Text>
@@ -314,12 +335,12 @@ Make sure you update your `app` file to use the component that you have created,
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
+import Constants from "expo-constants"
 import SignInScreen from "./components/SignInScreen";
 
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••";
 export default function App() {
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    <ClerkProvider publishableKey={Constants.expoConfig.extra.clerkPublishableKey}>
       <SafeAreaView styles={styles.container}>
         <SignedIn>
           <Text>You are Signed in</Text>
@@ -410,12 +431,12 @@ Make sure you update your `app` file to use the component that you have created,
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
+import Constants from "expo-constants"
 import SignInWithOAuth from "./components/SignInWithOAuth";
 
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••";
 export default function App() {
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+    <ClerkProvider publishableKey={Constants.expoConfig.extra.clerkPublishableKey}>
       <SafeAreaView styles={styles.container}>
         <SignedIn>
           <Text>You are Signed in</Text>
@@ -473,9 +494,8 @@ import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
 import { SignInWithOAuth } from "./components/SignInWithOAuth";
+import Constants from "expo-constants"
 import * as SecureStore from "expo-secure-store";
-
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••";
 
 const tokenCache = {
   async getToken(key: string) {
@@ -498,7 +518,7 @@ export default function App() {
   return (
     <ClerkProvider
       tokenCache={tokenCache}
-      publishableKey={CLERK_PUBLISHABLE_KEY}
+      publishableKey={Constants.expoConfig.extra.clerkPublishableKey}
     >
       <SafeAreaView styles={styles.container}>
         <SignedIn>
@@ -531,9 +551,8 @@ import React from "react";
 import { SafeAreaView, Text, StyleSheet, View, Button } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut,useAuth } from "@clerk/clerk-expo";
 import { SignInWithOAuth } from "./components/SignInWithOAuth";
+import Constants from "expo-constants"
 import * as SecureStore from "expo-secure-store";
-
-const CLERK_PUBLISHABLE_KEY = "pk_test_••••••••••••••••••••••••••••••••••";
 
 const tokenCache = {
   getToken(key: string) {
@@ -573,7 +592,7 @@ export default function App() {
   return (
     <ClerkProvider
       tokenCache={tokenCache}
-      publishableKey={CLERK_PUBLISHABLE_KEY}
+      publishableKey={Constants.expoConfig.extra.clerkPublishableKey}
     >
       <SafeAreaView styles={styles.container}>
         <SignedIn>


### PR DESCRIPTION
Changes:

-- | Img
-- | --
Add disclaimer about the needed dependencies that needs to be manually added | ![image](https://github.com/clerkinc/clerk-docs/assets/28108272/5a533d6b-c83a-4b01-ab8c-399c907c772d)
Make instructions more on par with what Next.JS have now | ![image](https://github.com/clerkinc/clerk-docs/assets/28108272/0a77cb3b-be06-43b1-bf31-6e99fe53c19f)

I found the second one specially useful since I worked in many codebases where people would blindly copy the snippets as they were provided.

So now, even if someone copy it and just change the values, they're likely to do as Expo recommends &mdash; and even learn something new about it 🙂 

