### PR TITLE
docs: update link referencing authMiddleware

### DIFF
--- a/docs/account-portal/overview.mdx
+++ b/docs/account-portal/overview.mdx
@@ -11,7 +11,7 @@ The Account Portal offers a comprehensive solution for managing user authenticat
 
 To use the Account Portal, add Clerk to your application and protect your pages. Any time an unauthenticated user attempts to access a protected page in your application, they will automatically get redirected to the Account Portal pages to Sign in.
 
-Depending on your choice of framework, you can redirect to them from your application using our NextJS [authMiddleware](/docs/references/nextjs/with-clerk-middleware), React [Control Components](docs/components/overview) or [ClerkJS SDK](/docs/references/javascript/overview).
+Depending on your choice of framework, you can redirect to them from your application using our NextJS [authMiddleware](/docs/references/nextjs/auth-middleware), React [Control Components](docs/components/overview) or [ClerkJS SDK](/docs/references/javascript/overview).
 
 
 # Features overview

--- a/docs/account-portal/overview.mdx
+++ b/docs/account-portal/overview.mdx
@@ -1,3 +1,8 @@
+---
+title: Account Portal
+description: The Account Portal offers a comprehensive solution for managing user authentication and profile management in your web application and is the fastest way to add Clerk's authentication to your application with minimal code required.
+---
+
 import { CodeBlockTabs } from "@/components/CodeBlockTabs";
 
 


### PR DESCRIPTION
This link was navigating to our with-clerk-middleware page, which refers to a helper that will become deprecated.
Updated the link to navigate to our new auth-middleware page.

<img width="731" alt="Screenshot 2023-08-10 at 11 40 14" src="https://github.com/clerkinc/clerk-docs/assets/98043211/8fde13b3-b401-4ce4-a3ef-24335dc9b143">

-- 
 
Also, added a missing title and description to the /account-portal/overview page.