### PR TITLE
DOCS-255 Consolidate setup guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ The content rendered on https://clerk.com/docs is pulled from the `main` branch 
 
 The documentation content is located in the [`/docs` directory](./docs/). Each MDX file located in this directory will be rendered under https://clerk.com/docs at its path relative to the root `/docs` directory, without the file extension.
 
-For example, the file at `/docs/get-started/setup-clerk.mdx` can be found at https://clerk.com/docs/get-started/setup-clerk.
+For example, the file at `/docs/quickstarts/setup-clerk.mdx` can be found at https://clerk.com/docs/quickstarts/setup-clerk.
 
 ### Navigation manifest
 

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -11,4 +11,4 @@ Clerk supports multiple authentication strategies so that you can implement the 
 
 Clerk's configuration settings affect how the users of your application can [sign up](/docs/authentication/configuration/sign-up-options) and [sign in](/docs/authentication/configuration/sign-in-options) and which attributes are editable via their user profile. You can also manage [user sessions](/docs/authentication/configuration/session-options), [control who gets access](/docs/authentication/configuration/allowlist) to your application, and [customize the email & SMS messages](/docs/authentication/configuration/email-options) that are sent by Clerk during authentication flows. All of these settings can be found under the **User & Authentication** section in your [Clerk Dashboard](https://dashboard.clerk.com/).
 
-Check out our detailed guide for information on [how to set up your application](/docs/quickstarts/get-started).
+Check out our detailed guide for information on [how to set up your application](/docs/quickstarts/setup-clerk).

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -11,4 +11,4 @@ Clerk supports multiple authentication strategies so that you can implement the 
 
 Clerk's configuration settings affect how the users of your application can [sign up](/docs/authentication/configuration/sign-up-options) and [sign in](/docs/authentication/configuration/sign-in-options) and which attributes are editable via their user profile. You can also manage [user sessions](/docs/authentication/configuration/session-options), [control who gets access](/docs/authentication/configuration/allowlist) to your application, and [customize the email & SMS messages](/docs/authentication/configuration/email-options) that are sent by Clerk during authentication flows. All of these settings can be found under the **User & Authentication** section in your [Clerk Dashboard](https://dashboard.clerk.com/).
 
-Check out our detailed guide for information on [how to set up your application](/docs/authentication/set-up-your-application).
+Check out our detailed guide for information on [how to set up your application](/docs/quickstarts/get-started).

--- a/docs/authentication/set-up-your-application.mdx
+++ b/docs/authentication/set-up-your-application.mdx
@@ -1,3 +1,0 @@
----
-sanity_slug: /docs/authentication/set-up-your-application
----

--- a/docs/quickstarts/setup-clerk.mdx
+++ b/docs/quickstarts/setup-clerk.mdx
@@ -75,4 +75,14 @@ Creating a Clerk account and using it in your apps can be done in three steps:
       <FrameworkCards title="Fastify" description="Learn about installing and initializing Clerk in a new Fastify application." link="/docs/quickstarts/fastify" cta="Get Started" icon="/docs/images/logos/fastify.svg" iconWidth="40" />
     </div>
   </div>
+
+  ### Learn about authentication
+
+  Clerk supports multiple authentication strategies so that you can implement the strategy that makes sense for your users. These strategies affect how the users of your application can sign up and sign in and which attributes are editable via their user profile. You can learn more in our [authentication guide](/docs/authentication/overview).
+
+  ### Customize your application
+
+  Clerk provides a set of [components](/docs/components/overview) that you can use to build *your* application. These components are highly customizable and can be used to build a variety of user flows. You can learn more about Clerk's components in our [components guide](/docs/components/overview).
+
+  If our prebuilt components don't meet your specific needs or you require more control over the authentication flow, Clerk enables you to build fully custom sign-up and sign-in flows. You can learn more about building custom flows in our [custom flows guide](/docs/custom-flows/overview).
 </Steps>


### PR DESCRIPTION
Currently, we have our old set up guide still being rendered, and also referenced, in our docs at /docs/authentication/set-up-your-application
I have reviewed it to ensure that all the information on this page is somehow replicated/updated in the new docs.
Most of the information is now located at /docs/authentication/configuration/sign-up-options

This PR
- adds more information to our "Setup Clerk" guide to better help guide users to the resources they will need when setting up an application. The authentication section is especially helpful, because it will navigate users to where the "set-up-your-application" information now lives.
- removes the page set-up-your-application from being rendered. Navigating to this old path will redirect to our /quickstarts/setup-clerk guide thanks to [this PR](https://github.com/clerkinc/clerk-marketing/pull/746)
- updates links that reference to "set-up-your-application"
- fixes incorrect links that I also found, which were using /get-started instead of /quickstarts