### PR TITLE
remove copy that mentions steps when written inside a <Steps /> component

### DIFF
--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -20,7 +20,7 @@ Set up a new Clerk account and integrate it into a new application.
 Creating a Clerk account and using it in your apps can be done in three steps:
 
 <Steps>
-  ### Step 1: Create a Clerk account
+  ### Create a Clerk account
 
   [Go to Clerk's sign-up page](https://dashboard.clerk.com/sign-up) and create an account.
 
@@ -28,7 +28,7 @@ Creating a Clerk account and using it in your apps can be done in three steps:
 
   <div style={{filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)", maxWidth: "400px"}}>![An interactive "Create your account" card which provides sign-up options for a GitHub or Google account as well as email and password.](/docs/images/get-started/create-clerk-account.png)</div>
 
-  ### Step 2: Create a Clerk application
+  ### Create a Clerk application
 
   Once you've created an account, you'll be redirected to [your Clerk dashboard](https://dashboard.clerk.com/).
 
@@ -52,7 +52,7 @@ Creating a Clerk account and using it in your apps can be done in three steps:
 
   <div style={{filter: "drop-shadow(rgba(0, 0, 0, 0.16) 0px 12px 24px)"}}>![A list of supported frameworks with instructions on how to add API keys underneath.](/docs/images/get-started/env-keys.png)</div>
 
-  ### Step 3: Spin up a new codebase
+  ### Spin up a new codebase
 
   The API keys listed in the dashboard are just the first step to integrating Clerk into your apps. To get the most out of Clerk, check out our "Quickstart" guides:
 


### PR DESCRIPTION
remove copy that mentions steps when written inside a `<Steps />` component, because the steps component already numbers each step
e.g. 'step 1' when inside a `<Steps />` component

reproduce on /docs/quickstarts/setup-clerk

![Screenshot 2023-08-21 at 11 37 05](https://github.com/clerkinc/clerk-docs/assets/98043211/fbedf450-61c5-4a9d-bb6b-ee8cd7b7acab)
