### PR TITLE
fix: Brand names casing

### DIFF
--- a/docs/integrations/webhooks.mdx
+++ b/docs/integrations/webhooks.mdx
@@ -98,7 +98,7 @@ Below is an example of a webhook payload for a `user.created` event:
 }
 ```
 
-## Typescript Support
+## TypeScript Support
 
 Clerk provides the types as part of our SDK offering. Below is an example of type usage in a webhook handler:
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -73,7 +73,7 @@
           ["Coinbase", "/authentication/social-connections/coinbase"],
           ["Discord", "/authentication/social-connections/discord"],
           ["Dropbox", "/authentication/social-connections/dropbox"],
-          ["Github", "/authentication/social-connections/github"],
+          ["GitHub", "/authentication/social-connections/github"],
           ["GitLab", "/authentication/social-connections/gitlab"],
           ["HubSpot", "/authentication/social-connections/hubspot"],
           ["Line", "/authentication/social-connections/line"],
@@ -397,7 +397,7 @@
   ],
   [
     {
-      "title": "Javascript",
+      "title": "JavaScript",
       "icon": "javascript",
       "root": "references/javascript"
     },

--- a/docs/references/javascript/types/oauth-strategy.mdx
+++ b/docs/references/javascript/types/oauth-strategy.mdx
@@ -33,7 +33,7 @@ type OAuthStrategy = |
     ]}, {cells: [
         <code>oauth_github</code>,
         <code>string</code>,
-        <>Specify Github as the verification OAuth provider.</>
+        <>Specify GitHub as the verification OAuth provider.</>
     ]}, {cells: [
         <code>oauth_google</code>,
         <code>string</code>,

--- a/docs/security/xss-leak-protection.mdx
+++ b/docs/security/xss-leak-protection.mdx
@@ -16,14 +16,14 @@ Clerk works to minimize the surface area by using HttpOnly cookies for authentic
 ## What is a HttpOnly cookie?
 HttpOnly is a flag on the [Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) header that is issued by a server to set a cookie in the browser.
 
-When this flag is set, the cookie can only be read from a server responding to an HTTP request. It is not accessible through Javascript with the document.cookie property.
+When this flag is set, the cookie can only be read from a server responding to an HTTP request. It is not accessible through JavaScript with the document.cookie property.
 
-Without the flag, a cookie can also be read by Javascript in the browser.
+Without the flag, a cookie can also be read by JavaScript in the browser.
 
 ## How do HttpOnly cookies minimize XSS attacks?
-XSS attacks allow the attacker to run arbitrary Javascript in the browser while users are navigating your application.
+XSS attacks allow the attacker to run arbitrary JavaScript in the browser while users are navigating your application.
 
-If Clerk did not use an HttpOnly cookie, but instead used a storage solution that is accessible through Javascript, it would mean the malicious Javascript could access users' session tokens.
+If Clerk did not use an HttpOnly cookie, but instead used a storage solution that is accessible through JavaScript, it would mean the malicious JavaScript could access users' session tokens.
 
 Unauthorized access to session tokens is especially problematic because the tokens can be used to take actions on behalf of a user, even after a XSS vulnerability has been resolved. As a result, when session tokens leak, it is recommended you invalidate existing tokens and force users to sign in again.
 


### PR DESCRIPTION
Fixed the following names: 
`Javascript` -> `JavaScript`
`Typescript` -> `TypeScript`
`Github` -> `GitHub`