### PR TITLE
feat: add reload user data section to useUser reference

### DIFF
--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -3,15 +3,15 @@ title: useUser()
 description: The `useUser` hook is used to get the current user object and to update the user's data on the client side.
 ---
 
-import { Callout } from "nextra-theme-docs";
-import { Tables } from "@/components/Table";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `useUser()`
 
 The `useUser` hook is used to get the current user object and to update the user's data on the client side.
 
 ## Usage
+
+<Callout type="info">
+  Note that your component must be a descendant of [`<ClerkProvider />`](/docs/components/clerk-provider).
+</Callout>
 
 ### Retrieve the current user data
 
@@ -58,8 +58,8 @@ export default function Home() {
 ### Update the current user data
 
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="home.tsx"
-import { useUser } from "@clerk/clerk-react";
+```tsx copy filename="app/page.tsx"
+import { useUser } from "@clerk/nextjs";
 
 export default function Home() {
   const { user } = useUser();
@@ -103,6 +103,61 @@ export default function Home() {
 ```
 </CodeBlockTabs>
 
+### Reload user data
+
+If you need to retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
+
+<CodeBlockTabs options={['Next.js', 'React']}>
+```tsx filename="app/page.tsx" copy
+import { useUser } from "@clerk/nextjs";
+
+export default function Home() {
+  const { user } = useUser();
+  if (!user) return null;
+  const updateUser = async () => {
+    // updated data via an api point
+    const updateMeta = await fetch("/api/updateMetadata");
+    if (!updateMeta.message == "success") {
+      throw new Error("Error updating");
+    }
+    user.reload();
+  };
+
+  return (
+    <>
+      <button onClick={updateUser}>Click me to update your metadata</button>
+      <p>user role: {user?.publicMetadata.role}</p>
+    </>
+  );
+}
+```
+
+```tsx filename="home.tsx" copy
+import { useUser } from "@clerk/clerk-react";
+
+export default function Home() {
+  const { user } = useUser();
+  if (!user) return null;
+  const updateUser = async () => {
+    // updated data via an api point
+    const updateMeta = await fetch("/api/updateMetadata");
+    if (!updateMeta.message == "success") {
+      throw new Error("Error updating");
+    }
+    user.reload();
+  };
+
+  return (
+    <>
+      <button onClick={updateUser}>Click me to update your metadata</button>
+      <p>user role: {user?.publicMetadata.role}</p>
+    </>
+  );
+}
+```
+</CodeBlockTabs>
+
+## Return value
 
 <Tables 
   headings={["Variables", "Description"]} 


### PR DESCRIPTION
Makes some minor updates to the `useUser()` reference docs, and adds a section on reloading user data.