### PR TITLE
code review

### DIFF
--- a/docs/account-portal/custom-redirects.mdx
+++ b/docs/account-portal/custom-redirects.mdx
@@ -9,7 +9,7 @@ After a user signs in or signs up, Clerk automatically redirects users back to y
 
 ## Environment variables
 
-You can define the paths you want the users to be redirected to via environment variables. In this example, we redirect users to "/dashboard" after signing in, and to "/onboarding" after signing up.
+You can define the paths you want the users to be redirected to via environment variables. In this example, we redirect users to `/dashboard` after signing in, and to `/onboarding` after signing up.
 
 <Tabs items={["Next.js", "Remix"]}>
 <Tab>
@@ -116,9 +116,15 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   export default function Home() {
     return (
       <div>
-      <h1> Sign in </h1>
-        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
-        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
+        <h1>Welcome!</h1>
+
+        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign in
+        </SignInButton>
+
+        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign up
+        </SignUpButton>
       </div>
     );
   }
@@ -130,9 +136,15 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   export default function Example() {
     return (
       <div>
-      <h1> Sign in </h1>
-        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
-        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
+        <h1>Welcome!</h1>
+
+        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign in
+        </SignInButton>
+
+        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign up
+        </SignUpButton>
       </div>
     );
   }
@@ -144,9 +156,15 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   export default function Home() {
     return (
       <div>
-      <h1> Sign in </h1>
-        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
-        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
+        <h1>Welcome!</h1>
+
+        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign in
+        </SignInButton>
+
+        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign up
+        </SignUpButton>
       </div>
     );
   }
@@ -158,44 +176,17 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   export default function Home() {
     return (
       <div>
-      <h1> Sign in </h1>
-        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
-        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'/>
+        <h1>Welcome!</h1>
+
+        <SignInButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign in
+        </SignInButton>
+
+        <SignUpButton afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding'>
+          Sign up
+        </SignUpButton>
       </div>
     );
   }
   ```
 </CodeBlockTabs>
-
-## Dashboard fallbacks
-
-If you provide users with a direct link to the Account Portal pages, you can specify the redirects as a fallback in the Clerk Dashboard. 
-
-<Callout type="info" emoji="💡">
-  While we provide this functionality as a fallback, **we do not recommend** configuring this through the dashboard and encourage you to specify redirects in your application flows instead. 
-</Callout>
-
-<Steps>
-
-### Set your static fallback host
-
-For development, set your static fallback localhost (e.g. http://localhost:3000) that we will use if we are unable to retrieve a dev browser for your client. In production, this will always be your application homepage. 
-
-<Images 
-  width={3248}
-  height={2112}
-  src="/docs/images/account-portal/account_portal_paths.png"
-  alt="Account Portal paths"
-/>
-  
-### Configure fallback redirects
-
-You can specify the fallback redirects through the Clerk Dashboard
-
-<Images 
-  width={3248}
-  height={2112}
-  src="/docs/images/account-portal/account_portal_redirects.png"
-  alt="Account Portal redirects"
-/>
-</Steps>

--- a/docs/account-portal/getting-started.mdx
+++ b/docs/account-portal/getting-started.mdx
@@ -5,9 +5,9 @@ description: The Account Portal offers a comprehensive solution for managing use
 
 # Getting started with the Account Portal  
 
-To integrate the Account Portal into your application, you need to simply follow one of our [quickstart guides](/docs/quickstarts/overview). 
+To integrate the Account Portal into your application, simply follow one of our [quickstart guides](/docs/quickstarts/overview). 
 
-Once your application is set up, all you have to do is fire it up. Clerk will automatically redirect your users to the Account Portal sign-in/sign-up pages. Once a user has successfully authenticated themself, they will be automatically be redirected back to your application with an active session. 
+Once your application is set up, all you have to do is fire it up. Clerk will automatically redirect your users to the Account Portal sign-in/sign-up pages. Once a user has successfully authenticated themself, they will be automatically redirected back to your application with an active session. 
 
 <Callout type="info" emoji="💡">
   **Dynamic Development Host Detection**  
@@ -15,3 +15,62 @@ Once your application is set up, all you have to do is fire it up. Clerk will au
   For development environments, the development host (e.g. http://localhost:3000) is dynamically detected by Clerk at runtime and tied to your client browser. We store this as the ‘home origin’ for your application and it is equivalent to your application domain in production environments.
 </Callout>
 
+## Fallback redirects
+
+After a user has finished their flow in an Account Portal page, Clerk automatically redirects them back to your application by appending a `redirect_url` query param on the Account Portal page. However, if a user accesses an Account Portal page directly, they cannot be redirected back to your application since they didn't originate from your application. Don't worry, Clerk offers configurable fallback redirects.
+
+<Steps>
+
+### Set your static fallback host
+
+Set your fallback host under **Paths** in the Clerk Dashboard. 
+
+For development, set your static fallback localhost with the port that you use (e.g. `http://localhost:3000`). Clerk will use this fallback host if a dev browser fails to be retrieved for your client. In production, this will always be your application homepage.
+
+<Images 
+  width={3248}
+  height={2112}
+  src="/docs/images/account-portal/account_portal_paths.png"
+  alt="Account Portal paths"
+/>
+  
+### Configure fallback redirects
+
+Specify the fallback redirects under **Account Portal -> Redirects** in the Clerk Dashboard.
+
+<Images 
+  width={3248}
+  height={2112}
+  src="/docs/images/account-portal/account_portal_redirects.png"
+  alt="Account Portal redirects"
+/>
+
+</Steps>
+
+## Direct links
+
+If you would like to provide users with a direct link to an Account Portal page, you need to specify the redirect in the link so that users can be redirected to your application after their Account Portal flow.
+
+### Development 
+
+For development instances, you can use the following format for your direct links:
+
+`https://accounts.<your-domain.com>/<account-portal-page>?redirect_url=http://localhost:3000/dashboard`
+
+#### Example
+
+In this example, the domain is `clerk.dev`, the user is being linked to the sign-in Account Portal page, and the user will be redirected to `http://localhost:3000/dashboard` after their Account Portal flow.
+
+`https://accounts.clerk.dev/sign-in?redirect_url=http://localhost:3000/dashboard`
+
+### Production
+
+For production instances, you can use the following format for your direct links:
+
+`https://accounts.<your-domain.com>/<account-portal-page>?redirect_url=https://<your-domain.com>/dashboard`
+
+#### Example
+
+In this example, the domain is `clerk.dev`, the user is being linked to the sign-in Account Portal page, and the user will be redirected to `https://clerk.dev/dashboard` after their Account Portal flow.
+
+`https://accounts.clerk.dev/sign-in?redirect_url=https://clerk.dev/dashboard`

--- a/docs/account-portal/overview.mdx
+++ b/docs/account-portal/overview.mdx
@@ -16,13 +16,13 @@ The Account Portal in Clerk is a powerful feature that allows you to streamline 
 
 ## Why use the Account Portal?
 
-The Account Portal provides all the pages your users need to sign-up, sign-in, and manage their accounts, all while maintaining seamless integration with your application. These pages are hosted on Clerk servers for you and they require minimal setup to get started. If you’re looking for the fastest way to get your application up and running, then this is a great choice.
+The Account Portal provides the pages necessary for your users to sign-up, sign-in, and manage their accounts, all while maintaining seamless integration with your application. These pages are hosted on Clerk servers for you and they require minimal setup to get started. If you’re looking for the fastest way to add authentication and user management to your application, then this is a great choice.
 
-However, if you require more precise customization or prefer having your application self-contained, then we would recommend using our [prebuilt components](/docs/components/overview) or [custom flows](/docs/custom-flows/overview) instead.
+However, if you require more precise customization or prefer having your application self-contained, then we would recommend using our fully customizable [prebuilt components](/docs/components/overview), or you can build your own [custom flows](/docs/custom-flows/overview) instead.
 
 ## How the Account Portal works
 
-The Account Portal uses our [prebuilt Clerk components](/docs/components/overview) embedded on dedicated pages hosted for your application. Users are automatically redirected to and from your application for a seamless authentication experience.  
+The Account Portal utilizes our [prebuilt Clerk components](/docs/components/overview), which are embedded into dedicated pages hosted on Clerk servers. After a user has finished their flow in an Account Portal page, Clerk automatically redirects them back to your application by appending a `redirect_url` query param on the Account Portal page. This way, users are automatically redirected to and from your application for a seamless authentication experience. To integrate the Account Portal with your application, check out our [setup guide](/docs/account-portal/getting-started).
 
 
 <Images 
@@ -32,7 +32,7 @@ The Account Portal uses our [prebuilt Clerk components](/docs/components/overvie
   alt="How the Account Portal works"
 />
 
-For each application environment, Clerk provides hosted pages including sign-up, sign-in, user profiles, organization profiles, and an organization creation flow.
+For each application environment, Clerk provides pages for sign-up, sign-in, user profile, organization profile, and organization creation flow.
 
 For development environments, Clerk will issue you a randomly generated domain on "lcl.dev". In production, by default, the URLs for your Account Portal are the following:
 

--- a/docs/account-portal/user-profile-org-profile.mdx
+++ b/docs/account-portal/user-profile-org-profile.mdx
@@ -1,16 +1,16 @@
 ---
-title: User & Organization Pages | Account Portal
+title: User & Organization pages | Account Portal
 description: In addition to the sign-in/sign-up pages, the Account Portal also provides the User Profile, Organization Profile and Create Organization flow out of the box. 
 ---
 
-# User & Organization Pages
+# User & Organization pages
 
-In addition to the sign-in/sign-up pages, the Account Portal also provides the User Profile, Organization Profile, and Create Organization flow out of the box. 
+In addition to the sign-in/sign-up pages, the Account Portal also provides the User Profile, Organization Profile, and Create Organization pages out of the box. 
 
 You can use Clerk's Control Components to navigate your users to the appropriate page.
 
 
-## User Profile Page
+## User Profile page
 
 
 The User Profile page is full-featured account management UI that allows users to manage their profile and security settings. 
@@ -23,10 +23,10 @@ The User Profile page is full-featured account management UI that allows users t
 />
 
 
-Redirect your authenticated users to their User profile page using the [`<RedirectToUserProfile/>`](/docs/components/control/redirect-to-userprofile) control component.
+Redirect your authenticated users to their User Profile page using the [`<RedirectToUserProfile/>`](/docs/components/control/redirect-to-userprofile) control component.
 
 
-## Organization Profile Page
+## Organization Profile page
 
 The Organization Profile page is a beautiful, full-featured organization management UI that allows users to manage their organization profile and security settings.
 
@@ -38,13 +38,13 @@ The Organization Profile page is a beautiful, full-featured organization managem
 />
 
 
-Redirect your authenticated users to their Organization's profile page using the [`<RedirectToOrganizationProfile/>`](/docs/components/control/redirect-to-organizationprofile) control component.
+Redirect your authenticated users to their Organization Profile page using the [`<RedirectToOrganizationProfile/>`](/docs/components/control/redirect-to-organizationprofile) control component.
 
 
 
-## Create Organization Flow
+## Create Organization page
 
-The organization creation flow is a UI that allows users to create brand new organizations within your application.
+The Create Organization page is a UI that allows users to create brand new organizations within your application.
 
 <Images 
   width={3248}

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -165,7 +165,7 @@
 
       "# Advanced Usage",
       ["Custom redirects", "/account-portal/custom-redirects"],
-      ["User & Organization Pages","/account-portal/user-profile-org-profile"],
+      ["User & Organization pages","/account-portal/user-profile-org-profile"],
       ["Disable Account Portal","/account-portal/disable-account-portal"]
     ]
   ],


### PR DESCRIPTION
I think fallback redirects are better on the "getting started" page, because its something users should set up and learn about when getting started with the account portal.  I also added a section about direct links to the account portal pages, with specific examples for each type of instance.