### PR TITLE
Delete 'deleting users' page and reference the backend sdk user operations

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -98,7 +98,6 @@
     [
       ["Overview", "/users/overview"],
       ["Metadata", "/users/metadata"],
-      ["Deleting users", "/users/deleting-users"],
       "# Prebuilt Components",
       ["<UserButton />", "/components/user/user-button"],
       ["<UserProfile />", "/components/user/user-profile"],

--- a/docs/references/backend/user/create-user.mdx
+++ b/docs/references/backend/user/create-user.mdx
@@ -13,13 +13,13 @@ Any email address and phone number created using this method will be automatical
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `externalId?` | `string` | The ID of the user you use in in your external systems. Must be unique across your instance. |
+| `externalId?` | `string` | The ID of the user you use in your external systems. Must be unique across your instance. |
 | `emailAddress[]?` | `string` | Email addresses to add to the user. Must be unique across your instance. The first email address will be set as the users primary email address. |
 | `phoneNumber[]?` | `string` | Phone numbers that will be added to the user. Must be unique across your instance. The first phone number will be set as the users primary phone number. |
 | `username?` | `string` | The username to give to the user. Must be unique across your instance. |
 | `password?` | `string` | The plaintext password to give the user. |
-| `firstName?` | `string` | User's first name. |
-| `lastName?` | `string` | User's last name. |
+| `firstName?` | `string` | The user's first name. |
+| `lastName?` | `string` | The user's last name. |
 | `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that is visible to both your Frontend and Backend APIs. |
 | `privateMetadata?` | `Record<string, unknown>` | Metadata saved on the user that is only visible to your Backend API. |
 | `unsafeMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. **Note:** Since this data can be modified from the frontend, it is not guaranteed to be safe. |

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -1,5 +1,0 @@
----
-sanity_slug: /docs/users/deleting-users
----
-
-# This is a stub

--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -19,3 +19,8 @@ For more information on the `User` object, such as helper methods for retrieving
 
 If you are using React, the [React SDK](/docs/references/react/use-user) provides hooks to help manage user authentication and profile data.
 
+## `User` operations
+
+The [Clerk Backend SDK](https://github.com/clerkinc/javascript/tree/main/packages/backend) exposes Clerk's backend API resources and low-level authentication utilities for JavaScript environments. While the backend SDK is mainly used as a building block for Clerk's higher-level SDKs, it can also be used on its own for advanced flows and custom integrations.
+
+For information about the `User` operations available, such as `getUser()`, `createUser()`, and `deleteUser()`, check out the [Backend SDK references documentation](/docs/references/backend/overview).

--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -23,4 +23,4 @@ If you are using React, the [React SDK](/docs/references/react/use-user) provide
 
 The [Clerk Backend SDK](https://github.com/clerkinc/javascript/tree/main/packages/backend) exposes Clerk's backend API resources and low-level authentication utilities for JavaScript environments. While the backend SDK is mainly used as a building block for Clerk's higher-level SDKs, it can also be used on its own for advanced flows and custom integrations.
 
-For information about the `User` operations available, such as `getUser()`, `createUser()`, and `deleteUser()`, check out the [Backend SDK references documentation](/docs/references/backend/overview).
+For information about the `User` operations available, such as `getUser()`, `createUser()`, and `deleteUser()`, check out the [Backend SDK documentation](/docs/references/backend/overview).


### PR DESCRIPTION
Previously, we had /docs/users/deleting-users

https://github.com/clerkinc/clerk-docs/assets/98043211/f6168fae-33ba-454e-b0b7-f1f56e65e9ed

This information is redundant, and exists at /docs/references/backend/user/delete-user

This PR

- deletes this page
- references the methods available through the backend SDK