### PR TITLE
fix for broken link GH action

### DIFF
--- a/docs/security/vulnerability-disclosure-policy.mdx
+++ b/docs/security/vulnerability-disclosure-policy.mdx
@@ -22,22 +22,22 @@ If you follow these guidelines when reporting an issue to us, we commit to:
 - Recognize your contribution on our Security Researcher Hall of Fame, if you are the first to report the issue and we make a code or configuration change based on the issue.
 
 ## Scope
-- https://dashboard.clerk.dev
-- https://accounts.clerk.dev
-- https://api.clerk.dev
-- https://clerk.clerk.dev
-- Production instances created on https://dashboard.clerk.dev
+- `https://dashboard.clerk.dev`
+- `https://accounts.clerk.dev`
+- `https://api.clerk.dev`
+- `https://clerk.clerk.dev`
+- Production instances created on `https://dashboard.clerk.dev`
 
 ## Out of scope
 
 Any services hosted by 3rd party providers and services are excluded from scope. These services include:
 
-- https://clerk.dev
-- https://docs.clerk.dev
+- `https://clerk.dev`
+- `https://docs.clerk.dev`
 
 In the interest of the safety of our users, staff, the Internet at large and you as a security researcher, the following test types are excluded from scope:
 
-- Findings in Development or Staging instances created on https://dashboard.clerk.dev
+- Findings in Development or Staging instances created on `https://dashboard.clerk.dev`
 - Findings from physical testing such as office access (e.g. open doors, tailgating)
 - Findings derived primarily from social engineering (e.g. phishing, vishing)
 - Findings from applications or systems not listed in the ‘Scope’ section


### PR DESCRIPTION
Let's throw these links in code snippets so that our link checker doesn't think we are trying to route out to them ?
The errors were:
https://accounts.clerk.dev/ found on https://clerk.dev/docs/security/vulnerability-disclosure-policy (403 - FORBIDDEN)
https://api.clerk.dev/ found on https://clerk.dev/docs/security/vulnerability-disclosure-policy (404 - NOT FOUND)

Let me know what you think.