### PR TITLE
DOCS-282 Consolidate component references

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -9,9 +9,9 @@ Clerk supports sharing sessions across different domains by adding one or many s
 
 Your "primary" domain is where the authentication state lives, and satellite domains are able to securely read that state from the primary domain, enabling a seamless authentication flow across domains.
 
-Users must complete the sign in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/custom-flows/use-sign-up#use-sign-in) hook.
+Users must complete the sign-in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/custom-flows/use-sign-up#use-sign-in) hook.
 
-To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign-in, they must be redirected to a sign-in flow hosted on the primary domain, then redirected back to the originating satellite domain.
+To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign in, they must be redirected to a sign in flow hosted on the primary domain, then redirected back to the originating satellite domain.
 
 
 ## How to add Satellite Domains
@@ -33,7 +33,7 @@ When building your sign-in flow, you must configure it to run within your primar
 
 ### Add your first satellite domain
 
-Go to the **Domains** tab in the Clerk dashboard and add a new satellite domain of your choice. Then, follow the instructions provided.
+Go to the [Domains](https://dashboard.clerk.com/last-active?path=domains) tab in the Clerk dashboard and add a new satellite domain of your choice. Then, follow the instructions provided.
 
 For the purposes of this guide, the satellite domain will be "satellite.dev".
 

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -9,7 +9,7 @@ Clerk supports sharing sessions across different domains by adding one or many s
 
 Your "primary" domain is where the authentication state lives, and satellite domains are able to securely read that state from the primary domain, enabling a seamless authentication flow across domains.
 
-Users must complete the sign in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/authentication/components/sign-in) component or our [`useSignIn()`](/docs/custom-flows/use-sign-up#use-sign-in) hook.
+Users must complete the sign in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or our [`useSignIn()`](/docs/custom-flows/use-sign-up#use-sign-in) hook.
 
 To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign-in, they must be redirected to a sign-in flow hosted on the primary domain, then redirected back to the originating satellite domain.
 

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -9,7 +9,7 @@ Clerk supports sharing sessions across different domains by adding one or many s
 
 Your "primary" domain is where the authentication state lives, and satellite domains are able to securely read that state from the primary domain, enabling a seamless authentication flow across domains.
 
-Users must complete the sign in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or our [`useSignIn()`](/docs/custom-flows/use-sign-up#use-sign-in) hook.
+Users must complete the sign in flow on the primary domain, either using Clerk’s [`<SignIn />`](/docs/components/authentication/sign-in) component or [`useSignIn()`](/docs/custom-flows/use-sign-up#use-sign-in) hook.
 
 To access authentication state from a satellite domain, users will be transparently redirected to the primary domain. If users need to sign-in, they must be redirected to a sign-in flow hosted on the primary domain, then redirected back to the originating satellite domain.
 
@@ -28,7 +28,7 @@ To get started, you need to create an Application from the [Clerk Dashboard](htt
 When building your sign-in flow, you must configure it to run within your primary application, e.g. on /sign-in.
 
 <Callout type="info">
-For more information about creating your application, check out our [detailed guide](/docs/quickstarts/setup-clerk).
+  For more information about creating your application, check out Clerk's [detailed guide](/docs/quickstarts/setup-clerk).
 </Callout>
 
 ### Add your first satellite domain

--- a/docs/authentication/components/overview.mdx
+++ b/docs/authentication/components/overview.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/authentication/using-clerk-components
----
-
-# This is a stub

--- a/docs/authentication/components/sign-in.mdx
+++ b/docs/authentication/components/sign-in.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/authentication/sign-in
----
-
-# This is a stub

--- a/docs/authentication/components/sign-up.mdx
+++ b/docs/authentication/components/sign-up.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/authentication/sign-up
----
-
-# This is a stub

--- a/docs/authentication/overview.mdx
+++ b/docs/authentication/overview.mdx
@@ -5,7 +5,7 @@ description: Learn how to configure authentication and user management for your 
 
 # Overview
 
-Clerk supports multiple authentication strategies so that you can implement the strategy that makes sense for *your* users. You can use Clerk's [hosted pages](/docs/authentication/using-clerk-hosted-pages), [pre-built components](/docs/authentication/components/overview), or [build your own custom flows](/docs/custom-flows/overview).
+Clerk supports multiple authentication strategies so that you can implement the strategy that makes sense for *your* users. You can use Clerk's [hosted pages](/docs/authentication/using-clerk-hosted-pages), [pre-built components](/docs/components/overview), or [build your own custom flows](/docs/custom-flows/overview).
 
 ## Configuration
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -52,8 +52,8 @@
       ["Email & SMS options", "/authentication/configuration/email-options"],
       ["Allowlist / Blocklist", "/authentication/configuration/allowlist"],
       "# Prebuilt Components",
-      ["<SignUp/>", "/components/authentication/sign-up"],
       ["<SignIn/>", "/components/authentication/sign-in"],
+      ["<SignUp/>", "/components/authentication/sign-up"],
       "# Social Connections",
       ["Overview", "/authentication/social-connections/overview"],
       [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -51,10 +51,6 @@
       ["Session options", "/authentication/configuration/session-options"],
       ["Email & SMS options", "/authentication/configuration/email-options"],
       ["Allowlist / Blocklist", "/authentication/configuration/allowlist"],
-      "# Prebuilt Components",
-      ["Overview", "/authentication/components/overview"],
-      ["<SignUp/>", "/authentication/components/sign-up"],
-      ["<SignIn/>", "/authentication/components/sign-in"],
       "# Social Connections",
       ["Overview", "/authentication/social-connections/overview"],
       [
@@ -100,9 +96,6 @@
       ["Overview", "/users/overview"],
       ["Metadata", "/users/metadata"],
       ["Deleting users", "/users/deleting-users"],
-      "# Prebuilt Components",
-      ["<UserButton />", "/users/user-button"],
-      ["<UserProfile />", "/users/user-profile"],
       "# Guides",
       ["Sync data to your backend", "/users/sync-data"],
       ["Web3 authentication", "/users/web3-wallets"]
@@ -112,10 +105,6 @@
     { "title": "Organizations", "icon": "user-group", "root": "organizations" },
     [
       ["Overview", "/organizations/overview"],
-      "# Components",
-      ["<CreateOrganization/>", "/organizations/create-component"],
-      ["<OrganizationProfile/>", "/organizations/profile-component"],
-      ["<OrganizationSwitcher/>", "/organizations/switcher-component"],
 
       "# Building custom flows",
       ["Using metadata", "/organizations/metadata"],
@@ -537,10 +526,12 @@
       [
         { "title": "Types" },
         [
-          ["Public User Data", "/references/javascript/types/public-user-data"],
-          ["Redirect Options", "/references/javascript/types/redirect-options"],
-          ["Magic Link Error", "/references/javascript/types/magic-link-error"],
-          ["Deleted Object", "/references/javascript/types/deleted-object"]
+          ["PublicUserData", "/references/javascript/types/public-user-data"],
+          ["RedirectOptions", "/references/javascript/types/redirect-options"],
+          ["MagicLinkError", "/references/javascript/types/magic-link-error"],
+          ["DeletedObject", "/references/javascript/types/deleted-object"],
+          ["OAuthProvider", "/references/javascript/types/oauth-provider"],
+          ["OAuthStrategy", "/references/javascript/types/oauth-strategy"]
         ]
       ]
     ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -51,6 +51,9 @@
       ["Session options", "/authentication/configuration/session-options"],
       ["Email & SMS options", "/authentication/configuration/email-options"],
       ["Allowlist / Blocklist", "/authentication/configuration/allowlist"],
+      "# Prebuilt Components",
+      ["<SignUp/>", "/components/authentication/sign-up"],
+      ["<SignIn/>", "/components/authentication/sign-in"],
       "# Social Connections",
       ["Overview", "/authentication/social-connections/overview"],
       [
@@ -96,6 +99,9 @@
       ["Overview", "/users/overview"],
       ["Metadata", "/users/metadata"],
       ["Deleting users", "/users/deleting-users"],
+      "# Prebuilt Components",
+      ["<UserButton />", "/components/user/user-button"],
+      ["<UserProfile />", "/components/user/user-profile"],
       "# Guides",
       ["Sync data to your backend", "/users/sync-data"],
       ["Web3 authentication", "/users/web3-wallets"]
@@ -105,7 +111,10 @@
     { "title": "Organizations", "icon": "user-group", "root": "organizations" },
     [
       ["Overview", "/organizations/overview"],
-
+      "# Prebuilt Components",
+      ["<CreateOrganization/>", "/components/organization/create-organization"],
+      ["<OrganizationProfile/>", "/components/organization/organization-profile"],
+      ["<OrganizationSwitcher/>", "/components/organization/organization-switcher"],
       "# Building custom flows",
       ["Using metadata", "/organizations/metadata"],
       ["Creating orgs", "/organizations/creating-organizations"],

--- a/docs/organizations/create-component.mdx
+++ b/docs/organizations/create-component.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/component-reference/createorganization
----
-
-# This is a stub

--- a/docs/organizations/overview.mdx
+++ b/docs/organizations/overview.mdx
@@ -1,5 +1,39 @@
 ---
-sanity_slug: /docs/organizations/overview
+title: Organizations
+description: Learn about how to create and manage Clerk Organizations and their members.
 ---
 
-# This is a stub
+# Organizations
+
+Organizations are shared accounts, useful for project and team leaders. Organization members can usually collaborate across shared resources. Each member of an organization needs to have a user account in your application. 
+
+All organization members have access to *most* of the organization resources, but depending on their [role](#roles), some members can take advantage of administrative features.
+
+Clerk provides [prebuilt components](/docs/components/overview), [React hooks](/docs/references/react/use-organization), and [APIs](/docs/references/javascript/organization/organization) to help you integrate organizations into your application.
+
+<Callout type="info">
+  To explore Clerk's Organizations, check out this demo repo:
+  https://github.com/clerkinc/organizations-demo
+</Callout>
+
+## Roles 
+
+You can establish differentiation among member permissions through organization member roles. Roles determine a user's level of access to the organization. There are currently two roles: administrators and members.
+
+- `admin` - Offers full access to organization resources. Members with the admin role have administrator privileges and can fully manage organizations and organization memberships.
+- `basic_member` - The standard role for a user that is part of the organization. Access to organization resources is limited. Basic members cannot manage organizations and organization memberships, but can view information about the organization and other members in it.
+
+## Available actions
+
+You can use Clerk's organizations feature to provide team grouping and sharing functionality for users of your applications.
+
+Your users can [create organizations](/docs/organizations/creating-organizations). Organization owners effectively get the `admin` role.
+
+All members of an organization, regardless of their role, can view information about other members in the same organization.
+
+Administrators can [invite other users to join the organization](/docs/organizations/inviting-users). An invitation email is sent out, and organization invitations support adding existing users of your application, or new ones. New users can register once they accept the invitation.
+
+Administrators can [manage roles](/docs/organizations/managing-roles), such as revoking an invitation for a user that hasn't joined yet or removing a user who is already a member from the organization. When removing organization members or updating their role, there needs to be at least one administrator for the organization at all times.
+
+Administrators can also update an organization, such as changing the organization name.
+

--- a/docs/organizations/profile-component.mdx
+++ b/docs/organizations/profile-component.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/component-reference/organizationprofile
----
-
-# This is a stub

--- a/docs/organizations/switcher-component.mdx
+++ b/docs/organizations/switcher-component.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/component-reference/organizationswitcher
----
-
-# This is a stub

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -180,7 +180,7 @@ These values control the behavior of the components when you sign in or sign up 
 
 ### Embed the `<UserButton />`
 
-The [`<UserButton />`](/docs/users/user-button) allows users to manage their account information and log out, thus allowing you to complete a full authentication circle.
+The [`<UserButton />`](/docs/components/user/user-button) allows users to manage their account information and log out, thus allowing you to complete a full authentication circle.
 
 You can add it anywhere you want, but next to the logo in your main application page is a good start.
 

--- a/docs/references/javascript/sign-in/authenticate-with.mdx
+++ b/docs/references/javascript/sign-in/authenticate-with.mdx
@@ -25,7 +25,7 @@ Signs in users via OAuth. This is commonly known as Single Sign On (SSO), where 
   rows={[{cells: [
         <code>strategy</code>,
         <code>string</code>,
-        <>The OAuth provider that will be used for signing in. Must be one of the supported <a href="#o-auth-strategy"><code>OAuthStrategy</code></a>.</>
+        <>The OAuth provider that will be used for signing in. Must be one of the supported <a href="/docs/references/javascript/types/oauth-strategy"><code>OAuthStrategy</code></a>.</>
     ]}, {cells: [
         <code>redirectUrl</code>,
         <code>string</code>,
@@ -111,91 +111,4 @@ Starts a sign in flow that authenticates the user against their public wallet ad
         <>The <a href="https://en.wikipedia.org/wiki/Cryptographic_nonce">crypographic nonce</a> used in the sign-in.</>
         ]}
     ]}
-/>
-
-## Types
-
-### `OAuthStrategy`
-
-```typescript
-type OAuthStrategy = |
-"oauth_facebook"|
-"oauth_github"|
-"oauth_google"|
-"oauth_hubspot"|
-"oauth_tiktok"|
-"oauth_gitlab"|
-"oauth_discord"|
-"oauth_twitter"|
-"oauth_twitch"|
-"oauth_linkedin"|
-"oauth_dropbox"|
-"oauth_bitbucket"|
-"oauth_microsoft"|
-"oauth_notion";
-```
-
-The OAuth provider that will be used for signing in. Must be one of the supported OAuthStrategy.
-
-<Tables
-  headings={['Name', 'Type', 'Description']}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[{cells: [
-        <code>oauth_facebook</code>,
-        <code>string</code>,
-        <>Specify Facebook as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_github</code>,
-        <code>string</code>,
-        <>Specify Github as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_google</code>,
-        <code>string</code>,
-        <>Specify Google as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_hubspot</code>,
-        <code>string</code>,
-        <>Specify HubSpot as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_tiktok</code>,
-        <code>string</code>,
-        <>Specify TikTok as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_gitlab</code>,
-        <code>string</code>,
-        <>Specify GitLab as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_discord</code>,
-        <code>string</code>,
-        <>Specify Discord as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_twitter</code>,
-        <code>string</code>,
-        <>Specify Twitter as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_twitch</code>,
-        <code>string</code>,
-        <>Specify Twitch as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_linkedin</code>,
-        <code>string</code>,
-        <>Specify LinkedIn as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_dropbox</code>,
-        <code>string</code>,
-        <>Specify Dropbox as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_bitbucket</code>,
-        <code>string</code>,
-        <>Specify Bitbucket as the verification OAuth provider.</>
-    ]}, {cells: [
-        <code>oauth_microsoft</code>,
-        <code>string</code>,
-        <>Specify Microsoft as the verification OAuth provider.</>
-    ]},
-    {cells: [
-        <code>oauth_notion</code>,
-        <code>string</code>,
-        <>Specify Notion as the verification OAuth provider.</>
-    ]}]}
 />

--- a/docs/references/javascript/sign-up/sign-up.mdx
+++ b/docs/references/javascript/sign-up/sign-up.mdx
@@ -85,7 +85,7 @@ The `create` method will return a promise of the new SignUp object. This sign up
 {cells: [<code>strategy</code>, <code>{"OAuthStrategy \| SamlStrategy \| TicketStrategy"}</code>, <>The strategy to use for the sign-up flow.</>]},
 {cells: [<code>redirectUrl</code>, <code>string</code>, <>The redirect URL after the sign-up flow has completed.</>]},
 {cells: [<code>actionCompleteRedirectUrl</code>, <code>string</code>, <>The redirect URL after the action has completed for OAuth and SAML sign-up strategies</>]},
-{cells: [<code>transfer</code>, <code>boolean</code>, <>Transfer the user to a dedicated sign up for an oauth flow.</>]},
+{cells: [<code>transfer</code>, <code>boolean</code>, <>Transfer the user to a dedicated sign up for an OAuth flow.</>]},
 {cells: [<code>ticket</code>, <code>string</code>, <>If the strategy is ticket you need to provide the ticket or token generated from the Backend API.</>]},
   ]}
 />

--- a/docs/references/javascript/types/deleted-object.mdx
+++ b/docs/references/javascript/types/deleted-object.mdx
@@ -3,10 +3,6 @@ title: DeletedObject
 description: The DeletectObject class represents an item that has been deleted from the database.
 ---
 
-import { Tables } from "@/components/Table";
-import { Images } from "@/components/Images";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `DeletedObject`
 
 The `DeletedObject` class represents an item that has been deleted from the database.

--- a/docs/references/javascript/types/oauth-provider.mdx
+++ b/docs/references/javascript/types/oauth-provider.mdx
@@ -1,0 +1,59 @@
+---
+title: OAuthProvider
+description: Options for OAuth providers.
+---
+
+# `OAuthProvider`
+
+```ts
+type FacebookOauthProvider = 'facebook';
+type GoogleOauthProvider = 'google';
+type HubspotOauthProvider = 'hubspot';
+type GithubOauthProvider = 'github';
+type TiktokOauthProvider = 'tiktok';
+type GitlabOauthProvider = 'gitlab';
+type DiscordOauthProvider = 'discord';
+type TwitterOauthProvider = 'twitter';
+type TwitchOauthProvider = 'twitch';
+type LinkedinOauthProvider = 'linkedin';
+type DropboxOauthProvider = 'dropbox';
+type AtlassianOauthProvider = 'atlassian';
+type BitbucketOauthProvider = 'bitbucket';
+type MicrosoftOauthProvider = 'microsoft';
+type NotionOauthProvider = 'notion';
+type AppleOauthProvider = 'apple';
+type LineOauthProvider = 'line';
+type InstagramOauthProvider = 'instagram';
+type CoinbaseOauthProvider = 'coinbase';
+type SpotifyOauthProvider = 'spotify';
+type XeroOauthProvider = 'xero';
+type BoxOauthProvider = 'box';
+type SlackOauthProvider = 'slack';
+type LinearOauthProvider = 'linear';
+
+type OAuthProvider =
+  | FacebookOauthProvider
+  | GoogleOauthProvider
+  | HubspotOauthProvider
+  | GithubOauthProvider
+  | TiktokOauthProvider
+  | GitlabOauthProvider
+  | DiscordOauthProvider
+  | TwitterOauthProvider
+  | TwitchOauthProvider
+  | LinkedinOauthProvider
+  | DropboxOauthProvider
+  | AtlassianOauthProvider
+  | BitbucketOauthProvider
+  | MicrosoftOauthProvider
+  | NotionOauthProvider
+  | AppleOauthProvider
+  | LineOauthProvider
+  | InstagramOauthProvider
+  | CoinbaseOauthProvider
+  | SpotifyOauthProvider
+  | XeroOauthProvider
+  | BoxOauthProvider
+  | SlackOauthProvider
+  | LinearOauthProvider;
+```

--- a/docs/references/javascript/types/oauth-strategy.mdx
+++ b/docs/references/javascript/types/oauth-strategy.mdx
@@ -1,0 +1,87 @@
+---
+title: OAuthStrategy
+description: Options for OAuth strategies.
+---
+
+# `OAuthStrategy`
+
+```typescript
+type OAuthStrategy = |
+"oauth_facebook"|
+"oauth_github"|
+"oauth_google"|
+"oauth_hubspot"|
+"oauth_tiktok"|
+"oauth_gitlab"|
+"oauth_discord"|
+"oauth_twitter"|
+"oauth_twitch"|
+"oauth_linkedin"|
+"oauth_dropbox"|
+"oauth_bitbucket"|
+"oauth_microsoft"|
+"oauth_notion";
+```
+
+<Tables
+  headings={['Name', 'Type', 'Description']}
+  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
+  rows={[{cells: [
+        <code>oauth_facebook</code>,
+        <code>string</code>,
+        <>Specify Facebook as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_github</code>,
+        <code>string</code>,
+        <>Specify Github as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_google</code>,
+        <code>string</code>,
+        <>Specify Google as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_hubspot</code>,
+        <code>string</code>,
+        <>Specify HubSpot as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_tiktok</code>,
+        <code>string</code>,
+        <>Specify TikTok as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_gitlab</code>,
+        <code>string</code>,
+        <>Specify GitLab as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_discord</code>,
+        <code>string</code>,
+        <>Specify Discord as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_twitter</code>,
+        <code>string</code>,
+        <>Specify Twitter as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_twitch</code>,
+        <code>string</code>,
+        <>Specify Twitch as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_linkedin</code>,
+        <code>string</code>,
+        <>Specify LinkedIn as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_dropbox</code>,
+        <code>string</code>,
+        <>Specify Dropbox as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_bitbucket</code>,
+        <code>string</code>,
+        <>Specify Bitbucket as the verification OAuth provider.</>
+    ]}, {cells: [
+        <code>oauth_microsoft</code>,
+        <code>string</code>,
+        <>Specify Microsoft as the verification OAuth provider.</>
+    ]},
+    {cells: [
+        <code>oauth_notion</code>,
+        <code>string</code>,
+        <>Specify Notion as the verification OAuth provider.</>
+    ]}]}
+/>

--- a/docs/references/javascript/types/public-user-data.mdx
+++ b/docs/references/javascript/types/public-user-data.mdx
@@ -3,10 +3,6 @@ title: PublicUserData
 description: Information about that user that's publicly available.
 ---
 
-import { Tables } from "@/components/Table";
-import { Images } from "@/components/Images";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `PublicUserData`
 
 Information about the user that's publicly available.

--- a/docs/references/javascript/types/redirect-options.mdx
+++ b/docs/references/javascript/types/redirect-options.mdx
@@ -3,10 +3,6 @@ title: RedirectOptions
 description: An interface that provides options for a range of redirect methods.
 ---
 
-import { Tables } from "@/components/Table";
-import { Images } from "@/components/Images";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `RedirectOptions`
 
 An interface that provides options for a range of redirect methods.

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -3,62 +3,55 @@ title: User
 description: The User object holds all the information for a user of your application and provides a set of methods to manage their account. Users have a unique authentication identifier which might be their email address, phone number or a username.
 ---
 
-import { Tables } from "@/components/Table";
-import { Images } from "@/components/Images";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `User`
 
-The `User` object holds all the information for a user of your application and provides a set of methods to manage their account. Users have a unique authentication identifier which might be their email address, phone number or a username.
+The `User` object holds all of the information for a single user of your application and provides a set of methods to manage their account. Each user has a unique authentication identifier which might be their email address, phone number, or a username.
 
-Users can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. Same thing with phone numbers; they can have more than one, but only one will be their primary. At the same time, they can also have one more more external accounts by connecting to OAuth providers such as Google, Apple, Facebook & many more.
+A user can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
 
-Finally, `User` objects hold profile data like their name, a profile image and a set of metadata that can be used internally to store arbitrary information. The metadata are split into public and private. Both types are set from the [Backend API](https://clerk.dev/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) and [Backend API](https://clerk.dev/docs/reference/backend-api).
+Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) as well.
 
 The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to help retrieve and update user information and authentication status.
 
 ## Attributes
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-    {cells: [<code>id</code>,  <code>string</code>,  <>A unique identifier for the user.</>]},
-{cells: [<code>firstName</code>,  <code>string | null</code>,  <>The user's first name.</>]},
-{cells: [<code>lastName</code>,  <code>string</code>,  <>The user's last name.</>]},
-{cells: [<code>fullName</code>,  <code>string | null</code>,  <>The user's full name.</>]},
-{cells: [<code>username</code>,  <code>string | null</code>,  <>The user's username.</>]},
-{cells: [<code>imageUrl</code>,  <code>string</code>,  <>Holds the users profile image or avatar.</>]},
-{cells: [<code>profileImageUrl</code>,  <code>string | null</code>,  <>The URL for the user's profile image. (deprecated in favor of image_url)</>]},
-{cells: [<code>primaryEmailAddress</code>,  <code><a href="/docs/references/javascript/email-address/email-address">EmailAddress</a> | null</code>,  <>Information about the user's primary email address.</>]},
-{cells: [<code>primaryEmailAddressId</code>,  <code>string | null</code>,  <>The unique identifier for the <a href="/docs/references/javascript/email-address/email-address">EmailAddress</a> that the user has set as primary.</>]},
-{cells: [<code>emailAddresses</code>,  <code><a href="/docs/references/javascript/email-address/email-address">EmailAddress</a>[]</code>,  <>Any array of all the <a href="/docs/references/javascript/email-address/email-address">EmailAddress</a> objects associated with the user. Includes the primary.</>]},
-{cells: [<code>hasVerifiedEmailAddress</code>,  <code>boolean</code>,  <>A getter boolean to check if the user has verified an email address.</>]},
-{cells: [<code>primaryPhoneNumber</code>,  <code><a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber</a>[] | null</code>,  <>Information about the user's primary phone number.</>]},
-{cells: [<code>primaryPhoneNumberId</code>,  <code>string | null</code>,  <>The unique identifier for the <a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber</a> that the user has set as primary.</>]},
-{cells: [<code>phoneNumbers</code>,  <code><a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber</a>[]</code>,  <>Any array of all the <a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber</a> objects associated with the user. Includes the primary.</>]},
-{cells: [<code>hasVerifiedPhoneNumber</code>,  <code>boolean</code>,  <>A getter boolean to check if the user has verified a phone number.</>]},
-{cells: [<code>primaryWeb3WalletId</code>,  <code>string | null</code>,  <>The unique identifier for the <a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a> that the user signed up with.</>]},
-{cells: [<code>primaryWeb3Wallet</code>,  <code><a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a></code>,  <>The <a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a> that the user signed up with.</>]},
-{cells: [<code>web3Wallets</code>,  <code><a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a>[]</code>,  <>Any array of all the <a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a> objects associated with the user. Includes the primary.</>]},
-{cells: [<code>externalAccounts</code>,  <code><a href="/docs/references/javascript/external-account">ExternalAccount</a>[]</code>,  <>An array of all the <a href="/docs/references/javascript/external-account">ExternalAccount</a> objects associated with the user via OAuth.  <strong>Note</strong>: This includes both verified &amp; unverified external accounts.</>]},
-{cells: [<code>verifiedExternalAccounts</code>,  <code><a href="/docs/references/javascript/external-account">ExternalAccount</a>[]</code>,  <>A getter for the user's list of verified external accounts.</>]},
-{cells: [<code>unverifiedExternalAccounts</code>,  <code><a href="/docs/references/javascript/external-account">ExternalAccount</a>[]</code>,  <>A getter for the user's list of unverified external accounts.</>]},
-{cells: [<code>samlAccounts</code>,  <code>SamlAccount[]</code>,  <>An <strong>experimental</strong> list of saml accounts associated with the user.</>]},
-{cells: [<code>organizationMemberships</code>,  <code><a href="/docs/references/javascript/organization-membership">OrganizationMembership</a></code>,  <>A list of <code><a href="/docs/references/javascript/organization-membership">OrganizationMembership</a></code>s representing the list of organizations the user is member with.</>]},
-{cells: [<code>passwordEnabled</code>,  <code>boolean</code>,  <>A boolean indicating whether the user has a password on their account.</>]},
-{cells: [<code>totpEnabled</code>,  <code>boolean</code>,  <>Whether the user has enabled TOTP by generating a TOTP secret and verifying it via an authenticator ap</>]},
-{cells: [<code>twoFactorEnabled</code>,  <code>boolean</code>,  <>Whether the user has enabled two-factor authentication.</>]},
-{cells: [<code>backupCodeEnabled</code>,  <code>boolean</code>,  <>Whether the user has enabled Backup codes.</>]},
-{cells: [<code>createOrganizationEnabled</code>,  <code>boolean</code>,  <>Whether the organization creation is enabled for the user or not.</>]},
-{cells: [<code>deleteSelfEnabled</code>,  <code>boolean</code>,  <>Whether the user is able to delete their own account or not.</>]},
-{cells: [<code>publicMetadata</code>,  <code>{"{[string]: any} | null"}</code>,  <>Metadata that can be read from the <a href="https://reference.clerk.dev/reference/frontend-api-reference">Frontend API</a> and <a href="https://clerk.dev/docs/reference/backend-api">Backend API</a> and can be set only from the Backend API .</>]},
-{cells: [<code>unsafeMetadata</code>,  <code>{"{[string]: any} | null"}</code>,  <>Metadata that can be read and set from the frontend. One common use case for this attribute is to use it to implement custom fields that will be attached to the <code>User</code> object. Please note that there is also an <code>unsafeMetadata</code> attribute in the SignUp object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete.</>]},
-{cells: [<code>lastSignInAt</code>,  <code>Date</code>,  <>Date when the user last signed in. May be empty if the user has never signed in.</>]},
-{cells: [<code>createdAt</code>,  <code>Date</code>,  <>Date when the user was first created.</>]},
-{cells: [<code>updatedAt</code>,  <code>Date</code>,  <>Date of the last time the user was updated.</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | A unique identifier for the user. |
+| `firstName` | `string \| null` | The user's first name. |
+| `lastName` | `string \| null` | The user's last name. |
+| `fullName` | `string \| null` | The user's full name. |
+| `username` | `string \| null` | The user's username. |
+| `imageUrl` | `string` | Holds the users profile image or avatar. |
+| `profileImageUrl` | `string \| null` | The URL for the user's profile image.<br />**This property is deprecated** in favor of `image_url` |
+| `primaryEmailAddress` | [`EmailAddress`](/docs/references/javascript/email-address/email-address) \| `null` | Information about the user's primary email address. |
+| `primaryEmailAddressId` | `string \| null` | The unique identifier for the `EmailAddress` that the user has set as primary. |
+| `emailAddresses` | <code><a href="/docs/references/javascript/email-address/email-address">EmailAddress[]</a></code> | An array of all the `EmailAddress` objects associated with the user. Includes the primary. |
+| `hasVerifiedEmailAddress` | `boolean` | A getter boolean to check if the user has verified an email address. |
+| `primaryPhoneNumber` | [`PhoneNumber`](/docs/references/javascript/phone-number/phone-number) \| `null` | Information about the user's primary phone number. |
+| `primaryPhoneNumberId` | `string \| null` | The unique identifier for the `PhoneNumber` that the user has set as primary. |
+| `phoneNumbers` | <code><a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber[]</a></code> | An array of all the `PhoneNumber` objects associated with the user. Includes the primary. |
+| `hasVerifiedPhoneNumber` | `boolean` | A getter boolean to check if the user has verified a phone number. |
+| `primaryWeb3WalletId` | `string \| null` | The unique identifier for the [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) that the user signed up with. |
+| `primaryWeb3Wallet` | [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) \| `null` | The `Web3Wallet` that the user signed up with. |
+| `web3Wallets` | <code><a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet[]</a></code> | An array of all the `Web3Wallet` objects associated with the user. Includes the primary. |
+| `externalAccounts` | <code><a href="/docs/references/javascript/external-account">ExternalAccount[]</a></code> | An array of all the `ExternalAccount` objects associated with the user via OAuth.<br />**Note**: This includes both verified & unverified external accounts. |
+| `verifiedExternalAccounts` | <code><a href="/docs/references/javascript/external-account">ExternalAccount[]</a></code> | A getter for the user's list of verified external accounts. |
+| `unverifiedExternalAccounts` | <code><a href="/docs/references/javascript/external-account">ExternalAccount[]</a></code> | A getter for the user's list of unverified external accounts. |
+| `samlAccounts` | `SamlAccount[]` | An **experimental** list of saml accounts associated with the user. |
+| `organizationMemberships` | <code><a href="/docs/references/javascript/organization-membership">OrganizationMembership[]</a></code> | A list of `OrganizationMembership`s representing the list of organizations the user is member with. |
+| `passwordEnabled` | `boolean` | A boolean indicating whether the user has a password on their account. |
+| `totpEnabled` | `boolean` | A boolean indicating whether the user has enabled TOTP by generating a TOTP secret and verifying it via an authenticator ap |
+| `twoFactorEnabled` | `boolean` | A boolean indicating whether the user has enabled two-factor authentication. |
+| `backupCodeEnabled` | `boolean` | A boolean indicating whether the user has enabled Backup codes. |
+| `createOrganizationEnabled` | `boolean` | A boolean indicating whether the organization creation is enabled for the user or not. |
+| `deleteSelfEnabled` | `boolean` | A boolean indicating whether the user is able to delete their own account or not. |
+| `publicMetadata` | `{[string]: any} \| null` | Metadata that can be read from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) and [Backend API](https://clerk.dev/docs/reference/backend-api) and can be set only from the Backend API . |
+| `privateMetadata` | `{[string]: any} \| null` | Metadata that can be read and set only from the [Backend API](https://clerk.dev/docs/reference/backend-api). |
+| `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference). One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
+| `lastSignInAt` | `Date` | Date when the user last signed in. May be empty if the user has never signed in. |
+| `createdAt` | `Date` | Date when the user was first created. |
+| `updatedAt` | `Date` | Date of the last time the user was updated. |
 
 ## Methods
 
@@ -73,25 +66,16 @@ Updates the user's attributes. Use this method to save information you collected
 #### `UpdateUserParams`
 
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>username</code>, <code>string</code>, <>The user's username.</>]},
-{cells: [<code>password</code>, <code>string</code>, <>
-The user's password.
-<br/>
-<br/>
-<strong>This property is deprecated.</strong> This will be removed in the next major version. Please use <a href="/docs/references/javascript/user/password-management#updatepassword"><code>updatePassword(params)</code></a> instead
-</>]},
-{cells: [<code>firstName</code>, <code>string</code>, <>The user's first name.</>]},
-{cells: [<code>lastName</code>, <code>string</code>, <>The user's last name.</>]},
-{cells: [<code>primaryEmailAddressId</code>, <code>string</code>, <>The unique identifier for the <a href="/docs/references/javascript/email-address/email-address">EmailAddress</a> that the user has set as primary.</>]},
-{cells: [<code>primaryPhoneNumberId</code>,  <code>string | null</code>,  <>The unique identifier for the <a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber</a> that the user has set as primary.</>]},
-{cells: [<code>primaryWeb3WalletId</code>,  <code>string | null</code>,  <>The unique identifier for the <a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a> that the user signed up with.</>]},
-{cells: [<code>unsafeMetadata</code>,  <code>{"{[string]: any} | null"}</code>,  <>Metadata that can be read and set from the frontend. One common use case for this attribute is to use it to implement custom fields that will be attached to the <code>User</code> object. Please note that there is also an <code>unsafeMetadata</code> attribute in the SignUp object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete.</>]},
-  ]}
-  />
+| Name | Type | Description |
+| --- | --- | --- |
+| `username` | `string` | The user's username. |
+| `password` | `string` | The user's password.<br />**This property is deprecated.** This will be removed in the next major version. Please use [`updatePassword(params)`](/docs/references/javascript/user/password-management#updatepassword) instead. |
+| `firstName` | `string` | The user's first name. |
+| `lastName` | `string` | The user's last name. |
+| `primaryEmailAddressId` | `string` | The unique identifier for the [`EmailAddress`](/docs/references/javascript/email-address/email-address) that the user has set as primary. |
+| `primaryPhoneNumberId` | `string` | The unique identifier for the [`PhoneNumber`](/docs/references/javascript/phone-number/phone-number) that the user has set as primary. |
+| `primaryWeb3WalletId` | `string` | The unique identifier for the [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) that the user signed up with. |
+| `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference). One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
 
 ### `delete()`
 
@@ -111,16 +95,11 @@ Add the user's profile image or replace it if one already exists. This method wi
 
 #### `SetProfileImageParams`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>file</code>, <code>Blob | File | string | null</code>, <>The file to set as the user's profile image.</>]}
- ]}
-  />
+| Name | Type | Description |
+| --- | --- | --- |
+| `file` | `Blob \| File \| string \| null` | The file to set as the user's profile image. |
 
 #### Returns
-
 
 <Tables
   headings={["Type", "Description"]}
@@ -133,15 +112,11 @@ Add the user's profile image or replace it if one already exists. This method wi
 
 ##### `ImageResource`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>id</code>, <code>string | undefined | null</code>, <>The unique identifier of the image.</>]},
-{cells: [<code>name</code>, <code>string | null</code>, <>The name of the image.</>]},
-{cells: [<code>publicUrl</code>, <code>string | null</code>, <>The publically accessible url for the image.</>]}
- ]}
-  />
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | The unique identifier of the image. |
+| `name` | `string \| null` | The name of the image. |
+| `publicUrl` | `string \| null` | The publically accessible url for the image. |
 
 
 ### `getSessions()`
@@ -174,16 +149,9 @@ A check whether or not the given resource is the primary identifier for the user
 
 #### Params
 
-
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>ident</code>, <code>
-<a href="/docs/references/javascript/email-address/email-address">EmailAddress</a> | <a href="/docs/references/javascript/phone-number/phone-number">PhoneNumber</a> | <a href="/docs/references/javascript/web3-wallet/web3-wallet">Web3Wallet</a>
-</code>, <>The resource checked against the user to see if it is the primary identifier.</>]},
- ]}
-  />
+| Name | Type | Description |
+| --- | --- | --- |
+| `ident` | [`EmailAddress`](/docs/references/javascript/email-address/email-address) \| [`PhoneNumber`](/docs/references/javascript/phone-number/phone-number) \| [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) | The resource checked against the user to see if it is the primary identifier. |
 
 ## Additional methods
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -9,7 +9,7 @@ The `User` object holds all of the information for a single user of your applica
 
 A user can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
 
-Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) as well.
+Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can also be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference).
 
 The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to help retrieve and update user information and authentication status.
 

--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -1,5 +1,21 @@
 ---
-sanity_slug: /docs/users/overview
+title: Users
+description: Learn how to manage your users in your Clerk application.
 ---
 
-# This is a stub
+# Users
+
+Clerk provides the prebuilt components [`<UserButton />`](/docs/components/user/user-button) and [`<UserProfile />`](/docs/components/user/user-profile) in order to help your users manage their profile data. However, if you would like to manage user authentication and profile data yourself, or if you would like to build your own profile management flow, Clerk provides a set of APIs to help you do that.
+
+## `User` object
+
+The `User` object holds all of the information for a single user of your application and provides a set of methods to manage their account. Each user has a unique authentication identifier which might be their email address, phone number, or a username.
+
+A user can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
+
+Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) as well.
+
+For more information on the `User` object, such as helper methods for retrieving and updating user information and authentication status, checkout the [ClerkJS SDK documentation](/docs/references/javascript/user/user).
+
+If you are using React, the [React SDK](/docs/references/react/use-user) provides some hooks to help manage user authentication and profile data.
+

--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -17,5 +17,5 @@ Finally, a `User` object holds profile data like the user's name, profile pictur
 
 For more information on the `User` object, such as helper methods for retrieving and updating user information and authentication status, checkout the [ClerkJS SDK documentation](/docs/references/javascript/user/user).
 
-If you are using React, the [React SDK](/docs/references/react/use-user) provides some hooks to help manage user authentication and profile data.
+If you are using React, the [React SDK](/docs/references/react/use-user) provides hooks to help manage user authentication and profile data.
 

--- a/docs/users/user-button.mdx
+++ b/docs/users/user-button.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/users/user-button
----
-
-# This is a stub

--- a/docs/users/user-profile.mdx
+++ b/docs/users/user-profile.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/users/user-profile
----
-
-# This is a stub


### PR DESCRIPTION
/components houses information on Clerk's prebuilt components

However, we also had /authentication/components/overview which housed redundant information on the prebuilt components. We also had [/organizations](/docs/organizations/create-component) which housed redundant information under a section titled "Components" and [/users](/docs/users/user-button) housed redundant information under a section titled "Prebuilt components".

This PR

- deletes these redundant pages, and instead, references to our /components documentation in the respective Overview pages. For example, /organizations no longer has a "Components" section with the `<UserButton />` and `<UserProfile />` pages. These pages already exist under /components/organization/* . Instead, /organizations/overview references these components and links out to their respective pages.
- migrates /users/overview and /organizations/overview from sanity to mdx, and also updates the content of these pages
- updates broken links found with our linter
- abstracts out types to be housed in dedicated pages under our /javascript/types/* path
- removes unnecessary imports (tech debt)

Both the /users and /organizations sections need a lot of work. But I think is a step in the right direction.
