### PR TITLE
docs: add window.Clerk examples

### DIFF
--- a/src/pages/reference-js/authentication/_meta.json
+++ b/src/pages/reference-js/authentication/_meta.json
@@ -1,0 +1,3 @@
+{
+  "sign-in": "Sign In"
+}

--- a/src/pages/reference-js/authentication/sign-in.mdx
+++ b/src/pages/reference-js/authentication/sign-in.mdx
@@ -18,27 +18,52 @@ Render the `SignIn` component to an HTML `<div>` element.
 
 ### Usage
 
-```typescript {15-19}
-import Clerk from '@clerk/clerk-js';
-import { dark } from "@clerk/themes";
+<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+  ```typescript {15-19}
+  import Clerk from '@clerk/clerk-js';
+  import { dark } from "@clerk/themes";
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div
-    id="sign-in-button"
-  ></div>
-`;
+  document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
+    <div
+      id="sign-in-button"
+    ></div>
+  `;
 
-const signInComponent = document.querySelector<HTMLDivElement>('#sign-in-button')!;
+  const signInComponent = document.querySelector<HTMLDivElement>('#sign-in-button')!;
 
-const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
-await clerk.load();
+  const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
+  await clerk.load();
 
-clerk.mountSignIn(signInComponent, {
-  appearance: {
-    baseTheme: dark
-  }
-});
-```
+  clerk.mountSignIn(signInComponent, {
+    appearance: {
+      baseTheme: dark
+    }
+  });
+  ```
+
+  ```html {13-17}
+  <div id="sign-in-button"></div>
+  <script>
+    const script = document.createElement('script');
+    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.async = true;
+    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+
+    script.addEventListener('load', async function () {
+      await window.Clerk.load();
+
+      const signInComponent = document.querySelector('#sign-in-button');
+
+      window.Clerk.openSignIn(signInComponent, {
+        appearance: {
+          baseTheme: dark
+        }
+      });
+    });
+    document.body.appendChild(script);
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### Props
 
@@ -72,27 +97,52 @@ Unmount and run cleanup on an existing SignIn component instance.
 
 ### Usage
 
-```typescript {20}
-import Clerk from '@clerk/clerk-js';
+<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+  ```typescript {19}
+  import Clerk from '@clerk/clerk-js';
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div
-    id="sign-in-button"
-  ></div>
-`
+  document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
+    <div
+      id="sign-in-button"
+    ></div>
+  `
 
-const signInComponent = document.querySelector<HTMLDivElement>('#sign-in-button')!;
+  const signInComponent = document.querySelector<HTMLDivElement>('#sign-in-button')!;
 
-const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
+  const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
 
-await clerk.load();
+  await clerk.load();
 
-clerk.mountSignIn(signInComponent);
+  clerk.mountSignIn(signInComponent);
 
-// ...
+  // ...
 
-clerk.unmountSignIn(signInComponent);
-```
+  clerk.unmountSignIn(signInComponent);
+  ```
+
+  ```html {17}
+  <div id="sign-in-button"></div>
+  <script>
+    const script = document.createElement('script');
+    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.async = true;
+    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+
+    script.addEventListener('load', async function () {
+      await window.Clerk.load();
+
+      const signInComponent = document.querySelector('#sign-in-button');
+
+      window.Clerk.mountSignIn(signInComponent);
+
+      // ...
+
+      window.Clerk.unmountSignIn(signInComponent);
+    });
+    document.body.appendChild(script);
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### Props
 
@@ -119,19 +169,41 @@ Opens the SignIn component as an overlay at the root of your HTML `body` element
 
 ### Usage
 
-```typescript {7-11}
-import Clerk from '@clerk/clerk-js';
-import { dark } from "@clerk/themes";
+<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+  ```typescript {7-11}
+  import Clerk from '@clerk/clerk-js';
+  import { dark } from "@clerk/themes";
 
-const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
-await clerk.load();
+  const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
+  await clerk.load();
 
-clerk.openSignIn({
-  appearance: {
-    baseTheme: dark
-  }
-});
-```
+  clerk.openSignIn({
+    appearance: {
+      baseTheme: dark
+    }
+  });
+  ```
+
+  ```html {10-14}
+  <script>
+    const script = document.createElement('script');
+    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.async = true;
+    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+
+    script.addEventListener('load', async function () {
+      await window.Clerk.load();
+
+      window.Clerk.openSignIn({
+        appearance: {
+          baseTheme: dark
+        }
+      });
+    });
+    document.body.appendChild(script);
+  </script>
+  ```
+</CodeBlockTabs>
 
 ### Props
 
@@ -155,6 +227,46 @@ function openSignIn(props?: SignInProps): void;
 ## `closeSignIn`
 
 Closes the sign in overlay.
+
+### Usage
+
+<CodeBlockTabs options={['NPM Module', 'window.Clerk']}>
+  ```typescript {11}
+  import Clerk from '@clerk/clerk-js';
+  import { dark } from "@clerk/themes";
+
+  const clerk = new Clerk(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
+  await clerk.load();
+
+  clerk.openSignIn();
+
+  // ...
+
+  clerk.closeSignIn();
+  ```
+
+  ```html {14}
+  <script>
+    const script = document.createElement('script');
+    script.setAttribute('data-clerk-publishable-key', 'pk_[publishable_key]');
+    script.async = true;
+    script.src = `https://[your-domain].clerk.accounts.dev/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`;
+
+    script.addEventListener('load', async function () {
+      await window.Clerk.load();
+
+      window.Clerk.openSignIn();
+
+      // ...
+
+      window.Clerk.closeSignIn();
+    });
+    document.body.appendChild(script);
+  </script>
+  ```
+</CodeBlockTabs>
+
+### Props
 
 ```typescript
 function closeSignIn(): void;


### PR DESCRIPTION
This PR builds on top of #100 to add `window.Clerk` examples for the JavaScript examples of Sign In components