### PR TITLE
fix: Use pnpm add instead of pnpm i or pnpm install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ yarn add @clerk/nextjs
 ​```
 
 ​```
-pnpm i @clerk/nextjs
+pnpm add @clerk/nextjs
 ​```
 
 </CodeBlockTabs>

--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -49,7 +49,7 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
   ```
 
   ```bash filename="terminal" copy
-  pnpm install @clerk/localizations
+  pnpm add @clerk/localizations
   ```
 </CodeBlockTabs>
 

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -28,7 +28,7 @@ Clerk offers [a set of themes that can be used with the `appearance` prop](/docs
   ```
 
   ```bash filename="terminal" copy
-  pnpm install @clerk/themes
+  pnpm add @clerk/themes
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -29,7 +29,7 @@ Once you have a Expo application ready, you need to install Clerk's Expo SDK.
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/clerk-expo
+  pnpm add @clerk/clerk-expo
   ```
 </CodeBlockTabs>
 
@@ -474,7 +474,7 @@ You can use it as your client JWT storage by setting the `tokenCache` prop in yo
   ```
 
   ```bash filename="terminal" copy
-  pnpm install install expo-secure-store
+  pnpm add install expo-secure-store
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -34,7 +34,7 @@ If you're looking for a more complete example, check out our [Fastify example ap
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/fastify
+  pnpm add @clerk/fastify
   ```
 </CodeBlockTabs>
 
@@ -67,8 +67,8 @@ This examples uses `dontenv` to load the environment variables. You can use any 
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/fastify
-  pnpm i -D types/dotenv
+  pnpm add @clerk/fastify
+  pnpm add -D types/dotenv
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -27,7 +27,7 @@ Once you have a React application ready, you need to install Clerk's React SDK. 
   ```
 
   ```bash filename="terminal" copy
-  pnpm i gatsby-plugin-clerk
+  pnpm add gatsby-plugin-clerk
   ```
 </CodeBlockTabs>
 

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -37,7 +37,7 @@ At the root of your project, install the ClerkJS package using your package mana
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/clerk-js
+  pnpm add @clerk/clerk-js
   ```
 </CodeBlockTabs>
 
@@ -79,7 +79,7 @@ CLERK_FRONTEND_API=[your-domain].clerk.accounts.dev
 To use the ClerkJS package, you'll need to initialize the Clerk class with your frontend API URL and publishable key.
 
 <CodeBlockTabs options={['npm Package', 'script Tag']}>
-```js copy filename="index.js" 
+```js copy filename="index.js"
 import Clerk from '@clerk/clerk-js';
 
 const clerkFrontendApi = `pk_{{pub_key}}`;

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -23,7 +23,7 @@ Once you have a Next.js application ready, you need to install Clerk's Next.js S
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/nextjs
+  pnpm add @clerk/nextjs
   ```
 </CodeBlockTabs>
 
@@ -108,7 +108,7 @@ With this middleware, your entire application is protected. If you try to access
 
 
 <Callout type="info" emoji="🎉">
- At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of box. 
+ At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of box.
  Start your Next.js application via `npm run dev`, visit `http://localhost:3000`, and sign up to get access to your application.
 </Callout>
 
@@ -164,7 +164,7 @@ In addition to the Account Portal, Clerk also offers a set of [prebuilt componen
 </Callout>
 
 
-#### Update your environment variables 
+#### Update your environment variables
 
 Next, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
 
@@ -198,7 +198,7 @@ export default function Home() {
 
 ```tsx copy filename="pages/example.tsx"
 import { UserButton } from "@clerk/nextjs";
- 
+
 export default function Example() {
   return (
     <>

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -30,7 +30,7 @@ Once you have a React application ready, you need to install Clerk's React SDK. 
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/clerk-react
+  pnpm add @clerk/clerk-react
   ```
 </CodeBlockTabs>
 
@@ -114,7 +114,7 @@ export default App;
 ```
 
 <Callout type="info" emoji="🎉">
- At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of box.  
+ At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of box.
 Start your React application via `npm run start`, visit `http://localhost:3000`, and sign up to get access to your application.
 </Callout>
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -22,7 +22,7 @@ Once you have a Remix application ready, you need to install Clerk's Remix SDK. 
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/remix
+  pnpm add @clerk/remix
   ```
 </CodeBlockTabs>
 
@@ -216,7 +216,7 @@ export const ErrorBoundary = V2_ClerkErrorBoundary(YourBoundary);
 
 #### Catch Boundary
 
-If you have not set the `v2_errorBoundary` future flag to `true`, use the `ClerkCatchBoundary` instead. 
+If you have not set the `v2_errorBoundary` future flag to `true`, use the `ClerkCatchBoundary` instead.
 
 ```ts filename="app/root.tsx" copy
 export const CatchBoundary = ClerkCatchBoundary();

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -29,7 +29,7 @@ There are two ways you can include ClerkJS in your project. You can either [impo
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/clerk-js
+  pnpm add @clerk/clerk-js
   ```
 </CodeBlockTabs>
 

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -29,7 +29,7 @@ Clerk's Next.js SDK gives you access to prebuilt components and hooks, as well a
   ```
 
   ```bash filename="terminal" copy
-  pnpm i @clerk/nextjs
+  pnpm add @clerk/nextjs
   ```
 </CodeBlockTabs>
 

--- a/docs/users/sync-data.mdx
+++ b/docs/users/sync-data.mdx
@@ -77,7 +77,7 @@ yarn add svix
 ```
 
 ```bash filename="terminal" copy
-pnpm i svix
+pnpm add svix
 ```
 
 </CodeBlockTabs>
@@ -144,7 +144,7 @@ yarn add svix
 ```
 
 ```bash filename="terminal" copy
-pnpm i svix
+pnpm add svix
 ```
 
 </CodeBlockTabs>
@@ -230,7 +230,7 @@ yarn add svix
 ```
 
 ```bash filename="terminal" copy
-pnpm i svix
+pnpm add svix
 ```
 
 </CodeBlockTabs>


### PR DESCRIPTION
This pull request updates all references to pnpm i and pnpm install when adding a package to pnpm add, as this is the preferred method mentioned in the PNPM documentation https://pnpm.io/cli/add