### PR TITLE
update image extension; fix grammar on heading

### DIFF
--- a/docs/authentication/configuration/sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-in-options.mdx
@@ -106,14 +106,14 @@ src="/docs/images/authentication/email-address-verification-methods.jpg"
 alt="The 'Email address' configuration settings with all options toggled on, and with a red outline around the 'Verification Methods' section."
 />
 
-### Allow users to sign in passwordlessly
+### Allow passwordless sign-in
 
 In the **Authentication factors** section under [Email, Phone, Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username), toggle on **Email verification link** and **Email verification code**. This will allow users to sign in with either a link or a code sent to their email.
 
 <Images 
 width={3024}
 height={1652}
-src="/docs/images/authentication/email-address-verification.png"
+src="/docs/images/authentication/email-address-verification.jpg"
 alt="The 'Authentication factors' section under 'Email, Phone, Username' tab with a red arrow pointing to the 'Email verification link' toggle and 'Email verification code, both toggled on. There is also a red arrow pointing to the 'Apply changes' button."
 />
 


### PR DESCRIPTION
This PR

- fixes an incorrect image extension (the image was optimized using squoosh which changed the extension from png to jpg)
- fixes the grammar on the heading "Allow users to sign in passwordlessly"