### PR TITLE
Create new <ClerkProvider/> docs page

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,11 +2,17 @@ type TableRow = {
   cells: Array<string>;
 };
 
+interface HeadingMeta {
+  maxWidth?: string;
+}
+
 export const Tables = ({
   headings,
+  headingsMeta,
   rows,
 }: {
   headings: Array<string>;
+  headingsMeta: Array<HeadingMeta>;
   rows: TableRow[];
 }) => {
   return (
@@ -17,11 +23,24 @@ export const Tables = ({
             <table className="min-w-full text-left text-sm">
               <thead className="border-b font-medium dark:border-neutral-500">
                 <tr>
-                  {headings?.map((heading, index) => (
-                    <th scope="col" className="px-6 py-4" key={`th-${index}`}>
-                      {heading}
-                    </th>
-                  ))}
+                  {headings?.map((heading, index) => {
+                    const maxWidth =
+                      headingsMeta?.[index]?.maxWidth ?? undefined;
+                    return (
+                      <th
+                        style={{
+                          maxWidth,
+                        }}
+                        scope="col"
+                        className={`px-6 py-4 ${
+                          maxWidth ? "whitespace-pre-wrap" : ""
+                        }`}
+                        key={`th-${index}`}
+                      >
+                        {heading}
+                      </th>
+                    );
+                  })}
                 </tr>
               </thead>
               <tbody>
@@ -32,11 +51,19 @@ export const Tables = ({
                   >
                     {row.cells.map((cell, idx) => {
                       const result = cell.split(/\r?\n/);
+                      const maxWidth =
+                        headingsMeta?.[idx]?.maxWidth ?? undefined;
+
                       if (result.length > 1) {
                         return (
                           <td
-                            className="whitespace-nowrap px-6 py-4"
+                            className={`whitespace-nowrap px-6 py-4 ${
+                              maxWidth ? "whitespace-pre-wrap" : ""
+                            }`}
                             key={`cell-${index}-${idx}`}
+                            style={{
+                              maxWidth,
+                            }}
                           >
                             {result.map((line, i) => (
                               <span className="my-2 " key={`line-${i}`}>
@@ -50,8 +77,13 @@ export const Tables = ({
 
                       return (
                         <td
-                          className="whitespace-nowrap px-6 py-4"
+                          className={`whitespace-nowrap px-6 py-4 ${
+                            maxWidth ? "whitespace-pre-wrap" : ""
+                          }`}
                           key={`cell-${index}-${idx}`}
+                          style={{
+                            maxWidth,
+                          }}
                         >
                           {cell}
                         </td>

--- a/src/pages/reference-react/_meta.json
+++ b/src/pages/reference-react/_meta.json
@@ -1,4 +1,5 @@
 {
+  "general": "General",
   "authentication": "Authentication",
   "user-management": "User Management",
   "organization-management": "Organization Management",

--- a/src/pages/reference-react/general/_meta.json
+++ b/src/pages/reference-react/general/_meta.json
@@ -1,0 +1,3 @@
+{
+  "clerk-provider": "<ClerkProvider/>"
+}

--- a/src/pages/reference-react/general/clerk-provider.mdx
+++ b/src/pages/reference-react/general/clerk-provider.mdx
@@ -1,0 +1,127 @@
+import { Tab, Tabs } from "nextra-theme-docs";
+import { Tables } from "@/components/Table";
+import { CodeBlockTabs } from "@/components/CodeBlockTabs";
+
+# `<ClerkProvider/>`
+
+The ClerkProvider component wraps your React application to provide active session and user context to Clerk's hooks and other components.
+
+## Usage
+
+The ClerkProvider component must be added to your React entrypoint.
+
+<Tabs items={['Next.js', 'React']}>
+<Tab>
+<CodeBlockTabs options={["App Directory", "Pages Directory"]}>
+```tsx copy filename="app/layout.tsx"
+import React from "react";
+import { ClerkProvider } from "@clerk/nextjs/app-beta";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <head>
+        <title>Next.js 13 with Clerk</title>
+      </head>
+      <ClerkProvider>
+        <body>{children}</body>
+      </ClerkProvider>
+    </html>
+  );
+}
+```
+```tsx filename="_app.tsx" copy
+import { ClerkProvider } from "@clerk/nextjs";
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider {...pageProps}>
+     <Component {...pageProps} />
+    </ClerkProvider>
+  );
+}
+
+export default MyApp;
+```
+</CodeBlockTabs>
+</Tab>
+<Tab>
+```tsx filename="index.tsx" copy
+import React from "react";
+import ReactDOM from "react-dom";
+import { ClerkProvider } from "@clerk/clerk-react";
+import App from "./App";
+
+const publishableKey = process.env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+ReactDOM.render(
+  <React.StrictMode>
+    <ClerkProvider publishableKey={publishableKey}>
+      <App/>
+    </ClerkProvider>
+  </React.StrictMode>,
+  document.getElementById("root")
+);
+```
+</Tab>
+</Tabs>
+
+{/* TODO: Make dedicated docs pages for these meta-frameworks */}
+> Other meta-frameworks, like Remix and Gatsby have wrappers around `<ClerkProvider/>`, like
+> [`<ClerkApp/>`](https://github.com/clerkinc/remix-auth-starter/blob/0f4793b32efe21c6987889f7f5e065b8ed157393/app/root.tsx#L4)
+> and [`gatsby-plugin-clerk`](https://www.gatsbyjs.com/plugins/gatsby-plugin-clerk/) respectively, to make their integrations tighter.
+
+## Props
+
+<Tables
+  headings={["Name", "Type", "Description"]}
+  rows={[
+    {
+      cells: [
+        "publishableKey",
+        "string",
+        `Clerk publishable key for your instance.\nThis can be found in your clerk Dashboard.`,
+      ],
+    },
+    {
+      cells: [
+        "frontendApi",
+        "string",
+        "The frontend API host for your instance.\nThis can be found in your clerk Dashboard.",
+      ],
+    },
+    {
+      cells: [
+        "navigate?",
+        "(to: string) => Promise<any> | void",
+        "A function which takes the destination path as\nan argument and performs a \"push\" navigation.",
+      ],
+    },
+    {
+      cells: [
+        "clerkJSVariant?",
+        "string",
+        "If your web application uses only Control\ncomponents you can set this value to headless\nand load a minimal ClerkJS bundle for optimal\npage performance.",
+      ],
+    },
+    {
+      cells: [
+        "supportEmail?",
+        "string",
+        "Optional support email for display in\nauthentication screens. Will only affect Clerk\nComponents and not Clerk Hosted pages.",
+      ],
+    },
+    {
+      cells: [
+        "localization?",
+        "object",
+        "Optional object to localize your Components.\nWill only affect Clerk Components and\nnot Clerk Hosted pages.",
+      ],
+    },
+  ]}
+/>

--- a/src/pages/reference-react/general/clerk-provider.mdx
+++ b/src/pages/reference-react/general/clerk-provider.mdx
@@ -80,47 +80,55 @@ ReactDOM.render(
 
 <Tables
   headings={["Name", "Type", "Description"]}
+  headingsMeta={[{}, {}, {maxWidth: '300px'}]}
   rows={[
     {
       cells: [
         "publishableKey",
         "string",
-        `Clerk publishable key for your instance.\nThis can be found in your clerk Dashboard.`,
+        `Clerk publishable key for your instance. This can be found in your Clerk Dashboard.`,
       ],
     },
     {
       cells: [
         "frontendApi",
         "string",
-        "The frontend API host for your instance.\nThis can be found in your clerk Dashboard.",
+        "The frontend API host for your instance. This can be found in your Clerk Dashboard.",
       ],
     },
     {
       cells: [
         "navigate?",
         "(to: string) => Promise<any> | void",
-        "A function which takes the destination path as\nan argument and performs a \"push\" navigation.",
+        "A function which takes the destination path asan argument and performs a \"push\" navigation.",
       ],
     },
     {
       cells: [
         "clerkJSVariant?",
         "string",
-        "If your web application uses only Control\ncomponents you can set this value to headless\nand load a minimal ClerkJS bundle for optimal\npage performance.",
+        "If your web application uses only Control components you can set this value to headless and load a minimal ClerkJS bundle for optimal page performance.",
       ],
     },
     {
       cells: [
         "supportEmail?",
         "string",
-        "Optional support email for display in\nauthentication screens. Will only affect Clerk\nComponents and not Clerk Hosted pages.",
+        "Optional support email for display in authentication screens. Will only affect Clerk Components and not Clerk Hosted pages.",
       ],
     },
     {
       cells: [
         "localization?",
         "object",
-        "Optional object to localize your Components.\nWill only affect Clerk Components and\nnot Clerk Hosted pages.",
+        "Optional object to localize your Components. Will only affect Clerk Components and not Clerk Hosted pages.",
+      ],
+    },
+    {
+      cells: [
+        "allowedRedirectOrigins?",
+        "Array<string | RegExp>",
+        "Optional array of domains used to validate against the query param of an auth redirect.\n\nIf no match is made, the redirect is considered unsafe and the default redirect will be used with a warning passed to the console.",
       ],
     },
   ]}


### PR DESCRIPTION
I added a new docs page: https://clerk-docs-git-clerk-provider.clerkpreview.com/reference-react/general/clerk-provider

We should make sure to add the `allowRedirectOrigins` to [this page of the stable docs](https://clerk.com/docs/reference/clerk-react/clerkprovider)

