### PR TITLE
migrate "ruby/available-methods" from sanity to mdx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,7 @@ If you have more complex content that you need inside a table, you can use the <
         </>,
       ],
     },
+  ]}
 />
 ```
 

--- a/docs/references/backend/sessions/verify-session.mdx
+++ b/docs/references/backend/sessions/verify-session.mdx
@@ -3,7 +3,7 @@ title: verifySession()
 description: Verifies whether a session with a given ID corresponds to the provided session token.
 ---
 
-# `revokeSession()`
+# `verifySession()`
 
 Verifies whether a session with a given ID corresponds to the provided session token. Throws an error if the provided ID is invalid.
 

--- a/docs/references/ruby/available-methods.mdx
+++ b/docs/references/ruby/available-methods.mdx
@@ -1,5 +1,135 @@
 ---
-sanity_slug: /docs/reference/ruby/available-methods
+title: Available methods | Ruby
+description: Learn about the available methods in the Clerk Ruby SDK.
 ---
 
-# This is a stub
+# Available methods
+
+The Ruby SDK mirrors the [Backend API](https://clerk.com/docs/reference/backend-api). The SDK is organized into resources, which are listed below. Each resource has a set of methods that correspond to the API endpoints.
+
+All examples assume you have an instance of the `Clerk::SDK`:
+
+```ruby
+sdk = Clerk::SDK.new
+```
+
+## Allowlist identifiers
+
+Retrieve the list of allowlist identifiers.
+
+```ruby
+sdk.allowlist_identifiers.all
+```
+
+Add a new identifier to the allowlist. If `notify` is true, an email will be sent to notify the owner of the identifier.
+
+```ruby
+sdk.allowlist_identifiers.create(identifier: "john@example.com", notify: true)
+```
+
+Delete an allowlist identifier, given a valid ID. Throws an error if the ID is invalid.
+
+```ruby
+sdk.allowlist_identifiers.delete("alid_xyz")
+```
+
+## Allowlist
+
+Toggle allowlist-only sign-ups on/off.
+
+```ruby
+sdk.allowlist.update(restricted_to_allowlist: true)
+```
+
+## Clients
+
+Retrieve a single client by its ID, if the ID is valid. Throws an error otherwise.
+
+```ruby
+sdk.clients.find("client_xyz")
+```
+
+Retrieve the list of clients.
+
+```ruby
+sdk.clients.all
+```
+
+Verify the JWT and return the client.
+
+```ruby
+sdk.clients.verify_token("jwt")
+```
+
+## Emails
+
+Send an email message to an email address ID belonging to another user.
+
+```ruby
+sdk.emails.create(
+    email_address_id: "ema_xyz", 
+    from_email_name: "noreply", 
+    subject: "Welcome",
+    body: "<html>...</html>",
+)
+```
+
+## Sessions
+
+Retrieve a single session by its ID, if the ID is valid. Throws an error otherwise.
+
+```ruby
+sdk.sessions.find("sess_xyz")
+```
+
+Retrieve a list of sessions.
+
+```ruby
+sdk.sessions.all
+```
+
+Revokes a session given its ID, if the ID is valid. Throws an error otherwise.
+
+```ruby
+sdk.sessions.revoke("sess_xyz")
+```
+
+Verify whether a session with a given ID corresponds to the provided session token. Throws an error if the provided ID is invalid.
+
+```ruby
+sdk.sessions.verify_token("sess_xyz", "jwt")
+```
+
+## SMS Messages
+
+Send an SMS message to a phone number ID belonging to another user.
+
+```ruby
+sdk.sms_messages.create(phone_number_id: "idn_xyz", message: "Welcome!")
+```
+
+## Users
+
+Retrieves a list of users.
+
+```ruby
+sdk.users.all
+```
+
+Retrieves a list of users, with filters:
+
+```ruby
+sdk.users.all(email_address: ["user1@example.com", "user2@example.com"])
+```
+
+Updates a user with a given ID. The provided ID must be valid, otherwise an error will be thrown.
+
+```ruby
+sdk.users.update("user_xyz", {first_name: "John"})
+```
+
+Deletes a user given a valid ID. Throws an error otherwise.
+
+```ruby
+sdk.users.delete("user_xyz")
+```

--- a/docs/references/ruby/available-methods.mdx
+++ b/docs/references/ruby/available-methods.mdx
@@ -13,7 +13,7 @@ All examples assume you have an instance of the `Clerk::SDK`:
 sdk = Clerk::SDK.new
 ```
 
-## Allowlist identifiers
+## [Allowlist identifiers](https://clerk.com/docs/reference/backend-api/tag/Allow-list-Block-list)
 
 Retrieve the list of allowlist identifiers.
 
@@ -41,7 +41,7 @@ Toggle allowlist-only sign-ups on/off.
 sdk.allowlist.update(restricted_to_allowlist: true)
 ```
 
-## Clients
+## [Clients](https://clerk.com/docs/reference/backend-api/tag/Clients)
 
 Retrieve a single client by its ID, if the ID is valid. Throws an error otherwise.
 
@@ -61,7 +61,7 @@ Verify the JWT and return the client.
 sdk.clients.verify_token("jwt")
 ```
 
-## Emails
+## [Emails](https://clerk.com/docs/reference/backend-api/tag/Emails)
 
 Send an email message to an email address ID belonging to another user.
 
@@ -74,7 +74,7 @@ sdk.emails.create(
 )
 ```
 
-## Sessions
+## [Sessions](https://clerk.com/docs/reference/backend-api/tag/Sessions)
 
 Retrieve a single session by its ID, if the ID is valid. Throws an error otherwise.
 
@@ -100,7 +100,7 @@ Verify whether a session with a given ID corresponds to the provided session tok
 sdk.sessions.verify_token("sess_xyz", "jwt")
 ```
 
-## SMS Messages
+## [SMS Messages](https://clerk.com/docs/reference/backend-api/tag/SMS-Messages)
 
 Send an SMS message to a phone number ID belonging to another user.
 
@@ -108,7 +108,7 @@ Send an SMS message to a phone number ID belonging to another user.
 sdk.sms_messages.create(phone_number_id: "idn_xyz", message: "Welcome!")
 ```
 
-## Users
+## [Users](https://clerk.com/docs/reference/backend-api/tag/Users)
 
 Retrieves a list of users.
 


### PR DESCRIPTION
The previous docs for /docs/references/ruby/available-methods had incorrect links and outdated information. 

This PR
- Migrate this page from Sanity to MDX
- Updates the content
- Fixes an incorrect heading on /docs/references/backend/sessions/verify-session 
- Adds missing brackets on a `<Table />` component in the CONTRIBUTING.md

The previous Ruby content (written in Sanity):

https://github.com/clerkinc/clerk-docs/assets/98043211/3df7f459-e91a-4bed-853f-a2eca9f613c0

The table held redundant as well as incorrect information (the first table heading is labeled incorrectly, the methods for some of the endpoints are incorrect). I removed this table and instead link to the endpoints within each corresponding heading.