### PR TITLE
Migrate custom-flows 'Overview' page from Sanity to MDX

### DIFF
--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -1,5 +1,65 @@
 ---
-sanity_slug: /docs/authentication/custom-flows
+title: Custom flows
+description: Learn the process behind building custom sign-up and sign-in flows with Clerk.
 ---
 
-# This is a stub
+# Custom flows
+
+If Clerk's [prebuilt components](/docs/components/overview) don't meet your specific needs or if you require more control over the authentication flow, Clerk enables you to build fully custom sign-up and sign-in flows using our [`useSignUp()`](/docs/references/react/use-sign-up) and [`useSignIn()`](/docs/references/react/use-sign-in) React hooks.
+
+But before diving deep into the code side, it is important to first understand the process behind building sign-up and sign-in flows, which fields are required, and the necessary steps to authenticate a user.
+
+## Sign-up flow
+
+Clerk provides a flexible way to build sign-up flows in your application. You can use a single [`SignUp`](/docs/references/javascript/sign-up/sign-up) object to gather information, verify their email address or phone number, add OAuth accounts, and finally, convert them into a [`User`](/docs/references/javascript/user/user).
+
+Every [`SignUp`](/docs/references/javascript/sign-up/sign-up) has a set of requirements it must meet before it is turned into a [`User`](/docs/references/javascript/user/user). These requirements are defined by the instance settings you selected in the [Clerk Dashboard](https://dashboard.clerk.com/). Once all requirements are met, the [`SignUp`](/docs/references/javascript/sign-up/sign-up) will turn into a new [`User`](/docs/references/javascript/user/user), and an active session for that [`User`](/docs/references/javascript/user/user) will be created on the current [`Client`](/docs/references/javascript/client).
+
+Don't worry about collecting all the required fields at once and passing them to a single request. The API is designed to accommodate a progressive sign-up flow, often corresponding to multi-step sign-up forms.
+
+### Required fields
+
+The [`SignUp`](/docs/references/javascript/sign-up/sign-up) will show the current state of requirement collection. You can consult the `required_fields`, `optional_fields`, and `missing_fields` keys for a hint on where things are and what you need to do next.
+
+| Name | Description |
+| --- | --- |
+| `required_fields` | All fields that must be collected before the [`SignUp`](/docs/references/javascript/sign-up/sign-up) converts into a [`User`](/docs/references/javascript/user/user). |
+| `optional_fields` | All fields that can be collected, but are not necessary to convert the [`SignUp`](/docs/references/javascript/sign-up/sign-up). |
+| `missing_fields` | A subset of `required_fields`. It contains all fields that still need to be collected before a successful [`SignUp`](/docs/references/javascript/sign-up/sign-up). Note that the `missing_fields` will be updated dynamically. As you add more fields to the [`SignUp`](/docs/references/javascript/sign-up/sign-up), they will be removed from `missing_fields`. Once it's empty, your [`SignUp`](/docs/references/javascript/sign-up/sign-up) will automatically convert into a [`User`](/docs/references/javascript/user/user). |
+
+The values of the collected fields are all accessible on the root of the [`SignUp`](/docs/references/javascript/sign-up/sign-up), under their corresponding keys; `email_address` and `phone_number` are examples of such keys.
+
+### Verified fields
+
+Some fields, such as `email_address` and `phone_number`, must be verified before it is fully added to the [`SignUp`](/docs/references/javascript/sign-up/sign-up). Similar to what happens with required fields, the [`SignUp`](/docs/references/javascript/sign-up/sign-up) contains the current state of all verified fields. The keys relative to verification are `unverified_fields` and `verifications`.
+
+| Name | Description |
+| --- | --- |
+| `unverified_fields` | A list of all [`User`](/docs/references/javascript/user/user) attributes that need to be verified and are pending verification. This is a list that gets updated dynamically. When verification for all required fields has been successfully completed, this value will become an empty array. |
+| `verifications` | An object that describes the current state of verification for the [`SignUp`](/docs/references/javascript/sign-up/sign-up). There are currently three different keys: `email_address`, `phone_number`, and `external_account`. |
+
+## Sign-in flow
+
+Sign-in's are initiated by creating a [`SignIn`](/docs/references/javascript/sign-in/sign-in) object on the current Client. The `SignIn` handles all the state and logic associated with a sign-in. If the sign-in is successfully authenticated, it will transform into an active session on the current [`Client`](/docs/references/javascript/client).
+
+### Completing a sign-in
+
+There are 3 main steps a user must perform in order to complete a sign-in:
+
+<Steps>
+
+### Identification
+
+The first step a user needs to make is to identify what account they'd like to sign in to. This is done with an identifier, which can either be an email address, a phone number, or a username.
+
+### Factor one verification
+
+Once a user is identified, they need to prove that "they are who they say they are". This is the process of "authenticating" the user. There's a number of strategies a user can use to perform authentication with the most basic being the humble password. Other authentication strategies, like passwordless sign-in, can be explored in the [sign-in options documentation](/docs/authentication/configuration/sign-in-options). 
+
+### Factor two verification (optional)
+
+This step only applies to users that have turned on two-factor authentication, also known as [multifactor authentication](/docs/custom-flows/mfa), for their user. 
+
+When one form of verification isn't enough, trust two! Forcing two different verification steps vastly increases the security of your account. The most common setup a user will have to protect their account is using a password as their first kind of verification, and a `phone_code` as their second kind of verification.
+
+</Steps>

--- a/docs/custom-flows/overview.mdx
+++ b/docs/custom-flows/overview.mdx
@@ -40,11 +40,11 @@ Some fields, such as `email_address` and `phone_number`, must be verified before
 
 ## Sign-in flow
 
-Sign-in's are initiated by creating a [`SignIn`](/docs/references/javascript/sign-in/sign-in) object on the current Client. The `SignIn` handles all the state and logic associated with a sign-in. If the sign-in is successfully authenticated, it will transform into an active session on the current [`Client`](/docs/references/javascript/client).
+Sign-in's are initiated by creating a [`SignIn`](/docs/references/javascript/sign-in/sign-in) object on the current [`Client`](/docs/references/javascript/client). The [`SignIn`](/docs/references/javascript/sign-in/sign-in) handles all the state and logic associated with a sign-in. If the sign-in is successfully authenticated, it will transform into an active session on the current [`Client`](/docs/references/javascript/client).
 
 ### Completing a sign-in
 
-There are 3 main steps a user must perform in order to complete a sign-in:
+There are 3 main steps a user must perform in order to complete a sign-in.
 
 <Steps>
 


### PR DESCRIPTION
/docs/custom-flows/overview

This PR

- migrates this page from Sanity to MDX

Acknowledging that these pages probably need work, and need their code examples updated - but for the scope of "Sanity to MDX Migration", this can be revisited at a later time, with better resources.

For reference, this is what the page looked like before this PR:

https://github.com/clerkinc/clerk-docs/assets/98043211/6767dcf2-8de9-47fe-8028-c5fb8902735f

