### PR TITLE
fix package name in nodejs example in docs/users/metadata

### DIFF
--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -62,7 +62,7 @@ export async function POST() {
 }
 ```
 ```ts copy filename="private.ts"
-import { clerkClient } from "@clerk/clerk-node-sdk";
+import { clerkClient } from "@clerk/clerk-sdk-node";
 
 app.post('/updateStripe', (req, res) => {
 


### PR DESCRIPTION
replaced `@clerk/clerk-node-sdk` with `@clerk/clerk-sdk-node` in example of set metadata in nodejs example 
 at docs/users/metadata. 