### PR TITLE
Proper usage of the word `tamper`

### DIFF
--- a/docs/advanced-usage/manual-jwt.mdx
+++ b/docs/advanced-usage/manual-jwt.mdx
@@ -11,7 +11,7 @@ import { Steps } from 'nextra-theme-docs'
 
 Your Clerk-generated session tokens are essentially JWTs which are signed using your instance's private key and can be verified using your instance's public key. Depending on your architecture, these tokens will be in your backend requests either via a cookie named __session or via the Authorization header.
 
-For every request, you must validate its token to make sure it hasn't expired and it is authentic (i.e. no malicious user tried to tamper it). If these validations pass, then it means that the user is authenticated to your application and you should consider them signed in.
+For every request, you must validate its token to make sure it hasn't expired and it is authentic (i.e. no malicious user tried to tamper with it). If these validations pass, then it means that the user is authenticated to your application and you should consider them signed in.
 
 <Steps>
 


### PR DESCRIPTION
Fixed `docs/advanced-usage/manual-jwt.mdx` for proper usage of the word `tamper` (tamper *with it* rather than tamper *it*).