### PR TITLE
feat: Add docs for remix repo level config

### DIFF
--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -231,7 +231,7 @@ export default function SignUpPage() {
   return (
     <div>
       <h1>Sign Up route</h1>
-      <SignUp routing={"path"} path={"/sign-up"} />
+      <SignUp />
     </div>
   );
 }
@@ -246,11 +246,24 @@ export default function SignInPage() {
   return (
     <div>
       <h1>Sign In route</h1>
-      <SignIn routing="path" path="/sign-in" />
+      <SignIn />
     </div>
   );
 }
 ```
+
+### Update your environment variables
+
+Next, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
+
+```sh copy filename=".env"
+CLERK_SIGN_IN_URL=/sign-in
+CLERK_SIGN_UP_URL=/sign-up
+CLERK_AFTER_SIGN_IN_URL=/
+CLERK_AFTER_SIGN_UP_URL=/
+```
+
+These values control the behavior of the components when you sign in or sign up and when you click on the respective links at the bottom of each component.
 
 ### Update your dashboard settings
 


### PR DESCRIPTION
We recently introduced the repo level config env variables for `Remix`, as we have for `Next.js`. This PR updates the remix + clerk docs to reflect that.

PS: we need to do a release for a fix for this feature so I'll merge this when that's done.