### PR TITLE
remove page; redirects to new content

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -105,8 +105,7 @@
       ["<UserProfile />", "/users/user-profile"],
       "# Guides",
       ["Sync data to your backend", "/users/sync-data"],
-      ["Web3 authentication", "/users/web3-wallets"],
-      ["Build custom UIs", "/users/build-your-own-ui"]
+      ["Web3 authentication", "/users/web3-wallets"]
     ]
   ],
   [

--- a/docs/users/build-your-own-ui.mdx
+++ b/docs/users/build-your-own-ui.mdx
@@ -1,3 +1,0 @@
----
-sanity_slug: /docs/users/build-your-own-ui
----


### PR DESCRIPTION
/docs/users/build-your-own-ui has redundant and outdated information (see below)

https://github.com/clerkinc/clerk-docs/assets/98043211/07364fbb-b5f1-439c-8101-e0914a700cf4

This PR removes that outdated page altogether.
[A PR in the Marketing Repo](https://github.com/clerkinc/clerk-marketing/pull/743) is redirecting our old path "/docs/users/build-your-own-ui" to the new page with updated information: "/docs/custom-flows/use-sign-up"