### PR TITLE
chore: restyle auth provider cards to match current docs

### DIFF
--- a/src/components/AuthProvidersCards.tsx
+++ b/src/components/AuthProvidersCards.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
+import { Figtree } from "next/font/google";
+
+const figtree = Figtree({ subsets: ["latin"] });
 
 interface AuthProvidersCards {
   title: string;
@@ -22,44 +25,43 @@ export const AuthProvidersCards = ({
   iconHeight = 24,
   iconWidth = 24,
 }: AuthProvidersCards) => (
-  <div className="max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
-    {icon && (
-      <Image
-        className="mb-2"
-        src={icon}
-        alt={`${title} icon`}
-        height={iconHeight}
-        width={iconWidth}
-      />
-    )}
+  <div className="w-full h-auto py-8 mb-8 bg-white shadow-lg px-9 rounded-2xl dark:bg-gray-800 dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
     <Link href={link}>
-      <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+      {icon && (
+        <Image
+          className="mb-5"
+          src={icon}
+          alt={`${title} icon`}
+          height={iconHeight}
+          width={iconWidth}
+        />
+      )}
+      <h5
+        className={`${figtree.className} mb-2 text-[16px] font-semibold tracking-tight text-gray-900 dark:text-white`}
+      >
         {title}
       </h5>
-    </Link>
-    <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
-      {description}
-    </p>
-    <Link
-      href={link}
-      className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-    >
-      {cta}
-      {!hideArrow && (
-        <svg
-          aria-hidden="true"
-          className="w-4 h-4 ml-2 -mr-1"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-            clipRule="evenodd"
-          ></path>
-        </svg>
-      )}
+      <p className="text-[13px] font-normal text-gray-500 dark:text-gray-400">
+        {description}
+      </p>
+      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:text-gray-400 group-hover:text-clerk-purple">
+        {cta}
+        {!hideArrow && (
+          <svg
+            aria-hidden="true"
+            className="w-3.5 h-3.5 ml-1 -mr-1 group-hover:animate-move-arrow"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            ></path>
+          </svg>
+        )}
+      </div>
     </Link>
   </div>
 );

--- a/src/pages/users/authentication-providers/overview.mdx
+++ b/src/pages/users/authentication-providers/overview.mdx
@@ -5,7 +5,7 @@ import {AuthProvidersCards} from "@/components/AuthProvidersCards";
 Clerk provides a wide range of application providers to ease your user's sign-up and sign-in processes.
 
 <div className="container mx-auto my-4">
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <div className="grid justify-center gap-x-7 grid-cols-1 lg:grid-cols-2">
         <AuthProvidersCards title="Facebook" description="Add Facebook as an authentication provider for your Clerk app." link="#" cta="Coming Soon" hideArrow={true} icon="/images/logos/auth_providers/facebook.svg" />
         <AuthProvidersCards title="Twitter" description="Add Twitter as an authentication provider for your Clerk app." link="#" cta="Coming Soon" hideArrow={true} icon="/images/logos/auth_providers/twitter.svg" />
         <AuthProvidersCards title="TikTok" description="Add TikTok as an authentication provider for your Clerk app." link="#" cta="Coming Soon" hideArrow={true} icon="/images/logos/auth_providers/tiktok.svg" />


### PR DESCRIPTION
This PR:

- Restyles `AuthProviderCards` to match the current docs and `FrameworkCards`
- Adjusts the cards' grid to be responsive in a similar way to the homepage cards


<img width="801" alt="Screenshot 2023-06-05 at 3 21 19 PM" src="https://github.com/clerkinc/clerk-docs/assets/133695690/b88b31f1-1530-44e8-bf44-a9501adc4fa9">
