### PR TITLE
fix: escaping of wildcard character

### DIFF
--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get paths to revalidate
         id: paths-to-revalidate
         run: |
-          paths_to_revalidate=$(echo ${{ contains(steps.changed-files.outputs.all_changed_files, 'docs/manifest.json') && '\\"*\\"' || toJSON(steps.changed-files.outputs.all_changed_files) }} | sed 's/.mdx//g' | sed 's/\/index//g')
+          paths_to_revalidate=$(echo ${{ contains(steps.changed-files.outputs.all_changed_files, 'docs/manifest.json') && '\\\"*\\\"' || toJSON(steps.changed-files.outputs.all_changed_files) }} | sed 's/.mdx//g' | sed 's/\/index//g')
           echo "paths=$paths_to_revalidate" >> "$GITHUB_OUTPUT"
 
       - name: Trigger revalidate


### PR DESCRIPTION
Fix escaping when sending `"*"` to the revalidate endpoint.