### PR TITLE
remove nextjs from 'backend-requests/handling'

### DIFF
--- a/docs/backend-requests/handling/nextjs.mdx
+++ b/docs/backend-requests/handling/nextjs.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/request-authentication/nextjs
----
-
-# This is a stub

--- a/docs/backend-requests/handling/nextjs.mdx
+++ b/docs/backend-requests/handling/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-sanity_slug: /docs/request-authentication/gatsby
+sanity_slug: /docs/request-authentication/nextjs
 ---
 
 # This is a stub

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -143,7 +143,6 @@
       ],
       ["JWT Templates", "/backend-requests/making/jwt-templates"],
       "# Handling requests",
-      ["Next.js", "/backend-requests/handling/nextjs"],
       ["Node.js & Express", "/backend-requests/handling/nodejs"],
       ["Go", "/backend-requests/handling/go"],
       ["Gatsby", "/backend-requests/handling/gatsby"],


### PR DESCRIPTION
/docs/backend-requests/handling/nextjs has redundant and outdated information (see below)

<img width="1512" alt="Screenshot 2023-08-23 at 09 08 26" src="https://github.com/clerkinc/clerk-docs/assets/98043211/c449a971-a870-45e0-a0cc-161337cc8f68">

This PR removes that outdated page altogether.
A PR in the Marketing Repo is redirect our old path "/docs/request-authentication/nextjs" to the new page with updated information: "/docs/references/nextjs/auth-middleware".
