### PR TITLE
DOCS-258 Remove references to Create React App

### DIFF
--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -58,7 +58,7 @@ Creating a Clerk account and using it in your apps can be done in three steps:
 
   <div className="container mx-auto my-4">
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-      <FrameworkCards title="React" description="Get started installing and initializing Clerk in a new Create React App." link="/docs/quickstarts/react" cta="Get Started" icon="/docs/images/logos/react.svg" />
+      <FrameworkCards title="React" description="Get started installing and initializing Clerk in a new React App." link="/docs/quickstarts/react" cta="Get Started" icon="/docs/images/logos/react.svg" />
 
       <FrameworkCards title="Next.js" description="Easily add secure, beautiful, and fast authentication to Next.js with Clerk." link="/docs/quickstarts/nextjs" cta="Get Started" icon="/docs/images/logos/nextjs.svg" iconWidth="40" />
 


### PR DESCRIPTION
The official React docs no longer push for CRA for installation. We can cut out mentionings of "Create React App" and just reference "React app"