### PR TITLE
Migrate backend-requests 'Overview' from Sanity to MDX

### DIFF
--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -31,7 +31,7 @@ For cross-origin requests, refer to our guide on [making cross-origin requests](
 
 ## Backend requests
 
-Clerk provides various middleware packages to set the session property for easy access and can also require a session to be available. Choose the guide based on the language or framework you're using:
+Clerk provides various middleware packages to set the session property for easy access. These packages can also require a session to be available on the current request. Choose the guide based on the language or framework you're using:
 
 - [Next.js](/docs/references/nextjs/auth-middleware)
 - [Gatsby](/docs/backend-requests/handling/gatsby)

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -41,8 +41,6 @@ Clerk provides various middleware packages to set the session property for easy 
 
 If there is not middleware available for your preferred language or framework, you can extract the session token manually.
 
-You can read more about [manual JWT verification](/docs/backend-requests/handling/manual-jwt) for additional information.
-
 ### Same-origin
 
 For same-origin requests, the session token is included in the `__session` cookie and you can use an open source library to parse the cookie on the back-end. 
@@ -51,3 +49,4 @@ For same-origin requests, the session token is included in the `__session` cooki
 
 For cross-origin requests, the Bearer token inside the `Authorization` header contains the session token.
 
+You can read more about [manual JWT verification](/docs/backend-requests/handling/manual-jwt) for additional information.

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -15,7 +15,9 @@ In order to authenticate the user on the backend using the Clerk SDK, the short-
 
 ## Frontend requests
 
-To make authenticated requests from the frontend, the approach differs based on whether your client and server are on the same origin. The origin includes the protocol, hostname, and port (optional):
+To make authenticated requests from the frontend, the approach differs based on whether your client and server are on the same origin. 
+
+The origin includes the protocol, hostname, and port (optional):
 
 `<protocol>//<hostname>[:<port>]`
 

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Request authentication
-description: Learn about various ways to make authenticated requests to the backend using the Clerk SDK.
+description: Learn about various ways to make authenticated requests to the backend using Clerk's SDK.
 ---
 
 # Request authentication

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -1,5 +1,51 @@
 ---
-sanity_slug: /docs/request-authentication/overview
+title: Request authentication
+description: Learn about various ways to make authenticated requests to the backend using the Clerk SDK.
 ---
 
-# This is a stub
+# Request authentication
+
+A request is considered “authenticated” when the backend can securely identify which user and which device is making the request. The reasons for making authenticated requests to the backend include:
+
+- Associating the user with the action being performed
+- Ensuring the user has permission to make the request
+- Keeping an audit log of which device the user is performing actions from
+
+In order to authenticate the user on the backend using the Clerk SDK, the short-lived [session token](/docs/backend-requests/resources/session-tokens) needs to be passed to the server.
+
+## Frontend requests
+
+To make authenticated requests from the frontend, the approach differs based on whether your client and server are on the same origin. The origin includes the protocol, hostname, and port (optional):
+
+`<protocol>//<hostname>[:<port>]`
+
+### Same-origin
+
+For same-origin requests, refer to our guide on making same-origin requests.
+
+### Cross-origin
+
+For cross-origin requests, refer to our guide on making cross-origin requests.
+
+## Backend requests
+
+Clerk provides various middleware packages to set the session property for easy access and can also require a session to be available. Choose the guide based on the language or framework you're using:
+
+- [Next.js](/docs/references/nextjs/auth-middleware)
+- [Gatsby](/docs/request-authentication/gatsby)
+- [Node.js / Express](/docs/request-authentication/nodejs-express)
+- [Go](/docs/request-authentication/go)
+- [Ruby on Rails / Rack](/docs/backend-requests/handling/ruby-rails)
+
+If there is not middleware available for your preferred language or framework, you can extract the session token manually.
+
+You can read more about [manual JWT verification](/docs/backend-requests/handling/manual-jwt) for additional information.
+
+### Same-origin
+
+For same-origin requests, the session token is included in the `__session` cookie and you can use an open source library to parse the cookie on the back-end. 
+
+### Cross-origin
+
+For cross-origin requests, the Bearer token inside the `Authorization` header contains the session token.
+

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -11,7 +11,7 @@ A request is considered “authenticated” when the backend can securely identi
 - Ensuring the user has permission to make the request
 - Keeping an audit log of which device the user is performing actions from
 
-In order to authenticate the user on the backend using the Clerk SDK, the short-lived [session token](/docs/backend-requests/resources/session-tokens) needs to be passed to the server.
+In order to authenticate the user on the backend using Clerk's SDK, the short-lived [session token](/docs/backend-requests/resources/session-tokens) needs to be passed to the server.
 
 ## Frontend requests
 

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -5,7 +5,7 @@ description: Learn about various ways to make authenticated requests to the back
 
 # Request authentication
 
-A request is considered “authenticated” when the backend can securely identify which user and which device is making the request. The reasons for making authenticated requests to the backend include:
+A request is considered “authenticated” when the backend can securely identify the user and device that is making the request. The reasons for making authenticated requests to the backend include:
 
 - Associating the user with the action being performed
 - Ensuring the user has permission to make the request

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -34,9 +34,9 @@ For cross-origin requests, refer to our guide on [making cross-origin requests](
 Clerk provides various middleware packages to set the session property for easy access and can also require a session to be available. Choose the guide based on the language or framework you're using:
 
 - [Next.js](/docs/references/nextjs/auth-middleware)
-- [Gatsby](/docs/request-authentication/gatsby)
-- [Node.js / Express](/docs/request-authentication/nodejs-express)
-- [Go](/docs/request-authentication/go)
+- [Gatsby](/docs/backend-requests/handling/gatsby)
+- [Node.js / Express](/docs/backend-requests/handling/nodejs)
+- [Go](/docs/backend-requests/handling/go)
 - [Ruby on Rails / Rack](/docs/backend-requests/handling/ruby-rails)
 
 If there is not middleware available for your preferred language or framework, you can extract the session token manually.

--- a/docs/backend-requests/overview.mdx
+++ b/docs/backend-requests/overview.mdx
@@ -23,11 +23,11 @@ The origin includes the protocol, hostname, and port (optional):
 
 ### Same-origin
 
-For same-origin requests, refer to our guide on making same-origin requests.
+For same-origin requests, refer to our guide on [making same-origin requests](/docs/backend-requests/making/same-origin).
 
 ### Cross-origin
 
-For cross-origin requests, refer to our guide on making cross-origin requests.
+For cross-origin requests, refer to our guide on [making cross-origin requests](/docs/backend-requests/making/cross-origin).
 
 ## Backend requests
 

--- a/docs/integrations/databases/wundgraph.mdx
+++ b/docs/integrations/databases/wundgraph.mdx
@@ -1,1 +1,0 @@
-# Coming soon


### PR DESCRIPTION
/docs/backend-requests/overview

This PR

- migrates this page from Sanity to MDX
- adds links to respective references
- deletes the empty "Wundgraph" page... should be wundergraph, and the content is not here yet so we do not need this page.

Acknowledging that these pages probably need work, and need their code examples updated - but for the scope of "Sanity to MDX Migration", this can be revisited at a later time, with better resources.

For reference, this is what the page looked like before this PR:

https://github.com/clerkinc/clerk-docs/assets/98043211/969bea76-98e8-4a8b-a8c1-7b3b69d27973


