### PR TITLE
Migrate 'Multiple orgs' from Sanity to MDX

### DIFF
--- a/docs/organizations/multiple-orgs.mdx
+++ b/docs/organizations/multiple-orgs.mdx
@@ -1,5 +1,49 @@
 ---
-sanity_slug: /docs/organizations/organization-switching
+title: Organization switching
+description: Learn how to switch the active organization.
 ---
 
-# This is a stub
+# Organization switching
+
+The [`useOrganizationList()`](/docs/references/react/use-organization-list) hook returns the `organizationList` property, which is useful for viewing all the organizations the current user is a member of and also for building an organization switcher component.
+
+## Usage
+
+This example shows how you can build an organization switcher in a Next.js application.
+
+```jsx filename="components/OrganizationSwitcher.js"
+import { useOrganization, useOrganizationList } from '@clerk/nextjs';
+import Select from 'react-select';
+
+function createOrganizationOptions(organizationList) {
+  return organizationList.map(({ organization }) => ({
+    value: organization.id,
+    label: organization.name
+  }));
+}
+
+export default function Switcher() {
+  const { setActive, organizationList, isLoaded } = useOrganizationList();
+  const { organization } = useOrganization();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  const handleOrgChange = e => {
+    setActive({ organization: e.value });
+  };
+
+  if (!organization) {
+    return null;
+  }
+
+  return (
+    <Select
+      options={createOrganizationOptions(organizationList)}
+      onChange={handleOrgChange}
+      value={{ value: organization.id, label: organization.name }}
+    />
+  );
+}
+```


### PR DESCRIPTION
/docs/organizations/multiple-orgs

This PR

- migrates this page from Sanity to MDX
- adds links to respective references

Acknowledging that these pages probably need work, and need their code examples updated - but for the scope of "Sanity to MDX Migration", this can be revisited at a later time, with better resources.