### PR TITLE
Migrate 'Deleting users' from Sanity to MDX

### DIFF
--- a/docs/references/backend/user/create-user.mdx
+++ b/docs/references/backend/user/create-user.mdx
@@ -13,13 +13,13 @@ Any email address and phone number created using this method will be automatical
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `externalId?` | `string` | The ID of the user you use in in your external systems. Must be unique across your instance. |
+| `externalId?` | `string` | The ID of the user you use in your external systems. Must be unique across your instance. |
 | `emailAddress[]?` | `string` | Email addresses to add to the user. Must be unique across your instance. The first email address will be set as the users primary email address. |
 | `phoneNumber[]?` | `string` | Phone numbers that will be added to the user. Must be unique across your instance. The first phone number will be set as the users primary phone number. |
 | `username?` | `string` | The username to give to the user. Must be unique across your instance. |
 | `password?` | `string` | The plaintext password to give the user. |
-| `firstName?` | `string` | User's first name. |
-| `lastName?` | `string` | User's last name. |
+| `firstName?` | `string` | The user's first name. |
+| `lastName?` | `string` | The user's last name. |
 | `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that is visible to both your Frontend and Backend APIs. |
 | `privateMetadata?` | `Record<string, unknown>` | Metadata saved on the user that is only visible to your Backend API. |
 | `unsafeMetadata?` | `Record<string, unknown>` | Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. **Note:** Since this data can be modified from the frontend, it is not guaranteed to be safe. |

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -1,5 +1,69 @@
 ---
-sanity_slug: /docs/users/deleting-users
+title: Deleting users
+description: Learn how to delete users from your Clerk backend.
 ---
 
-# This is a stub
+# Deleting users
+
+Clerk currently supports deleting users through our [backend API](https://clerk.com/docs/reference/backend-api/tag/Users#operation/DeleteUser). 
+
+The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a single argument: the user ID of the user you want to delete. It can be accessed from the `users` sub-api of the `clerkClient`. 
+
+<CodeBlockTabs options={["Curl", "App router", "Pages router", "Node"]}>
+```bash copy filename="curl.sh"
+curl -XDELETE -H 'Authorization: CLERK_SECRET_KEY' 'https://api.clerk.com/v1/users/{user_id}'
+```
+
+```ts copy filename="app/route/private.ts"
+import { clerkClient } from "@clerk/nextjs";
+import { NextResponse } from 'next/server';
+
+export async function DELETE() {
+  const userId = await body.json().userId;
+
+  try {
+    await clerkClient.users.deleteUser(userId);
+    return NextResponse.json({ message: 'Success' });
+  }
+  catch (error) {
+    console.log(error);
+    return NextResponse.json({ error: 'Error deleting user' });
+  }
+}
+```
+
+```ts copy filename="pages/api/private.ts"
+import { clerkClient } from "@clerk/nextjs/server";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const userId = req.body.userId;
+
+  try {
+    await clerkClient.users.deleteUser(userId);
+    return res.status(200).json({ message: 'Success' });
+  }
+  catch (error) {
+    console.log(error);
+    return res.status(500).json({ error: 'Error deleting user' });
+  }
+}
+```
+
+```ts copy filename="private.ts"
+import { clerk } from "@clerk/clerk-node-sdk";
+
+app.post('/deleteUser', (req, res) => {
+  const userId = req.body.userId;
+
+  try {
+    await clerkClient.users.deleteUser(userId);
+    return res.status(200).json({ message: 'Success' });
+  }
+  catch (error) {
+    console.log(error);
+    return res.status(500).json({ error: 'Error deleting user' });
+  }
+});
+```
+</CodeBlockTabs>

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -7,7 +7,7 @@ description: Learn how to delete users from your Clerk backend.
 
 Clerk currently supports deleting users through our [backend API](https://clerk.com/docs/reference/backend-api/tag/Users#operation/DeleteUser). 
 
-The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a single argument: the user ID of the user you want to delete. It can be accessed from the `users` sub-api of the `clerkClient`. 
+The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a single argument: the user ID of the user you want to delete. It can be accessed from the `users` sub-api of the `clerkClient` instance.
 
 <CodeBlockTabs options={["Curl", "Next.js App Router", "Next.js Pages Router", "Node"]}>
 ```bash copy filename="curl.sh"

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -14,12 +14,12 @@ The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a s
 curl -XDELETE -H 'Authorization: CLERK_SECRET_KEY' 'https://api.clerk.com/v1/users/{user_id}'
 ```
 
-```ts copy filename="app/route/private.ts"
+```ts copy filename="app/private/route.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextResponse } from 'next/server';
 
-export async function DELETE() {
-  const userId = await body.json().userId;
+export async function DELETE(request: Request) {
+  const { userId } = await request.body.json();
 
   try {
     await clerkClient.users.deleteUser(userId);

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -9,7 +9,7 @@ Clerk currently supports deleting users through our [backend API](https://clerk.
 
 The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a single argument: the user ID of the user you want to delete. It can be accessed from the `users` sub-api of the `clerkClient`. 
 
-<CodeBlockTabs options={["Curl", "App router", "Pages router", "Node"]}>
+<CodeBlockTabs options={["Curl", "Next.js App Router", "Next.js Pages Router", "Node"]}>
 ```bash copy filename="curl.sh"
 curl -XDELETE -H 'Authorization: CLERK_SECRET_KEY' 'https://api.clerk.com/v1/users/{user_id}'
 ```
@@ -57,7 +57,7 @@ app.post('/deleteUser', (req, res) => {
   const userId = req.body.userId;
 
   try {
-    await clerkClient.users.deleteUser(userId);
+    await clerk.users.deleteUser(userId);
     return res.status(200).json({ message: 'Success' });
   }
   catch (error) {

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -118,42 +118,49 @@ clerk.users.updateMetadata("user_xyz", private_metadata: privateMetadata)
 
 You can retrieve the private metadata for a user by using the `getUser` method. This method will return user object which contains the private metadata.
 
-<CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
+<CodeBlockTabs options={['cURL', 'Next.js App Router', 'Next.js Pages Router', 'Node', 'Go','Ruby']}>
 ```bash copy filename="curl.sh"
 curl -XGET -H 'Authorization: CLERK_SECRET_KEY' -H "Content-type: application/json" 'https://api.clerk.com/v1/users/{user_id}'
 ```
+
+```ts copy filename="app/private/route.ts"
+import { NextResponse } from 'next/server';
+import { clerkClient } from "@clerk/nextjs";
+
+export async function GET(request: Request) {
+  const { stripeId, userId } = await request.body.json();
+
+  const user = await clerkClient.users.getUser(userId)
+  return NextResponse.json(user.privateMetadata);
+}
+```
+
 ```ts copy filename="pages/api/private.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { userId } = await req.body.json();
 
-  const user = await clerkClient.users.getUser("userId")
+  const user = await clerkClient.users.getUser(userId)
 
   res.status(200).json(user.privateMetadata);
 }
 ```
-```ts copy filename="app/route/private.ts"
-import { NextResponse } from 'next/server';
-import { clerkClient } from "@clerk/nextjs";
 
-export async function GET() {
-  const { stripeId, userId } = await body.json();
-  const user = await clerkClient.users.getUser("userId")
-  return NextResponse.json(user.privateMetadata);
-}
-```
 ```ts copy filename="private.ts"
 import { clerkClient } from "@clerk/clerk-node-sdk";
 
 app.post('/updateStripe', (req, res) => {
+  const { userId } = await req.body.json();
 
-  const user = await clerkClient.users.getUser("userId")
+  const user = await clerkClient.users.getUser(userId)
 
   res.status(200).json(user.privateMetadata);
 });
 
 ```
+
 ```ts copy filename="private.go"
 var client clerk.Client
 
@@ -165,6 +172,7 @@ func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
 	}
 }
 ```
+
 ```ts copy filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'

--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -19,3 +19,8 @@ For more information on the `User` object, such as helper methods for retrieving
 
 If you are using React, the [React SDK](/docs/references/react/use-user) provides hooks to help manage user authentication and profile data.
 
+## `User` operations
+
+The [Clerk Backend SDK](https://github.com/clerkinc/javascript/tree/main/packages/backend) exposes Clerk's backend API resources and low-level authentication utilities for JavaScript environments. While the backend SDK is mainly used as a building block for Clerk's higher-level SDKs, it can also be used on its own for advanced flows and custom integrations.
+
+For information about the `User` operations available, such as `getUser()`, `createUser()`, and `deleteUser()`, check out the [Backend SDK documentation](/docs/references/backend/overview).


### PR DESCRIPTION
This PR

- migrates this page from Sanity to MDX
- updates the content and includes links to respective references
- adds more examples for accessing the `deleteUser()` method

For reference, this is what the page looked like before this PR:

https://github.com/clerkinc/clerk-docs/assets/98043211/f6168fae-33ba-454e-b0b7-f1f56e65e9ed