### PR TITLE
chore: change table divider color

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -20,8 +20,8 @@ export const Tables = ({
       <div className="sm:-mx-6 lg:-mx-8">
         <div className="inline-block min-w-full py-2 sm:px-6 lg:px-8">
           <div className="overflow-x-auto">
-            <table className="min-w-full text-left text-sm">
-              <thead className="border-b font-medium dark:border-neutral-500">
+            <table className="min-w-full text-sm text-left">
+              <thead className="font-medium border-b border-[#C4B5FF]">
                 <tr>
                   {headings?.map((heading, index) => {
                     const maxWidth =
@@ -46,7 +46,7 @@ export const Tables = ({
               <tbody>
                 {rows.map((row, index) => (
                   <tr
-                    className="border-b dark:border-neutral-500"
+                    className="border-b border-[#C4B5FF]"
                     key={`row-${index}`}
                   >
                     {row.cells.map((cell, idx) => {

--- a/src/pages/reference-react/general/clerk-provider.mdx
+++ b/src/pages/reference-react/general/clerk-provider.mdx
@@ -100,7 +100,7 @@ ReactDOM.render(
       cells: [
         <code>navigate?</code>,
         <code>{`(to: string) => Promise<unknown> | void`}</code>,
-        "A function which takes the destination path asan argument and performs a \"push\" navigation.",
+        "A function which takes the destination path as an argument and performs a \"push\" navigation.",
       ],
     },
     {


### PR DESCRIPTION
This PR: 

- changes the color of the table dividers to match the current docs
- fixes a small typo