### PR TITLE
DOCS-283 update hosted pages to now reference account portal

### DIFF
--- a/docs/account-portal/custom-redirects.mdx
+++ b/docs/account-portal/custom-redirects.mdx
@@ -1,5 +1,5 @@
 ---
-title: Customizing your redirects | Account Portal
+title: Customizing your Account Portal redirect
 description:  Customize where your users are redirected to after they sign in or sign up.
 ---
 

--- a/docs/account-portal/direct-links.mdx
+++ b/docs/account-portal/direct-links.mdx
@@ -1,5 +1,5 @@
 ---
-title: Direct links | Account Portal
+title: Direct links
 description: Learn how to share direct links to your Account Portal pages, and how to set up fallback redirects.
 ---
 

--- a/docs/account-portal/getting-started.mdx
+++ b/docs/account-portal/getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting started | Account Portal
+title: Getting started with the Account Portal
 description: The Account Portal offers a comprehensive solution for managing user authentication and profile management in your web application and is the fastest way to add Clerk's authentication to your application with minimal code required.
 ---
 

--- a/docs/account-portal/user-profile-org-profile.mdx
+++ b/docs/account-portal/user-profile-org-profile.mdx
@@ -1,5 +1,5 @@
 ---
-title: User & Organization Pages | Account Portal
+title: User & Organization Pages
 description: In addition to the sign-in/sign-up pages, the Account Portal also provides the User Profile, Organization Profile and Create Organization flow out of the box. 
 ---
 

--- a/docs/authentication/configuration/sign-in-options.mdx
+++ b/docs/authentication/configuration/sign-in-options.mdx
@@ -11,7 +11,7 @@ Clerk provides a large selection of options for managing your user's sign-in exp
   For more information about the steps required for a user to sign in, see the [sign-in flow documentation](/docs/custom-flows/overview#sign-in-flow).
 </Callout>
 
-You can create your sign-in flow with Clerk's [hosted pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview). If you need more control over your flow, you can build your own by using [React hooks](/docs/custom-flows/use-sign-up) or by using the methods of the [`SignIn` object](/docs/references/javascript/sign-in/sign-in).
+You can create your sign-in flow with Clerk's [Account Portal pages](/docs/account-portal/overview) or [prebuilt components](/docs/components/overview). If you need more control over your flow, you can build your own by using [React hooks](/docs/custom-flows/use-sign-up) or by using the methods of the [`SignIn` object](/docs/references/javascript/sign-in/sign-in).
 
 ## Getting started
 

--- a/docs/authentication/using-clerk-hosted-pages.mdx
+++ b/docs/authentication/using-clerk-hosted-pages.mdx
@@ -1,3 +1,0 @@
----
-sanity_slug: /docs/authentication/using-clerk-hosted-pages
----

--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -131,7 +131,7 @@ ReactDOM.render(
       cells: [
         <code>appearance?</code>,
         <code>object</code>,
-        <>Optional object to customize your Components. Will only affect Clerk Components and not Clerk Hosted pages.</>,
+        <>Optional object to customize your Components. Will only affect Clerk Components and not Account Portal pages.</>,
       ],
     },
     {

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -224,7 +224,7 @@ export const CatchBoundary = ClerkCatchBoundary();
 
 ### Build your own sign-in and sign-up pages
 
-In addition to the Hosted Pages, Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Next.js application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Next.js optional catch-all route.
+In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Next.js application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Next.js optional catch-all route.
 
 The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev).
 


### PR DESCRIPTION
This PR

- deletes the old "Using Clerk Hosted Pages" page
- updates "Hosted Pages" references to reference "Account Portal pages"
- updates a few titles to be more palatable - partially for OG Images 