### PR TITLE
DOCS-233: Change colors to match current docs

### DIFF
--- a/src/components/AuthProvidersCards.tsx
+++ b/src/components/AuthProvidersCards.tsx
@@ -41,10 +41,10 @@ export const AuthProvidersCards = ({
       >
         {title}
       </h5>
-      <p className="text-[13px] font-normal text-gray-500 dark:tcard-dark-text">
+      <p className="text-[13px] font-normal text-gray-500 dark:card-dark-text">
         {description}
       </p>
-      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:tcard-dark-text group-hover:text-clerk-purple">
+      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:card-dark-text group-hover:text-clerk-purple">
         {cta}
         {!hideArrow && (
           <svg

--- a/src/components/AuthProvidersCards.tsx
+++ b/src/components/AuthProvidersCards.tsx
@@ -25,7 +25,7 @@ export const AuthProvidersCards = ({
   iconHeight = 24,
   iconWidth = 24,
 }: AuthProvidersCards) => (
-  <div className="w-full h-auto py-8 mb-8 bg-white shadow-lg px-9 rounded-2xl dark:bg-gray-800 dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
+  <div className="w-full h-auto py-8 mb-8 bg-white shadow-lg px-9 rounded-2xl dark:bg-card-dark-grey dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
     <Link href={link}>
       {icon && (
         <Image
@@ -41,10 +41,10 @@ export const AuthProvidersCards = ({
       >
         {title}
       </h5>
-      <p className="text-[13px] font-normal text-gray-500 dark:text-gray-400">
+      <p className="text-[13px] font-normal text-gray-500 dark:tcard-dark-text">
         {description}
       </p>
-      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:text-gray-400 group-hover:text-clerk-purple">
+      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:tcard-dark-text group-hover:text-clerk-purple">
         {cta}
         {!hideArrow && (
           <svg

--- a/src/components/Cards.tsx
+++ b/src/components/Cards.tsx
@@ -25,7 +25,7 @@ export const Cards = ({
   iconHeight = 24,
   iconWidth = 24,
 }: CardsProps) => (
-  <div className="h-auto py-8 mb-8 bg-white shadow-lg px-9 min-w-96 rounded-2xl dark:bg-gray-800 dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
+  <div className="h-auto py-8 mb-8 bg-white shadow-lg px-9 min-w-96 rounded-2xl dark:bg-card-dark-grey dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
     <Link href={link}>
       {icon && (
         <Image
@@ -41,10 +41,10 @@ export const Cards = ({
       >
         {title}
       </h5>
-      <p className="text-[13px] font-normal text-gray-500 dark:text-gray-400">
+      <p className="text-[13px] font-normal text-gray-500 dark:card-dark-text">
         {description}
       </p>
-      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:text-gray-400 group-hover:text-clerk-purple mb-0">
+      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:card-dark-text group-hover:text-clerk-purple mb-0">
         {cta}
         {!hideArrow && (
           <svg

--- a/src/components/FrameworkCards.tsx
+++ b/src/components/FrameworkCards.tsx
@@ -25,7 +25,7 @@ export const FrameworkCards = ({
   iconHeight = 24,
   iconWidth = 24,
 }: FrameworkCardsProps) => (
-  <div className="w-full h-auto py-8 mb-8 bg-white shadow-lg px-9 rounded-2xl dark:bg-gray-800 dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
+  <div className="w-full h-auto py-8 mb-8 bg-white shadow-lg px-9 rounded-2xl dark:bg-card-dark-grey dark:border-gray-700 hover:cursor-pointer hover:shadow-2xl group">
     <Link href={link}>
       {icon && (
         <Image
@@ -41,10 +41,10 @@ export const FrameworkCards = ({
       >
         {title}
       </h5>
-      <p className="text-[13px] font-normal text-gray-500 dark:text-gray-400">
+      <p className="text-[13px] font-normal text-gray-500 dark:text-card-dark-text">
         {description}
       </p>
-      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:text-gray-400 group-hover:text-clerk-purple">
+      <div className="inline-flex items-center mt-6 text-[13px] font-medium text-center text-gray-600 dark:text-card-dark-text group-hover:text-clerk-purple">
         {cta}
         {!hideArrow && (
           <svg

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, SetStateAction } from "react";
 import Image from "next/image";
 import { useTheme } from "next-themes";
 import { Figtree } from "next/font/google";
@@ -7,32 +8,51 @@ const figtree = Figtree({ subsets: ["latin"] });
 export const Hero = () => {
   const { theme, systemTheme } = useTheme();
 
-  const currentTheme = theme === "system" ? systemTheme : theme;
+  const [currentTheme, setCurrentTheme] =
+    useState<SetStateAction<string | undefined>>("");
+
+  useEffect(() => {
+    setCurrentTheme(theme === "system" ? systemTheme : theme);
+  }, [theme, systemTheme]);
 
   const lightModeHeroImage = "/images/home/docs-hero-light.svg";
   const darkModeHeroImage = "/images/home/docs-hero-dark.svg";
 
   return (
-    <div className="flex flex-col items-center justify-center px-4 pt-8 mb-8 border-b-2 md:flex-row md:items-end md:justify-around md:px-12 h-72 h-max">
-      <div className="self-center w-64 sm:w-auto">
+    <div className="flex flex-col px-4 pt-8 mb-8 border-b-2 md:justify-around h-max md:flex-row">
+      <div className="flex flex-col self-center w-auto flex-nowrap">
         <h2
-          className={`${figtree.className} w-56 mb-2 text-3xl font-semibold sm:w-auto text-black dark:text-white`}
+          className={`${figtree.className} mb-2 text-3xl font-semibold text-black dark:text-white md:w-48`}
         >
           Welcome to Clerk Docs
         </h2>
-        <p className="mb-8 text-base text-gray-500 dark:text-gray-300">
+        <p className="mb-8 text-base text-gray-500 dark:text-[#545965] md:w-64">
           Find all the guides and resources you need to develop with Clerk.
         </p>
       </div>
-      <div className="md:h-60 md:pr-6">
-        <Image
-          className="w-full h-auto md:max-w-lg sm:h-full sm:w-auto"
-          src={currentTheme === "dark" ? darkModeHeroImage : lightModeHeroImage}
-          width="600"
-          height="288"
-          alt="Hero Image"
-        />
+      <div className="hidden md:h-60 md:pr-6 md:block">
+        {currentTheme === "dark" && (
+          <Image
+            className="w-full h-auto md:max-w-lg sm:h-full sm:w-auto"
+            src={darkModeHeroImage}
+            width="600"
+            height="288"
+            alt="Hero Image"
+            priority={true}
+          />
+        )}
+        {currentTheme === "light" && (
+          <Image
+            className="w-full h-auto md:max-w-lg sm:h-full sm:w-auto"
+            src={lightModeHeroImage}
+            width="600"
+            height="288"
+            alt="Hero Image"
+            priority={true}
+          />
+        )}
       </div>
+      <div className="md:h-267.48"></div>
     </div>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,8 @@ module.exports = {
       },
       colors: {
         "clerk-purple": "#6C47FF",
+        "card-dark-grey": "#222225",
+        "card-dark-text": "#798191",
       },
     },
   },


### PR DESCRIPTION
This PR:

- Adjusts the card background and font colors to match the current docs
- Adds those colors to the tailwind config
- Fixes the `Hero` image behavior (and [error](https://nextjs.org/docs/messages/react-hydration-error)) so it does not default to light mode on refresh
- Adjusts `Hero` text to match design