### PR TITLE
docs(fastify): Cleanup getUser condition in routes

### DIFF
--- a/src/pages/quickstarts/backend/fastify.mdx
+++ b/src/pages/quickstarts/backend/fastify.mdx
@@ -142,7 +142,7 @@ fastify.get("/protected", async (request, reply) => {
     return reply.code(403).send();
   }
 
-  const user = userId ? await clerkClient.users.getUser(userId) : null;
+  const user = await clerkClient.users.getUser(userId);
   return { user };
 });
 ```
@@ -175,7 +175,7 @@ const protectedRoutes: FastifyPluginCallback = (instance, opts, done) => {
       return reply.code(403).send();
     }
 
-    const user = userId ? await clerkClient.users.getUser(userId) : null;
+    const user = await clerkClient.users.getUser(userId);
     return { user };
   });
   done();


### PR DESCRIPTION
Removed the `userId` check since the example already returns a `403` if `userId` is falsy.