### PR TITLE
chore: add organization invitation docs page

### DIFF
--- a/src/pages/reference-js/_meta.json
+++ b/src/pages/reference-js/_meta.json
@@ -1,5 +1,6 @@
 {
   "overview": "Overview",
   "clerk": "Clerk",
-  "organization": "Organization"
+  "organization": "Organization",
+  "organization-invitation": "Organization Invitation"
 }

--- a/src/pages/reference-js/organization-invitation.mdx
+++ b/src/pages/reference-js/organization-invitation.mdx
@@ -1,0 +1,79 @@
+import { Tab, Tabs } from "nextra-theme-docs";
+import { Tables } from "@/components/Table";
+import { Images } from "@/components/Images";
+import { CodeBlockTabs } from "@/components/CodeBlockTabs";
+
+# OrganizationInvitation
+
+The `OrganizationInvitation` object is the model around an organization invitation.
+
+## Attributes
+
+<Tables
+  headings={["Name", "Type", "Description"]}
+  rows={[
+    {cells: [
+        <code>id</code>,
+        <code>string</code>,
+        "A unique identifier for this organization membership.",
+        ]},
+        {cells: [
+        <code>emailAddress</code>,
+        <code>string</code>,
+        "The email address the invitation has been sent.",
+        ]},
+        {cells: [
+        <code>organizationId</code>,
+        <code>string</code>,
+        "The organization id of the organization this invitation is for.",
+        ]},
+        {cells: [
+        <code>publicMetadata</code>,
+        <code>object</code>,
+        "The public metadata of the organization membership.",
+        ]},
+        {cells: [
+        <code>role</code>,
+        <code>'admin' | 'basic_member' | 'guest_member'</code>,
+        "The role of the current user in the organization.",
+        ]},
+        {cells: [
+        <code>status</code>,
+        <code>'pending' | 'accepted' | 'revoked'</code>,
+        "The status of the invitation.",
+        ]},
+        {cells: [
+        <code>createdAt</code>,
+        <code>Date</code>,
+        "Date of the time the membership was created.",
+        ]},
+        {cells: [
+        <code>updatedAt</code>,
+        <code>Date</code>,
+        "Date of the last time the membership was updated.",
+        ]},
+    ]}
+/>
+
+## Methods
+
+### `revoke()`
+
+```typescript
+function revoke(): Promise<OrganizationInvitation>;
+```
+
+Revokes the invitation for the email it corresponds to.
+
+### Returns
+
+<Tables
+  headings={["Type", "Description"]}
+  headingsMeta={[{}, {maxWidth: "300px"}]}
+  rows={[
+  {cells: [
+  <code>Promise{"<"}<a href="/reference-js/organization-invitation">OrganizationInvitation</a>{">"}</code>,
+  <>This method returns a <code>Promise</code> which resolves to the <code>OrganizationInvitation</code> for the revolked invitation.</>,
+  ]},
+  ]}
+/>

--- a/src/pages/reference-js/organization/invitations.mdx
+++ b/src/pages/reference-js/organization/invitations.mdx
@@ -10,7 +10,7 @@ These are all methods on [the Organization class](/reference-js/organization/org
 ## `getPendingInvitations()`
 
 ```typescript
-function getPendingInvitations(params?: GetPendingInvitationsParams): Promise<OrganizationInvitationResource[]>;
+function getPendingInvitations(params?: GetPendingInvitationsParams): Promise<OrganizationInvitation[]>;
 ```
 
 Retrieve the members of the selected organization.
@@ -40,8 +40,8 @@ Retrieve the members of the selected organization.
   headingsMeta={[{}, {maxWidth: "300px"}]}
   rows={[
   {cells: [
-  <code>Promise{"<"}OrganizationInvitationResource[]{">"}</code>,
-  <>This method returns a <code>Promise</code> which resolves with a list of <code>OrganizationInvitationResource</code> objects.</>,
+  <code>Promise{"<"}<a href="/reference-js/organization-invitation">OrganizationInvitation</a>[]{">"}</code>,
+  <>This method returns a <code>Promise</code> which resolves with a list of <code><a href="/reference-js/organization-invitation">OrganizationInvitation</a></code> objects.</>,
   ]},
   ]}
 />
@@ -49,7 +49,7 @@ Retrieve the members of the selected organization.
 ## `inviteMember()`
 
 ```typescript
-function inviteMember(params: InviteMemberParams): Promise<OrganizationInvitationResource>;
+function inviteMember(params: InviteMemberParams): Promise<OrganizationInvitation>;
 ```
 
 Creates and sends an invitation to the target email address for becoming a member with the role passed on the  function parameters.
@@ -79,8 +79,8 @@ Creates and sends an invitation to the target email address for becoming a membe
   headingsMeta={[{}, {maxWidth: "300px"}]}
   rows={[
   {cells: [
-  <code>Promise{"<"}OrganizationMembershipResource{">"}</code>,
-  <>This method returns a <code>Promise</code> which resolves to the <code>OrganizationInvitationResource</code> for the created invitation.</>,
+  <code>Promise{"<"}<a href="/reference-js/organization-invitation">OrganizationInvitation</a>{">"}</code>,
+  <>This method returns a <code>Promise</code> which resolves to the <code><a href="/reference-js/organization-invitation">OrganizationInvitation</a></code> for the created invitation.</>,
   ]},
   ]}
 />
@@ -88,7 +88,7 @@ Creates and sends an invitation to the target email address for becoming a membe
 ## `inviteMembers()`
 
 ```typescript
-function inviteMembers(params: InviteMembersParams): Promise<OrganizationInvitationResource[]>;
+function inviteMembers(params: InviteMembersParams): Promise<OrganizationInvitation[]>;
 ```
 
 Creates and sends an invitation to the target email addresses for becoming a member with the role passed on the function parameters.
@@ -118,8 +118,8 @@ Creates and sends an invitation to the target email addresses for becoming a mem
   headingsMeta={[{}, {maxWidth: "300px"}]}
   rows={[
   {cells: [
-  <code>Promise{"<"}OrganizationMembershipResource[]{">"}</code>,
-  <>This method returns a <code>Promise</code> which resolves to a list of <code>OrganizationInvitationResource</code>s for the created invitations.</>,
+  <code>Promise{"<"}<a href="/reference-js/organization-invitation">OrganizationInvitation</a>[]{">"}</code>,
+  <>This method returns a <code>Promise</code> which resolves to a list of <code><a href="/reference-js/organization-invitation">OrganizationInvitation</a></code>s for the created invitations.</>,
   ]},
   ]}
 />


### PR DESCRIPTION
This PR adds the reference docs for the organization's invitation and deep links existing methods into the page

Preview: https://clerk-docs-git-clerk-js-organization-invitation.clerkpreview.com/reference-js/organization-invitation