### PR TITLE
Use V2_RouteConventions

### DIFF
--- a/src/pages/quickstarts/full-stack/remix.mdx
+++ b/src/pages/quickstarts/full-stack/remix.mdx
@@ -216,7 +216,7 @@ The functionality of the components are controlled by the instance settings you 
 
 ### Build Your Sign Up
 
-```tsx filename="app/routes/sign-up/$.tsx" copy
+```tsx filename="app/routes/sign-up.$.tsx" copy
 import { SignUp } from "@clerk/remix";
 
 export default function SignUpPage() {
@@ -231,7 +231,7 @@ export default function SignUpPage() {
 
 ### Build Your Sign In
 
-```tsx filename="app/routes/sign-in/$.tsx" copy
+```tsx filename="app/routes/sign-in.$.tsx" copy
 import { SignIn } from "@clerk/remix";
 
 export default function SignInPage() {


### PR DESCRIPTION
## Issue

The current [Remix Quick Start](https://clerk.com/docs/quickstarts/get-started-with-remix) mentions to:

> Disable ErrorBoundary
> Currently we are unable to support ErrorBoundaryV2 but will support this when Remix V2 is in general release, make sure that it is set to false in your remix.config.js

However, it still preserves `v2_routeConvention: true,`

Then later in the tutorial it is suggesting to create /sign-in/$ and /sign-up/$ wildcard routes; however, it is using the routes nested by file structure which is V1 routing instead of nesting by file name which is V2.

See: https://remix.run/docs/en/1.17.1/file-conventions/routes-files#splat-routes

This results in errors like

> No routes matched location "/sign-in/abc123" since the splat/wildcard route is not being recognized.

## Solution

Change file paths
`/sign-in/$.tsx` -> `/sign-in.$.tsx`
`/sign-up/$.tsx` -> `/sign-up.$.tsx`