### PR TITLE
docs: Update Ruby SDK examples.

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -109,7 +109,7 @@ privateMetadata = {
 }
 
 
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", private_metadata: privateMetadata)
 ```
 </CodeBlockTabs>
@@ -168,7 +168,7 @@ func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
 ```ts copy filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.getUser("user_xyz")
 ```
 </CodeBlockTabs>
@@ -261,7 +261,7 @@ publicMetadata = {
 }
 
 
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", public_metadata: publicMetadata)
 ```
 </CodeBlockTabs>
@@ -366,7 +366,7 @@ unsafeMetadata = {
 }
 
 
-clerk = Clerk::SDK.new(secret_key: "you_clerk_secret_key")
+clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
 clerk.users.updateMetadata("user_xyz", unsafe_metadata: unsafeMetadata)
 ```
 </CodeBlockTabs>


### PR DESCRIPTION
Pull forward the changes from https://github.com/clerkinc/clerk-docs/pull/151 rebased onto the new repository structure.