### PR TITLE
chore: Update Gatsby quickstart guide

### DIFF
--- a/src/pages/quickstarts/full-stack/gatsby.mdx
+++ b/src/pages/quickstarts/full-stack/gatsby.mdx
@@ -33,18 +33,18 @@ Once you have a React application ready, you need to install Clerk's React SDK. 
 
 ### Set Environment Keys
 
-Below is an example of your .env.development file. To get the respective keys go to the API Keys page in the Clerk dashboard.
+Below is an example of your `.env.development` file. To get the respective keys go to the API Keys page in the Clerk dashboard.
 
 ```sh copy filename=".env.development"
 GATSBY_CLERK_PUBLISHABLE_KEY=pk_test_••••••••••••••••••••••••••••••••••
 CLERK_SECRET_KEY=sk_test_••••••••••••••••••••••••••••••••••
 ```
 
-### Update gatsby.config.ts
+### Update gatsby-config.ts
 
-To use Clerk you will need to update your `gatsby.config.ts` to resolve the `gatsby-plugin-clerk` and load from `.env` files.
+To use Clerk you will need to update your `gatsby-config.ts` to resolve `gatsby-plugin-clerk` and load from `.env` files.
 
-```ts filename="gatsby.config.js"" copy
+```ts filename="gatsby-config.ts" copy
 import type { GatsbyConfig } from "gatsby"
 
 require("dotenv").config({
@@ -55,9 +55,7 @@ const config: GatsbyConfig = {
     title: `clerk-test`,
     siteUrl: `https://www.yourdomain.tld`,
   },
-  graphqlTypegen: true,
-
-  // add gatsby plugin
+  // Add Gatsby plugin
   plugins: [
     {
       resolve: `gatsby-plugin-clerk`
@@ -72,7 +70,7 @@ export default config
 
 Clerk offers Control Components that allow you to protect your pages, below is a simple example using Clerk's hosted components and the `<SignedIn/>` and `<SignedOut/>` control components.
 
-```tsx filename="index.tsx" copy
+```tsx filename="src/pages/index.tsx" copy
 import React from 'react'
 import {
   SignIn,
@@ -105,7 +103,7 @@ Clerk provides a set of hooks and helpers that you can use to access the active 
 
 The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx copy filename="pages/example.tsx"
+```tsx copy filename="src/pages/example.tsx"
 import { useAuth } from "gatsby-plugin-clerk";
 
 export default function Example() {
@@ -128,7 +126,7 @@ export default function Example() {
 
 The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx copy filename="pages/example.tsx"
+```tsx copy filename="src/pages/example.tsx"
 import { useUser } from "gatsby-plugin-clerk";
 
 export default function Example() {
@@ -144,7 +142,7 @@ export default function Example() {
 
 ### SSR Usage
 
-```tsx copy filename="pages/SSRPage.tsx"
+```tsx copy filename="src/pages/SSRPage.tsx"
 import * as React from 'react';
 import { GetServerData } from 'gatsby';
 import { withServerAuth } from 'gatsby-plugin-clerk/ssr';

--- a/src/pages/quickstarts/full-stack/gatsby.mdx
+++ b/src/pages/quickstarts/full-stack/gatsby.mdx
@@ -33,7 +33,7 @@ Once you have a React application ready, you need to install Clerk's React SDK. 
 
 ### Set Environment Keys
 
-Below is an example of your `.env.development` file. To get the respective keys go to the API Keys page in the Clerk dashboard.
+Below is an example of your `.env.development` file. To get the respective keys, go to the API Keys page in the Clerk dashboard.
 
 ```sh copy filename=".env.development"
 GATSBY_CLERK_PUBLISHABLE_KEY=pk_test_••••••••••••••••••••••••••••••••••
@@ -42,7 +42,7 @@ CLERK_SECRET_KEY=sk_test_••••••••••••••••••�
 
 ### Update gatsby-config.ts
 
-To use Clerk you will need to update your `gatsby-config.ts` to resolve `gatsby-plugin-clerk` and load from `.env` files.
+To use Clerk, you will need to update your `gatsby-config.ts` in order to resolve `gatsby-plugin-clerk` and load from `.env` files.
 
 ```ts filename="gatsby-config.ts" copy
 import type { GatsbyConfig } from "gatsby"
@@ -68,7 +68,7 @@ export default config
 
 ### Protecting Your Pages
 
-Clerk offers Control Components that allow you to protect your pages, below is a simple example using Clerk's hosted components and the `<SignedIn/>` and `<SignedOut/>` control components.
+Clerk offers Control Components that allow you to protect your pages. Below is a simple example using Clerk's hosted components and the `<SignedIn />` and `<SignedOut />` control components.
 
 ```tsx filename="src/pages/index.tsx" copy
 import React from 'react'


### PR DESCRIPTION
Hi!

Here are some improvements to the Gatsby quickstart guide, most notably correcting that its config file is `gatsby-config.ts` and not `gatsby.config.ts` :)