### PR TITLE
feat(nextjs): Update middleware docs with updated matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ next-env.d.ts
 yarn.lock
 
 .idea/
+
+/docs/docs
+/docs/docs/

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -120,7 +120,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
     });
 
     export const config = {
-      matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
     };
     ```
     </CodeBlockTabs>

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -120,7 +120,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
     });
 
     export const config = {
-      matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api)(.*)"],
+      matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
     };
     ```
     </CodeBlockTabs>

--- a/docs/docs
+++ b/docs/docs
@@ -1,1 +1,0 @@
-/Users/alexis/Documents/Sites/clerk-docs/docs

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -98,7 +98,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware({});
 
 export const config = {
-  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 
 ```

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -98,7 +98,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware({});
 
 export const config = {
-  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 
 ```

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -15,9 +15,11 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware();
 
 export const config = {
-  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
+
+With the recommend matcher, all routes are protected by Clerk's authentication middleware, with the exception of internal `/_next/` routes and static files. Static files are detected by matching on paths that end in `.+\..+`. If your middleware needs to run on all routes but you don't want Clerk to protect every route, use the [`ignoredRoutes` option](#options).
 
 ### Using `afterAuth()` for fine-grained control
 
@@ -67,7 +69,7 @@ export default authMiddleware({
 });
 
 export const config = {
-  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
 
@@ -83,7 +85,7 @@ export default authMiddleware({
 });
 
 export const config = {
-  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
 
@@ -95,7 +97,6 @@ NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
 ```
-
 
 ### Execution order of `beforeAuth`, `publicRoutes`, and `afterAuth`
   

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -15,7 +15,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware();
 
 export const config = {
-  matcher: ["/((?!.+[\\w]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
 
@@ -69,7 +69,7 @@ export default authMiddleware({
 });
 
 export const config = {
-  matcher: ["/((?!.+[\\w]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
 
@@ -85,7 +85,7 @@ export default authMiddleware({
 });
 
 export const config = {
-  matcher: ["/((?!.+[\\w]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
 

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -15,7 +15,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware();
 
 export const config = {
-  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 ```
 
@@ -69,7 +69,7 @@ export default authMiddleware({
 });
 
 export const config = {
-  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 ```
 
@@ -85,7 +85,7 @@ export default authMiddleware({
 });
 
 export const config = {
-  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 ```
 

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -56,7 +56,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware();
 
 export const config = {
-  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 ```
 

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -56,7 +56,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware();
 
 export const config = {
-  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+[\\w-\\$\\(\\)]+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
 


### PR DESCRIPTION
Dependent on https://github.com/clerkinc/javascript/pull/1695 landing.

Updates the default middleware matcher and clarifies expected behavior.

related to JS-694