### PR TITLE
fix: use correct syntax in table to solve rendering error

### DIFF
--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -163,7 +163,7 @@ All props below are optional.
         <code>unsafeMetadata</code>,
         <code>object</code>,
         <>
-          An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. <code>{ "company": "companyID1234" }</code>
+          An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. <code>\{ "company": "companyID1234" \}</code>
         </>,
       ],
     },

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -162,7 +162,9 @@ All props below are optional.
       cells: [
         <code>unsafeMetadata</code>,
         <code>object</code>,
-        <>An object with the key and value for unsafeMetadata that will be saved to the user after signUp. IE, `{{ "company": "companyID1234" }}`</>,
+        <>
+          An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. <code>{ "company": "companyID1234" }</code>
+        </>,
       ],
     },
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -98,75 +98,13 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
 
 All props below are optional.
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-    {
-      cells: [
-        <code>appearance</code>,
-        <code>object</code>,
-        <>Controls the overall look and feel of the component. See <a href="/docs/components/ui/appearance/">Appearance</a> for more information.</>,
-      ]
-    },
-    {
-      cells: [
-        <code>routing</code>,
-        <code>string</code>,
-        <>The routing strategy for your pages. Supported values are: 
-          <ul>
-            <li>hash (default): Hash-based routing.</li>
-            <li>path: Path-based routing.</li>
-            <li>virtual: Virtual-based routing</li>
-          </ul>
-        </>,
-      ],
-    },
-    {
-      cells: [
-        <code>path</code>,
-        <code>string</code>,
-        <>The path where the component is mounted on when path-based routing is used e.g. /sign-up.</>,
-      ],
-    },
-    {
-      cells: [
-        <code>redirectUrl</code>,
-        <code>string</code>,
-        <>Full URL or path to navigate to after successful sign in or sign up.
-        <br/>The same as setting afterSignInUrl and afterSignUpUrl to the same value.</>,
-      ],
-    },
-    {
-      cells: [
-        <code>afterSignInUrl</code>,
-        <code>string</code>,
-        <>The full URL or path to navigate to after a successful sign in.</>,
-      ],
-    },
-    {
-      cells: [
-        <code>signInUrl</code>,
-        <code>string</code>,
-        <>Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered.</>,
-      ],
-    },
-    {
-      cells: [
-        <code>afterSignUpUrl</code>,
-        <code>string</code>,
-        <>The full URL or path to navigate after a successful sign up.</>,
-      ],
-    },
-    {
-      cells: [
-        <code>unsafeMetadata</code>,
-        <code>object</code>,
-        <>
-          An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. <code>\{ "company": "companyID1234" \}</code>
-        </>,
-      ],
-    },
-
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `appearance` | `object` | Controls the overall look and feel of the component. See [Appearance](/docs/components/ui/appearance/) for more information. |
+| `routing` | `string` | The routing strategy for your pages.<br />Supported values are: <ul><li>hash (default): Hash-based routing.</li> <li>path: Path-based routing.</li> <li>virtual: Virtual-based routing</li></ul> |
+| `path` | `string` | The path where the component is mounted on when path-based routing is used e.g. /sign-up. |
+| `redirectUrl` | `string` | Full URL or path to navigate to after successful sign in or sign up.<br />The same as setting afterSignInUrl and afterSignUpUrl to the same value. |
+| `afterSignInUrl` | `string` | The full URL or path to navigate to after a successful sign in. |
+| `signInUrl` | `string` | Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered. |
+| `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
+| `unsafeMetadata` | `object` | An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. `{ "company": "companyID1234" }` |


### PR DESCRIPTION
The previous syntax was causing JSX to be rendered, and it was incorrect JSX syntax. This was causing a deployment failure.

This PR updates the syntax to be correct.