### PR TITLE
DOCS-240: Fix homepage cards responsiveness issue

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -4,7 +4,7 @@ import {FrameworkCards} from "@/components/FrameworkCards"
 import {Subheader} from "@/components/Subheader"
 
 <Hero/>
-<div className="container mx-auto my-4">
+<div className="container my-4 min-w-full">
   <div className="grid xl:grid-cols-3 xl:grid-rows-2 md:grid-cols-2 md:grid-rows-3 justify-center gap-x-7">
     <FrameworkCards
       title="Next.js Stable"
@@ -55,7 +55,7 @@ import {Subheader} from "@/components/Subheader"
 
 <Subheader text="Components"/>
 
-<div className="container mx-auto my-4">
+<div className="container min-w-full my-4">
   <div className="grid xl:grid-cols-2 auto-rows-auto md:grid-cols-2 gap-x-7 justify-items-stretch">
     <Cards
       title="Authentication"
@@ -98,7 +98,7 @@ import {Subheader} from "@/components/Subheader"
 
 <Subheader text="Hooks"/>
 
-<div className="container mx-auto my-4">
+<div className="container min-w-full my-4">
   <div className="grid xl:grid-cols-2 auto-rows-auto md:grid-cols-2 gap-x-7 justify-items-stretch">
     <Cards
       title="User Management"
@@ -125,7 +125,7 @@ import {Subheader} from "@/components/Subheader"
 
 <Subheader text="SDKs"/>
 
-<div className="container mx-auto my-4">
+<div className="container min-w-full my-4">
   <div className="grid xl:grid-cols-2 auto-rows-auto md:grid-cols-2 gap-x-7 justify-items-stretch">
     <Cards
       title="Next.js"


### PR DESCRIPTION
This PR changes the width of the `Card` containers on the homepage so their width stays consistent at breakpoints.