### PR TITLE
chore: make reference docs headers more consistent

### DIFF
--- a/src/pages/reference-react/customization/_meta.json
+++ b/src/pages/reference-react/customization/_meta.json
@@ -1,0 +1,4 @@
+{
+  "appearance": "Appearance",
+  "localization": "Localization"
+}

--- a/src/pages/reference-react/internals/use-clerk.mdx
+++ b/src/pages/reference-react/internals/use-clerk.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# useClerk
+# `useClerk()`
 
 The `useClerk` hook provides access to the the Clerk object, giving you the ability to build alternatives to any Clerk Component.
 

--- a/src/pages/reference-react/internals/use-session-list.mdx
+++ b/src/pages/reference-react/internals/use-session-list.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# useSessionList
+# `useSessionList()`
 
 The `useSessionList` hook provides returns an array of Session objects that have been registered on the client device.
 

--- a/src/pages/reference-react/internals/use-session.mdx
+++ b/src/pages/reference-react/internals/use-session.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# useSession
+# `useSession()`
 
 The `useSession` hook provides access to the the current user Session object, and helpers to set the active session.
 
@@ -15,7 +15,7 @@ import { useSession } from "@clerk/nextjs";
 
 export default function Home() {
   const { isLoaded, session,isSignedIn } = useSession();
-  
+
   if (!isLoaded) {
     // handle loading state
     return null;
@@ -24,10 +24,10 @@ export default function Home() {
     // handle not signed in state
     return null;
   }
-  
+
   return (
-    <div> 
-      <p>This session has been active 
+    <div>
+      <p>This session has been active
       since {session.lastActiveAt.toLocaleString()}
       </p>
     </div>
@@ -41,7 +41,7 @@ import { useSession } from "@clerk/clerk-react";
 
 export default function Home() {
   const { isLoaded, session,isSignedIn } = useSession();
-  
+
   if (!isLoaded) {
     // handle loading state
     return null;
@@ -50,10 +50,10 @@ export default function Home() {
     // handle not signed in state
     return null;
   }
-  
+
   return (
-    <div> 
-      <p>This session has been active 
+    <div>
+      <p>This session has been active
       since {session.lastActiveAt.toLocaleString()}
       </p>
     </div>

--- a/src/pages/reference-react/internals/use-sign-in.mdx
+++ b/src/pages/reference-react/internals/use-sign-in.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# `useSignIn`
+# `useSignIn()`
 
 The `useSignIn` hook gives you access to the SignIn object, which allows you to check the current state of a sign in and sign in users with custom flows.
 

--- a/src/pages/reference-react/internals/use-sign-up.mdx
+++ b/src/pages/reference-react/internals/use-sign-up.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# `useSignUp`
+# `useSignUp()`
 
 The `useSignUp` hook gives you access to the SignUp object, which allows you to check the current state of a sign up and sign up users with custom flows.
 

--- a/src/pages/reference-react/user-management/use-auth.mdx
+++ b/src/pages/reference-react/user-management/use-auth.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# useAuth
+# `useAuth()`
 
 The `useAuth` hook provides lightweight access to the current auth state, helpers to manage the state and load data from external sources.
 

--- a/src/pages/reference-react/user-management/use-user.mdx
+++ b/src/pages/reference-react/user-management/use-user.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 import { Callout } from "nextra-theme-docs";
 import { Tables } from "@/components/Table";
 
-# `useUser`
+# `useUser()`
 
 The `useUser` hook is used to get the current user object and to update the user's data on the client side.
 


### PR DESCRIPTION
This PR makes sure that all reference docs use the same headers like:

- `useHook()`
- `<Comp/>`
- `fn()`