### PR TITLE
Update use-organization-list.mdx

### DIFF
--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -57,7 +57,7 @@ export default JoinedOrganizationList;
 ```
 
 ```tsx copy filename="joined-organizations.tsx"
-import { useOrganizationList } from "@clerk/nextjs";
+import { useOrganizationList } from "@clerk/clerk-react";
 import React from "react";
 
 const JoinedOrganizationList = () => {


### PR DESCRIPTION
when you click on the the "React" tab here: https://clerk.com/docs/references/react/use-organization-list#infinite-list-of-joined-organizations

the import for `useOrganizationList` is from `"@clerk/nextjs"`, but it should be `"@clerk/clerk-react"`, so this PR reflects that change