### PR TITLE
feat: adds workflow to trigger revalidation of docs pages

### DIFF
--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -37,4 +37,4 @@ jobs:
           curl -X POST ${{ env.CLERK_COM_BASE_URL }}/api/revalidate-docs \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
-            -d "{\"paths\": ${{ steps.paths-to-revalidate.outputs.paths }}}""
+            -d "{\"paths\": ${{ steps.paths-to-revalidate.outputs.paths }}}"

--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -1,0 +1,40 @@
+name: Revalidate Production Pages
+
+env:
+  CLERK_COM_BASE_URL: https://new-docs.clerkpreview.com
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+jobs:
+  trigger_revalidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10 # Fetch more than just the latest commit so we can accurately compare
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: docs/**
+          json: true
+
+      - name: Get paths to revalidate
+        id: paths-to-revalidate
+        run: |
+          paths_to_revalidate=$(echo ${{ contains(steps.changed-files.outputs.all_changed_files, 'docs/manifest.json') && '\\"*\\"' || toJSON(steps.changed-files.outputs.all_changed_files) }} | sed 's/.mdx//g' | sed 's/\/index//g')
+          echo "paths=$paths_to_revalidate" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger revalidate
+        run: |
+          curl -X POST ${{ env.CLERK_COM_BASE_URL }}/api/revalidate-docs \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
+            -d '{"paths": ${{ steps.paths-to-revalidate.outputs.paths }}}'

--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -37,4 +37,4 @@ jobs:
           curl -X POST ${{ env.CLERK_COM_BASE_URL }}/api/revalidate-docs \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_DOCS_SECRET }}" \
-            -d '{"paths": ${{ steps.paths-to-revalidate.outputs.paths }}}'
+            -d "{\"paths\": ${{ steps.paths-to-revalidate.outputs.paths }}}""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Once your pull request is approved, a member of the Clerk team will merge it and
 
 ## Deployment
 
-The content rendered on https://clerk.com/docs is pulled from the `production` branch in this repository. In most cases, all changes merged to `main` are considered "production ready" and will be merged into the `production` branch within a reasonable amount of time.
+The content rendered on https://clerk.com/docs is pulled from the `main` branch in this repository. Once changes are merged to the `main` branch, a workflow is triggered that updates the production pages. Changes should be reflected on https://clerk.com/docs within a matter of seconds.
 
 ## Repository structure
 


### PR DESCRIPTION
Adds a workflow to trigger revalidation of changed docs pages. It does this by detecting changed files and sending the changed files list in a POST request to our `revalidate-docs` endpoint. If the `manifest.json` file is changed, it will send a request with `"paths": "*"`, which will trigger revalidation of every path.

Requires https://github.com/clerkinc/clerk-marketing/pull/715 to be merged into the assembly branch.