### PR TITLE
Add Gatsby Reference Page

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,5 +1,5 @@
 type TableRow = {
-  cells: Array<string>;
+  cells: Array<string | React.ReactNode>;
 };
 
 interface HeadingMeta {
@@ -50,7 +50,8 @@ export const Tables = ({
                     key={`row-${index}`}
                   >
                     {row.cells.map((cell, idx) => {
-                      const result = cell.split(/\r?\n/);
+                      const result =
+                        typeof cell === "string" ? cell.split(/\r?\n/) : [];
                       const maxWidth =
                         headingsMeta?.[idx]?.maxWidth ?? undefined;
 

--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -46,6 +46,7 @@
   },
   "reference-react": "React",
   "reference-next": "NextJS",
+  "reference-gatsby": "Gatsby",
   "reference-js": "JavaScript",
   "reference-node": {
     "title": "Node (coming Soon)"

--- a/src/pages/reference-gatsby/_meta.json
+++ b/src/pages/reference-gatsby/_meta.json
@@ -1,0 +1,3 @@
+{
+  "with-server-auth": "withServerAuth()"
+}

--- a/src/pages/reference-gatsby/with-server-auth.mdx
+++ b/src/pages/reference-gatsby/with-server-auth.mdx
@@ -1,0 +1,31 @@
+import { Tab, Tabs } from "nextra-theme-docs";
+import { Callout } from "nextra-theme-docs";
+import { Tables } from "@/components/Table";
+
+# `withServerAuth()`
+
+## Usage
+
+```tsx
+import * as React from 'react';
+import { GetServerData } from 'gatsby';
+import { withServerAuth } from 'gatsby-plugin-clerk/ssr';
+
+export const getServerData: GetServerData<any> = withServerAuth(
+  async props => {
+    return { props: { data: '1', auth: props.auth } };
+  },
+  { loadUser: true },
+);
+
+function SSRPage({ serverData }: any) {
+  return (
+    <main>
+      <h1>SSR Page with Clerk</h1>
+      <pre>{JSON.stringify(serverData, null, 2)}</pre>
+    </main>
+  );
+}
+
+export default SSRPage;
+```

--- a/src/pages/reference-gatsby/with-server-auth.mdx
+++ b/src/pages/reference-gatsby/with-server-auth.mdx
@@ -8,17 +8,17 @@ import { Tables } from "@/components/Table";
 
 ```tsx
 import * as React from 'react';
-import { GetServerData } from 'gatsby';
 import { withServerAuth } from 'gatsby-plugin-clerk/ssr';
+import { PageProps } from "gatsby";
 
-export const getServerData: GetServerData<any> = withServerAuth(
+export const getServerData = withServerAuth(
   async props => {
     return { props: { data: '1', auth: props.auth } };
   },
   { loadUser: true },
 );
 
-function SSRPage({ serverData }: any) {
+function SSRPage({ serverData }: PageProps) {
   return (
     <main>
       <h1>SSR Page with Clerk</h1>
@@ -29,3 +29,102 @@ function SSRPage({ serverData }: any) {
 
 export default SSRPage;
 ```
+
+## Props
+
+`withServerAuth` takes two arguments:
+
+{/* CB is technically optional, but no matter what options I set here I couldn't get anything returned to `serverData` */}
+
+
+```typescript
+function withServer(cb: Callback, options: Options): GetServerDataReturn;
+```
+
+Gatsby then automatically passes the result of `withServer`'s callback to the `serverData` property on the page's component props.
+
+### Callback Props
+
+<Tables
+  headings={["Name", "Type", "Description"]}
+  headingsMeta={[{}, {}, {maxWidth: '300px'}]}
+  rows={[
+    {
+      cells: [
+        <code>auth</code>,
+        // TODO: Add link to reference page for this property when it exists
+        <code>ServerSideAuth</code>,
+        <>Current auth data, including <code>sessionId</code> and <code>userId</code>.</>,
+      ],
+    },
+    {
+      cells: [
+        <code>session</code>,
+        // TODO: Update link to be on this docs site when page exists
+        <a href="https://clerk.com/docs/reference/clerkjs/session#attributes"><code>Session</code></a>,
+        <>The current session.<br/><br/>Requires <code>loadSession</code> to be set to <code>true</code> in options.</>
+      ],
+    },
+    {
+      cells: [
+        <code>user</code>,
+        // TODO: Update link to be on this docs site when page exists
+        <a href="https://clerk.com/docs/reference/clerkjs/user#attributes"><code>User</code></a>,
+        <>The current user.<br/><br/>Requires <code>loadUser</code> to be set to <code>true</code> in options.</>,
+      ],
+    },
+    {
+      cells: [
+        <code>organization</code>,
+        // TODO: Update link to be on this docs site when page exists
+        <a href="https://clerk.com/docs/reference/clerkjs/organization#attributes"><code>Organization</code></a>,
+        <>The current organization.<br/><br/>Requires <code>loadOrg</code> to be set to <code>true</code> in options.</>,
+      ],
+    }
+  ]}
+/>
+
+
+### Options
+
+<Tables
+  headings={["Name", "Type", "Description"]}
+  headingsMeta={[{}, {}, {maxWidth: '300px'}]}
+  rows={[
+    {
+      cells: [
+        <code>loadUser?</code>,
+        <code>boolean</code>,
+        <>If <code>true</code>, load the user data for the current auth session.</>,
+      ],
+    },
+    {
+      cells: [
+        <code>loadSession?</code>,
+        <code>boolean</code>,
+        <>If <code>true</code>, load the session data for the current auth session.</>,
+      ],
+    },
+    {
+      cells: [
+        <code>loadOrg?</code>,
+        <code>boolean</code>,
+        <>If <code>true</code>, load the organization data for the current auth session.</>,
+      ],
+    },
+    {
+      cells: [
+        <code>jwtKey?</code>,
+        <code>string</code>,
+        <>An optional custom JWT key to use for session token validation.<br/><br/><a href="https://clerk.com/docs/reference/node/networkless-token-verification#networkless-token-verification-using-the-jwt-verification-key">Read more about <code>jwtKey</code> with our docs page.</a></>,
+      ],
+    },
+    {
+      cells: [
+        <code>authorizedParties?</code>,
+        <code>string[]</code>,
+        <>An optional list of domains allowed to request JWT authorization.<br/><br/><a href="https://clerk.com/docs/reference/node/networkless-token-verification#validate-the-authorized-party-of-a-session-token">Read more about <code>authorizedParties</code> with our docs page.</a></>,
+      ],
+    }
+  ]}
+/>

--- a/src/pages/reference-js/overview.mdx
+++ b/src/pages/reference-js/overview.mdx
@@ -1,6 +1,6 @@
 # Clerk
 
-###### The Clerk object is the core of the ClerkJS SDK.
+The Clerk object is the core of the ClerkJS SDK.
 
 ## Overview[](https://clerk.com/docs/reference/clerkjs/clerk#overview)
 
@@ -11,7 +11,7 @@ The `Clerk` object is always available via `window.Clerk`.
 ## Attributes[](https://clerk.com/docs/reference/clerkjs/clerk#attributes)
 
 | Name    | Type                       | Description                                                                                                                              |
-| ------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+|---------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | client  | Client                     | The `Client` object for the current window.                                                                                              |
 | session | session / null / undefined | The `Client` object for the current window.                                                                                              |
 | user    | User / null / undefined    | A shortcut to Session.user which holds the currently active User object. If the session is null or undefined, the user field will match. |
@@ -43,13 +43,13 @@ Please note that the `session` and `user` object have a special relationship
 **Parameters**
 
 | Name     | Type                           | Description                                             |
-| -------- | ------------------------------ | ------------------------------------------------------- |
+|----------|--------------------------------|---------------------------------------------------------|
 | listener | (resources: Resources) => void | A function to be called when the Client object changes. |
 
 **Returns**
 
 | Type       | Description                                                                          |
-| ---------- | ------------------------------------------------------------------------------------ |
+|------------|--------------------------------------------------------------------------------------|
 | () => void | This method returns a function that can be used to clean up the registered listener. |
 
 ### authenticateWithMetamask(params)[](https://clerk.com/docs/reference/clerkjs/clerk#authenticate-with-metamask-params)
@@ -61,7 +61,7 @@ Starts an authentication flow that uses the Metamask browser extension to authen
 **Parameters**
 
 | Type                            | Description                                                                                                    |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+|---------------------------------|----------------------------------------------------------------------------------------------------------------|
 | AuthenticateWithMetamaskParams​ | ​​These props allow you to define the URL where the user should be redirected to on successful authentication. |
 
 **Returns**
@@ -159,12 +159,13 @@ Take a look at the function parameters description below for more usage details.
 **Parameters**
 
 | Name   | Type                              | Description                                                                                                                                                                                                                                                                                                                    |
-| ------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|--------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | params | HandleMagicLinkVerificationParams | These props allow you to define the URLs where the user should be redirected to on successful verification and completed sign in or sign up attempt pending sign in or sign up attempt. If the magic link is successfully verified on another device, there's a callback function parameter that allows custom code execution. |
 
 **Returns**
-Type | Description |
-\------------------------------ | ------------------------------------------------------- |
+
+| Type           | Description                                                                                                                                     |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | MagicLinkError | This method will throw a MagicLinkError if the magic link verification failed or the link expired. Check the error's code property for details. |
 
 ### isReady()[](https://clerk.com/docs/reference/clerkjs/clerk#is-ready)
@@ -178,9 +179,10 @@ Returns **true** when the [ClerkJS](https://clerk.com/docs/reference/clerk-re
 This method accepts no parameters.
 
 **Returns**
-Type | Description |
-\------------------------------ | ------------------------------------------------------- |
-boolean | This method will return true when the Clerk object is ready, false otherwise. |
+
+| Type    | Description                                                                   |
+|---------|-------------------------------------------------------------------------------|
+| boolean | This method will return true when the Clerk object is ready, false otherwise. |
 
 ### load(options?)[](https://clerk.com/docs/reference/clerkjs/clerk#load-options)
 
@@ -193,12 +195,13 @@ It is absolutely necessary to call this method before using the `Clerk` object
 **Parameters**
 
 | Name    | Type             | Description                                                                       |
-| ------- | ---------------- | --------------------------------------------------------------------------------- |
+|---------|------------------|-----------------------------------------------------------------------------------|
 | options | ComponentOptions | Configuration and options for initializing the Clerk object and Clerk Components. |
 
 **Returns**
-Type | Description |
-\------------------------------ | ------------------------------------------------------- |
+
+| Type    | Description                                                                             |
+|---------|-----------------------------------------------------------------------------------------|
 | boolean | This method will return **true** when the `Clerk` object is ready, **false** otherwise. |
 
 ### mountSignIn(node, nodeProps?)[](https://clerk.com/docs/reference/clerkjs/clerk#mount-sign-in-node-node-props)
@@ -210,6 +213,6 @@ Renders a [`<SignIn/>`](https://clerk.com/docs/component-reference/sign-in) co
 **Parameters**
 
 | Name       | Type           | Description                                                           |
-| ---------- | -------------- | --------------------------------------------------------------------- |
+|------------|----------------|-----------------------------------------------------------------------|
 | node       | HTMLDivElement | An HTML `<div/>` element which will render the `<SignIn/>` component. |
 | nodeProps? | SignInProps    | Additional props that will be passed to the `<SignIn/>` component.    |


### PR DESCRIPTION
This PR documents the uniquely exported `withServerAuth` from the `gatsby-plugin-clerk` package.

https://clerk-docs-git-gatsby-reference.clerkpreview.com/reference-gatsby/with-server-auth