### PR TITLE
Add Remix Reference Page

### DIFF
--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -47,6 +47,7 @@
   "reference-react": "React",
   "reference-next": "NextJS",
   "reference-gatsby": "Gatsby",
+  "reference-remix": "Remix",
   "reference-js": "JavaScript",
   "reference-node": {
     "title": "Node (coming Soon)"

--- a/src/pages/reference-react/general/clerk-provider.mdx
+++ b/src/pages/reference-react/general/clerk-provider.mdx
@@ -84,50 +84,50 @@ ReactDOM.render(
   rows={[
     {
       cells: [
-        "publishableKey",
-        "string",
+        <code>publishableKey</code>,
+        <code>string</code>,
         `Clerk publishable key for your instance. This can be found in your Clerk Dashboard.`,
       ],
     },
     {
       cells: [
-        "frontendApi",
-        "string",
+        <code>frontendApi</code>,
+        <code>string</code>,
         "The frontend API host for your instance. This can be found in your Clerk Dashboard.",
       ],
     },
     {
       cells: [
-        "navigate?",
-        "(to: string) => Promise<any> | void",
+        <code>navigate?</code>,
+        <code>{`(to: string) => Promise<unknown> | void`}</code>,
         "A function which takes the destination path asan argument and performs a \"push\" navigation.",
       ],
     },
     {
       cells: [
-        "clerkJSVariant?",
-        "string",
+        <code>clerkJSVariant?</code>,
+        <code>string</code>,
         "If your web application uses only Control components you can set this value to headless and load a minimal ClerkJS bundle for optimal page performance.",
       ],
     },
     {
       cells: [
-        "supportEmail?",
-        "string",
+        <code>supportEmail?</code>,
+        <code>string</code>,
         "Optional support email for display in authentication screens. Will only affect Clerk Components and not Clerk Hosted pages.",
       ],
     },
     {
       cells: [
-        "localization?",
-        "object",
+        <code>localization?</code>,
+        <code>object</code>,
         "Optional object to localize your Components. Will only affect Clerk Components and not Clerk Hosted pages.",
       ],
     },
     {
       cells: [
-        "allowedRedirectOrigins?",
-        "Array<string | RegExp>",
+        <code>allowedRedirectOrigins?</code>,
+        <code>{`Array<string | RegExp>`}</code>,
         "Optional array of domains used to validate against the query param of an auth redirect.\n\nIf no match is made, the redirect is considered unsafe and the default redirect will be used with a warning passed to the console.",
       ],
     },

--- a/src/pages/reference-remix/_meta.json
+++ b/src/pages/reference-remix/_meta.json
@@ -1,0 +1,4 @@
+{
+  "clerk-app": "<ClerkApp/>",
+  "clerk-catch-boundary": "ClerkCatchBoundary()"
+}

--- a/src/pages/reference-remix/clerk-app.mdx
+++ b/src/pages/reference-remix/clerk-app.mdx
@@ -1,0 +1,51 @@
+# `<ClerkApp />`
+
+Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree. This helper works with Remix SSR out-of-the-box and follows the "higher-order component" paradigm.
+
+## Usage
+
+```tsx
+import { ClerkApp } from "@clerk/remix";
+import type { MetaFunction,LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+// Import ClerkApp
+import { ClerkApp } from "@clerk/remix";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+// Wrap your app in ClerkApp(app)
+export default ClerkApp(App);
+```

--- a/src/pages/reference-remix/clerk-app.mdx
+++ b/src/pages/reference-remix/clerk-app.mdx
@@ -1,10 +1,12 @@
+import { Tables } from "@/components/Table";
+
 # `<ClerkApp />`
 
 Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree. This helper works with Remix SSR out-of-the-box and follows the "higher-order component" paradigm.
 
 ## Usage
 
-```tsx
+```tsx {1, 40-41}
 import { ClerkApp } from "@clerk/remix";
 import type { MetaFunction,LoaderFunction } from "@remix-run/node";
 
@@ -18,8 +20,6 @@ import {
 } from "@remix-run/react";
 
 import { rootAuthLoader } from "@clerk/remix/ssr.server";
-// Import ClerkApp
-import { ClerkApp } from "@clerk/remix";
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
@@ -49,3 +49,57 @@ function App() {
 // Wrap your app in ClerkApp(app)
 export default ClerkApp(App);
 ```
+
+## Props
+
+`<ClerkApp>` supports [all of the same properties as `<ClerkProvider>`](/reference-react/general/clerk-provider#props) with the exception of the `navigate` property:
+
+
+<Tables
+  headings={["Name", "Type", "Description"]}
+  headingsMeta={[{}, {}, {maxWidth: '300px'}]}
+  rows={[
+    {
+      cells: [
+        <code>publishableKey</code>,
+        <code>string</code>,
+        `Clerk publishable key for your instance. This can be found in your Clerk Dashboard.`,
+      ],
+    },
+    {
+      cells: [
+        <code>frontendApi</code>,
+        <code>string</code>,
+        "The frontend API host for your instance. This can be found in your Clerk Dashboard.",
+      ],
+    },
+    {
+      cells: [
+        <code>clerkJSVariant?</code>,
+        <code>string</code>,
+        "If your web application uses only Control components you can set this value to headless and load a minimal ClerkJS bundle for optimal page performance.",
+      ],
+    },
+    {
+      cells: [
+        <code>supportEmail?</code>,
+        <code>string</code>,
+        "Optional support email for display in authentication screens. Will only affect Clerk Components and not Clerk Hosted pages.",
+      ],
+    },
+    {
+      cells: [
+        <code>localization?</code>,
+        <code>object</code>,
+        "Optional object to localize your Components. Will only affect Clerk Components and not Clerk Hosted pages.",
+      ],
+    },
+    {
+      cells: [
+        <code>allowedRedirectOrigins?</code>,
+        <code>{`Array<string | RegExp>`}</code>,
+        "Optional array of domains used to validate against the query param of an auth redirect.\n\nIf no match is made, the redirect is considered unsafe and the default redirect will be used with a warning passed to the console.",
+      ],
+    },
+  ]}
+/>

--- a/src/pages/reference-remix/clerk-catch-boundary.mdx
+++ b/src/pages/reference-remix/clerk-catch-boundary.mdx
@@ -70,7 +70,7 @@ export const CatchBoundary = ClerkCatchBoundary(YourBoundary);
     {
       cells: [
         <code>RootCatchBoundary?</code>,
-        <code>React.ReactNode</code>,
+        <code>React.ComponentType</code>,
         `A optional component used as your application boundary.`,
       ],
     }

--- a/src/pages/reference-remix/clerk-catch-boundary.mdx
+++ b/src/pages/reference-remix/clerk-catch-boundary.mdx
@@ -1,13 +1,14 @@
+import { Tables } from "@/components/Table";
+
 # `ClerkCatchBoundary()`
 
-Clerk uses short-lived tokens to keep your application secure. To refresh expired tokens Clerk uses Remix's catch boundary.
+Clerk uses short-lived tokens to keep your application secure. To refresh expired tokens Clerk [uses Remix's catch boundary feature](https://remix.run/docs/en/main/route/catch-boundary).
 
 > If you do not implement this into your app, you will see a 401 after a short period of time even though your user is logged in.
 
 ## Usage
 
-```tsx
-import { ClerkApp } from "@clerk/remix";
+```tsx {13, 23-24}
 import type { MetaFunction, LoaderFunction } from "@remix-run/node";
 
 import {
@@ -29,6 +30,7 @@ export const meta: MetaFunction = () => ({
 });
 
 export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+
 // add a Catch Boundary
 export const CatchBoundary = ClerkCatchBoundary();
 
@@ -51,3 +53,26 @@ function App() {
 
 export default ClerkApp(App);
 ```
+
+If you need to add a custom boundary to your application you can pass it as an argument to the `ClerkCatchBoundary`.
+
+```tsx
+export const CatchBoundary = ClerkCatchBoundary(YourBoundary);
+```
+
+## Props
+
+
+<Tables
+  headings={["Name", "Type", "Description"]}
+  headingsMeta={[{}, {}, {maxWidth: '300px'}]}
+  rows={[
+    {
+      cells: [
+        <code>RootCatchBoundary?</code>,
+        <code>React.ReactNode</code>,
+        `A optional component used as your application boundary.`,
+      ],
+    }
+  ]}
+/>

--- a/src/pages/reference-remix/clerk-catch-boundary.mdx
+++ b/src/pages/reference-remix/clerk-catch-boundary.mdx
@@ -1,0 +1,53 @@
+# `ClerkCatchBoundary()`
+
+Clerk uses short-lived tokens to keep your application secure. To refresh expired tokens Clerk uses Remix's catch boundary.
+
+> If you do not implement this into your app, you will see a 401 after a short period of time even though your user is logged in.
+
+## Usage
+
+```tsx
+import { ClerkApp } from "@clerk/remix";
+import type { MetaFunction, LoaderFunction } from "@remix-run/node";
+
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+import { rootAuthLoader } from "@clerk/remix/ssr.server";
+import { ClerkApp, ClerkCatchBoundary } from "@clerk/remix";
+
+export const meta: MetaFunction = () => ({
+  charset: "utf-8",
+  title: "New Remix App",
+  viewport: "width=device-width,initial-scale=1",
+});
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+// add a Catch Boundary
+export const CatchBoundary = ClerkCatchBoundary();
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default ClerkApp(App);
+```


### PR DESCRIPTION
`@clerk/remix` has two unique exports that we should document in our reference docs:

- `<ClerkApp/>`
- `ClerkCatchBoundary()`

This PR documents them both:

- https://clerk-docs-git-remix-reference.clerkpreview.com/reference-remix/clerk-app
- https://clerk-docs-git-remix-reference.clerkpreview.com/reference-remix/clerk-catch-boundary