### PR TITLE
fix: add import of createClerkClient to "Retrieve Full User" example

### DIFF
--- a/src/pages/quickstarts/full-stack/remix.mdx
+++ b/src/pages/quickstarts/full-stack/remix.mdx
@@ -386,6 +386,10 @@ export const loader: LoaderFunction = async (args) => {
 #### Retrieve Full User
 
 ```tsx filename="routes/example.tsx" copy
+import { LoaderFunction, redirect } from "@remix-run/node";
+import { getAuth } from "@clerk/remix/ssr.server";
+import { createClerkClient } from '@clerk/remix/api.server';
+
 export const loader: LoaderFunction = async (args) => {
   const { userId } = await getAuth(args);
 


### PR DESCRIPTION
### Issue

The code snippet for the "Retrieve Full User" example was using `createClerkClient` without importing the function. This makes the snippet incomplete.

Up until that point in the guide the user is only familiar with these two import locations: "@clerk/remix" and "@clerk/remix/ssr.server", neither of which export `createClerkClient`.

**This means at this point in the guide the user is blocked and would not know how to import `createClerkClient`**

### Solution

I saw from this [upgrade documentation](https://clerk.com/docs/upgrade-guides/upgrade-remix-from-1.x-to-2.x) that appropriate  import is: `import { createClerkClient } from '@clerk/remix/api.server'`

I added imports to the snippet