### PR TITLE
docs: Update Ruby SDK examples.

### DIFF
--- a/src/pages/users/metadata.mdx
+++ b/src/pages/users/metadata.mdx
@@ -101,7 +101,7 @@ privateMetadata = {
 }
 
 
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", private_metadata: privateMetadata)
 ```
 </CodeBlockTabs>
@@ -160,7 +160,7 @@ func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
 ```ts copy filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.getUser("user_xyz")
 ```
 </CodeBlockTabs>
@@ -253,7 +253,7 @@ publicMetadata = {
 }
 
 
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", public_metadata: publicMetadata)
 ```
 </CodeBlockTabs>
@@ -358,7 +358,7 @@ unsafeMetadata = {
 }
 
 
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", unsafe_metadata: unsafeMetadata)
 ```
 </CodeBlockTabs>


### PR DESCRIPTION
Hi! Great product, looking to contribute more.

### Problem:
The Ruby examples are out of sync with the [clerk-sdk-ruby](https://github.com/clerkinc/clerk-sdk-ruby) codebase.

The current codebase and [clerk-sdk-ruby](https://github.com/clerkinc/clerk-sdk-ruby) Readme use `Clerk::SDK.new(api_key: 'your_secret_key')` instead of `Clerk::SDK.new(secret_key: 'your_secret_key')`.


### Solution:
Update examples to use current symbol in initializer.

### Screenshots of pain point
![image](https://github.com/clerkinc/clerk-docs/assets/10838726/07bfeb7f-40f3-4762-b22d-b56734f225fd)
