### PR TITLE
remove copy attribute from all code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,10 @@ function add(a: number, b: number) {
 ​```
 ```
 
-You can also specify a filename and pass a `copy` attribute to show a copy-to-clipboard button:
+You can also specify a filename:
 
 ```
-​```typescript filename="add.ts" copy
+​```typescript filename="add.ts"
 function add(a: number, b: number) {
   a + b
 }

--- a/docs/account-portal/custom-redirects.mdx
+++ b/docs/account-portal/custom-redirects.mdx
@@ -12,11 +12,11 @@ After a user signs in or signs up, Clerk automatically redirects users back to y
 You can define the paths you want the users to be redirected to via environment variables. In this example, we redirect users to `/dashboard` after signing in, and to `/onboarding` after signing up.
 
 <CodeBlockTabs options={['Next.js', 'Remix']}>
-```sh filename=".env" copy
+```sh filename=".env"
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/dashboard
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/onboarding
 ```
-```sh filename=".env" copy
+```sh filename=".env"
 CLERK_AFTER_SIGN_IN_URL=/dashboard
 CLERK_AFTER_SIGN_UP_URL=/onboarding
 ```
@@ -30,7 +30,7 @@ If you are using Next.js and want a more programmatically generated redirect opt
   The `afterAuth()` function will always take precedence over environment variables.
 </Callout>
 
-```tsx filename="middleware.ts" copy
+```tsx filename="middleware.ts"
 export default authMiddleware({
   afterAuth(auth, req, evt) {
     // handle users who aren't authenticated
@@ -53,7 +53,7 @@ You can explicitly define the redirect paths by passing the `afterSignInUrl` and
 ### Control components
 <CodeBlockTabs options={['ClerkProvider', 'RedirectToSignIn', 'RedirectToSignUp']}>
 
-```javascript filename="example.js" copy
+```javascript filename="example.js"
 function App() {
   return (
     <ClerkProvider publishableKey={clerkPubKey} afterSignInUrl='/dashboard' afterSignUpUrl='/onboarding' >
@@ -67,7 +67,7 @@ function App() {
   );
 }
 ```
-```javascript filename="example.js" copy
+```javascript filename="example.js"
 function App() {
   return (
     <ClerkProvider publishableKey={clerkPubKey}>
@@ -81,7 +81,7 @@ function App() {
   );
 }
 ```
-```javascript filename="example.js" copy
+```javascript filename="example.js"
 function App() {
   return (
     <ClerkProvider publishableKey={clerkPubKey} >
@@ -106,7 +106,7 @@ function App() {
 In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/sign-in-button) or [`<SignUpButton />`](/docs/components/unstyled/sign-up-button), you can also pass the props into those components. We recommend defining both `afterSignInUrl` and `afterSignUpUrl` redirects in each button as some users may choose to sign up instead after attempting to sign in.
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton, SignUpButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -126,7 +126,7 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignInButton, SignUpButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -146,7 +146,7 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton, SignUpButton } from "@clerk/remix";
 
   export default function Home() {
@@ -166,7 +166,7 @@ In the case that you are using a [`<SignInButton />`](/docs/components/unstyled/
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton, SignUpButton } from "gatsby-plugin-clerk";
 
   export default function Home() {

--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -28,7 +28,7 @@ Retrieve the **Callback URL** for the client application you want to configure. 
 
 Next, you need to create an OAuth Application in Clerk via the [Backend API](https://clerk.com/docs/reference/backend-api/tag/OAuth-Applications) by providing the Callback URL and a Name. Note that in this context the name is used to help you identify your application and is not displayed anywhere publicly.
 
-```sh copy filename="POST /v1/oauth_applications"
+```sh filename="POST /v1/oauth_applications"
 curl
  -X POST https://api.clerk.com/v1/oauth_applications \
  -H "Authorization: Bearer <CLERK_SECRET_KEY>"  \
@@ -45,7 +45,7 @@ To create an OAuth Application that uses the authorization code flow with proof 
 Clerk creates an OAuth application and returns it's configurations back to you.
 
 
-```json copy filename="RESPONSE"
+```json filename="RESPONSE"
 {
     "object":"oauth_application",
     "id":"oa_2O4BCh3zUONvWlZHtBXv6s6tm7u",

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -50,7 +50,7 @@ alt="Clerk Dashboard inside the satellites tab of the domain"
 Now that you have created the satellite application, it's time to configure it as such. You can do so with the environment variables below or via properties (see the next step).
 
 <CodeBlockTabs options={["Next.js", "Remix"]}>
-```env copy filename=".env.local"
+```env filename=".env.local"
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 
@@ -59,7 +59,7 @@ NEXT_PUBLIC_CLERK_IS_SATELLITE=true
 
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=https://primary.dev/sign-in
 ```
-```env filename=".env" copy
+```env filename=".env"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 
@@ -87,7 +87,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
     You can embed the `<SignIn />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignIn />` component should be mounted on a public page.
 
     <CodeBlockTabs options={["<ClerkProvider />", "Middleware"]}>
-    ```jsx copy filename="_app.tsx"
+    ```jsx filename="_app.tsx"
     import { ClerkProvider } from "@clerk/nextjs";
     import Head from "next/head";
 
@@ -104,7 +104,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
     }
     ```
 
-    ```js copy filename="middleware.ts"
+    ```js filename="middleware.ts"
     import { authMiddleware, redirectToSignIn } from "@clerk/nextjs/server";
 
     export default authMiddleware({
@@ -127,7 +127,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
   </Tab>
 
   <Tab>
-    ```js copy filename="root.tsx"
+    ```js filename="root.tsx"
     export const loader = (args) => {
       return rootAuthLoader(
         args,

--- a/docs/backend-requests/handling/manual-jwt.mdx
+++ b/docs/backend-requests/handling/manual-jwt.mdx
@@ -45,7 +45,7 @@ If the above process is successful, it means that the user is signed in to your 
 
 ## Example usage
 
-```tsx copy filename="pages/api/token-example.ts"
+```tsx filename="pages/api/token-example.ts"
 import type { NextApiRequest, NextApiResponse } from "next";
 import Cookies from "cookies";
 import jwt from "jsonwebtoken";

--- a/docs/backend-requests/making/custom-session-token.mdx
+++ b/docs/backend-requests/making/custom-session-token.mdx
@@ -55,7 +55,7 @@ Now that you have added the custom claims to your session token, you can use the
 
 #### Using `getAuth` in your Next.js application
 
-```tsx copy fileName=pages/api/example.ts
+```tsx fileName=pages/api/example.ts
 import { getAuth } from "@clerk/nextjs/server";
 
 export default async function handler(req, res) {

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -23,7 +23,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
     You can embed the `<SignIn />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignIn />` component should be mounted on a public page.
 
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="/app/sign-in/[[...sign-in]]/page.[jsx/tsx]"
+      ```jsx filename="/app/sign-in/[[...sign-in]]/page.[jsx/tsx]"
       import { SignIn } from "@clerk/nextjs";
 
       export default function Page() {
@@ -31,7 +31,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
       }
       ```
 
-      ```jsx copy filename="/pages/sign-in/[[...index]].tsx"
+      ```jsx filename="/pages/sign-in/[[...index]].tsx"
       import { SignIn } from "@clerk/nextjs";
 
       const SignInPage = () => (
@@ -43,7 +43,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/pages/sign-in/[[...index]].[jsx/tsx]"
+    ```jsx filename="/pages/sign-in/[[...index]].[jsx/tsx]"
     import { SignIn } from "@clerk/react";
 
     const SignInPage = () => (
@@ -54,7 +54,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```jsx copy filename="app/routes/sign-in/$.tsx"
+    ```jsx filename="app/routes/sign-in/$.tsx"
     import { SignIn } from "@clerk/remix";
 
     export default function SignInPage() {
@@ -69,7 +69,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/pages/sign-in.js"
+    ```jsx filename="/pages/sign-in.js"
     import { SignIn } from "gatsby-plugin-clerk";
 
     export default function SignInPage() {
@@ -84,7 +84,7 @@ Below is basic implementation of the `<SignIn />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```js copy filename="sign-in.js"
+    ```js filename="sign-in.js"
     window.Clerk.mountSignIn(
       document.getElementById("sign-in")
     );

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -25,7 +25,7 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
     <Callout>The example below shows the Sign In page mounted on the url /sign-in. For more information on how to implement this, check out the [`<SignIn />` UI page](/docs/components/authentication/sign-in).</Callout>
 
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="/app/sign-up/[[...sign-up]]/page.[jsx/tsx]"
+      ```jsx filename="/app/sign-up/[[...sign-up]]/page.[jsx/tsx]"
       import { SignUp } from "@clerk/nextjs";
 
       export default function Page() {
@@ -33,7 +33,7 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
       }
       ```
 
-      ```jsx copy filename="/pages/sign-up/[[...index]].[jsx/tsx]"
+      ```jsx filename="/pages/sign-up/[[...index]].[jsx/tsx]"
       import { SignUp } from "@clerk/nextjs";
 
       const SignUpPage = () => (
@@ -45,7 +45,7 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```jsx copy filename="sign-up.jsx"
+    ```jsx filename="sign-up.jsx"
     import { SignUp } from "@clerk/clerk-react";
 
     function SignUpPage() {
@@ -55,7 +55,7 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
     </Tab>
 
     <Tab>
-    ```jsx copy filename="app/routes/sign-up/$.tsx"
+    ```jsx filename="app/routes/sign-up/$.tsx"
     import { SignUp } from "@clerk/remix";
 
     export default function SignUpPage() {
@@ -70,7 +70,7 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/pages/sign-up.js"
+    ```jsx filename="/pages/sign-up.js"
     import { SignUp } from "gatsby-plugin-clerk";
 
     export default function SignUpPage() {
@@ -85,7 +85,7 @@ Below is basic implementation of the `<SignUp />` component. You can use this as
   </Tab>
 
   <Tab>
-    ```js copy filename="sign-up.js"
+    ```js filename="sign-up.js"
     window.Clerk.mountSignUp(
       document.getElementById("sign-up")
     );

--- a/docs/components/clerk-provider.mdx
+++ b/docs/components/clerk-provider.mdx
@@ -18,7 +18,7 @@ The `<ClerkProvider />` component must be added to your React entrypoint.
 <Tabs items={['Next.js', 'React']}>
 <Tab>
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
-```tsx copy filename="app/layout.tsx"
+```tsx filename="app/layout.tsx"
 import React from "react";
 import { ClerkProvider } from "@clerk/nextjs";
 
@@ -39,7 +39,7 @@ export default function RootLayout({
   );
 }
 ```
-```tsx filename="_app.tsx" copy
+```tsx filename="_app.tsx"
 import { ClerkProvider } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
 
@@ -56,7 +56,7 @@ export default MyApp;
 </CodeBlockTabs>
 </Tab>
 <Tab>
-```tsx filename="index.tsx" copy
+```tsx filename="index.tsx"
 import React from "react";
 import ReactDOM from "react-dom";
 import { ClerkProvider } from "@clerk/clerk-react";

--- a/docs/components/control/authenticate-with-callback.mdx
+++ b/docs/components/control/authenticate-with-callback.mdx
@@ -17,7 +17,7 @@ The `<AuthenticateWithRedirectCallback />` is used to complete a custom OAuth fl
 <Tab>
 This example below uses built in Next.js pages, but you could use any routing library you want.
 
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import '@/styles/globals.css';
 import { ClerkProvider, SignedIn, SignedOut, useSignIn } from '@clerk/nextjs';
 import { AppProps } from 'next/app';
@@ -65,7 +65,7 @@ export default MyApp;
 
 Once you have implemented your sign in flow, you can implement the callback page.
 
-```tsx copy filename="/pages/sso-callback.tsx"
+```tsx filename="/pages/sso-callback.tsx"
 import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
 
 export default function SSOCallBack() {
@@ -78,7 +78,7 @@ export default function SSOCallBack() {
 
 This example below is using the `react-router-dom` library. You can use any routing library you want.
 
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import {
   ClerkProvider,
   AuthenticateWithRedirectCallback,

--- a/docs/components/control/clerk-loaded.mdx
+++ b/docs/components/control/clerk-loaded.mdx
@@ -14,7 +14,7 @@ The `<ClerkLoaded />` component guarantees that the Clerk object has loaded and 
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import "@/styles/globals.css";
 import { ClerkLoaded, ClerkProvider } from "@clerk/nextjs";
 import { AppProps } from "next/app";
@@ -35,7 +35,7 @@ export default MyApp;
 
 Once you have wrapped your app with `<ClerkLoaded />`, you can access the `Clerk` object without the need to check if it exists.
 
-```tsx copy filename="pages/index.tsx"
+```tsx filename="pages/index.tsx"
 declare global {
   interface Window {
     Clerk: any;
@@ -49,7 +49,7 @@ export default function Home() {
 
 </Tab>
 <Tab>
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { useEffect } from "react";
 import { ClerkLoaded, ClerkProvider } from "@clerk/clerk-react";
 
@@ -85,7 +85,7 @@ export default App;
 ```
 </Tab>
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import { ClerkLoaded } from "@clerk/remix";
 
 export default function Index() {

--- a/docs/components/control/clerk-loading.mdx
+++ b/docs/components/control/clerk-loading.mdx
@@ -14,7 +14,7 @@ The `<ClerkLoading />` renders its children while Clerk is loading, and is helpf
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import "@/styles/globals.css";
 import { ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/nextjs";
 import { AppProps } from "next/app";
@@ -38,7 +38,7 @@ export default MyApp;
 </Tab>
 <Tab>
 
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { ClerkLoaded, ClerkLoading, ClerkProvider } from '@clerk/clerk-react';
 
 function App() {
@@ -64,7 +64,7 @@ export default App;
 
 </Tab>
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import { ClerkLoading } from "@clerk/remix";
 
 export default function Index() {

--- a/docs/components/control/multi-session.mdx
+++ b/docs/components/control/multi-session.mdx
@@ -14,7 +14,7 @@ The `<MultisessionAppSupport />` provides a wrapper for your React application t
 
 <Tabs items={['Next.js', 'React']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import "@/styles/globals.css";
 import { MultisessionAppSupport,ClerkProvider } from "@clerk/nextjs";
 import { AppProps } from "next/app";
@@ -33,7 +33,7 @@ export default MyApp;
 ```
 </Tab>
 <Tab>
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { ClerkProvider, MultisessionAppSupport } from "@clerk/clerk-react";
 
 function App() {

--- a/docs/components/control/redirect-to-createorganization.mdx
+++ b/docs/components/control/redirect-to-createorganization.mdx
@@ -11,7 +11,7 @@ The `<RedirectToCreateOrganization />` component will navigate to the create org
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -39,7 +39,7 @@ export default MyApp;
 </Tab>
 
 <Tab>
-```tsx copy filename="pages/privatepage.tsx"
+```tsx filename="pages/privatepage.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -63,7 +63,7 @@ function PrivatePage() {
 </Tab>
 
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,

--- a/docs/components/control/redirect-to-organizationprofile.mdx
+++ b/docs/components/control/redirect-to-organizationprofile.mdx
@@ -11,7 +11,7 @@ The `<RedirectToOrganizationProfile />` component will navigate to the organizat
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -39,7 +39,7 @@ export default MyApp;
 </Tab>
 
 <Tab>
-```tsx copy filename="pages/privatepage.tsx"
+```tsx filename="pages/privatepage.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -63,7 +63,7 @@ function PrivatePage() {
 </Tab>
 
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,

--- a/docs/components/control/redirect-to-signin.mdx
+++ b/docs/components/control/redirect-to-signin.mdx
@@ -11,7 +11,7 @@ The `<RedirectToSignIn />` component will navigate to the sign in URL which has 
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -37,7 +37,7 @@ export default MyApp;
 ```
 </Tab>
 <Tab>
-```tsx copy filename="pages/privatepage.tsx"
+```tsx filename="pages/privatepage.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -62,7 +62,7 @@ function PrivatePage() {
 ```
 </Tab>
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,

--- a/docs/components/control/redirect-to-signup.mdx
+++ b/docs/components/control/redirect-to-signup.mdx
@@ -11,7 +11,7 @@ The `<RedirectToSignUp />` component will navigate to the sign up URL which has 
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -38,7 +38,7 @@ export default MyApp;
 </Tab>
 
 <Tab>
-```tsx copy filename="pages/privatepage.tsx"
+```tsx filename="pages/privatepage.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -63,7 +63,7 @@ function PrivatePage() {
 </Tab>
 
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,

--- a/docs/components/control/redirect-to-userprofile.mdx
+++ b/docs/components/control/redirect-to-userprofile.mdx
@@ -11,7 +11,7 @@ The `<RedirectToUserProfile />` component will navigate to the user profile URL 
 
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="pages/_app.tsx"
+```tsx filename="pages/_app.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -39,7 +39,7 @@ export default MyApp;
 </Tab>
 
 <Tab>
-```tsx copy filename="pages/privatepage.tsx"
+```tsx filename="pages/privatepage.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -63,7 +63,7 @@ function PrivatePage() {
 </Tab>
 
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,

--- a/docs/components/control/signed-in.mdx
+++ b/docs/components/control/signed-in.mdx
@@ -14,7 +14,7 @@ The `<SignedIn />` component offers authentication checks as a cross-cutting con
 ## Usage
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import "@/styles/globals.css";
 import {
   ClerkProvider,
@@ -39,7 +39,7 @@ export default MyApp;
 ```
 </Tab>
 <Tab>
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { SignedIn, ClerkProvider } from "@clerk/clerk-react";
 
 function Page() {
@@ -62,7 +62,7 @@ function Page() {
 ```
 </Tab>
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   UserButton,
@@ -87,7 +87,7 @@ export default function Index() {
 
 Below is an example of how to use `<SignedIn />` with React Router. The `<SignedIn />` component can be used as a child of a `<Route />` component to render content only to signed in users.
 
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { Routes, Route } from 'react-router-dom';
 import {
   ClerkProvider,

--- a/docs/components/control/signed-out.mdx
+++ b/docs/components/control/signed-out.mdx
@@ -13,7 +13,7 @@ The `<SignedOut />` component offers authentication checks as a cross-cutting co
 ## Usage
 <Tabs items={['Next.js', 'React', 'Remix']}>
 <Tab>
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import "@/styles/globals.css";
 import {
   ClerkProvider,
@@ -37,7 +37,7 @@ export default MyApp;
 ```
 </Tab>
 <Tab>
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { SignedOut, ClerkProvider } from "@clerk/clerk-react";
 
 function Page() {
@@ -62,7 +62,7 @@ function Page() {
 
 Below is an example of how to use `<SignedOut />` with React Router. The `<SignedOut />` component can be used as a child of a `<Route />` component to render content only to signed in users.
 
-```tsx copy filename="app.tsx"
+```tsx filename="app.tsx"
 import { Routes, Route } from 'react-router-dom';
 import {
   ClerkProvider,
@@ -93,7 +93,7 @@ function App() {
 ```
 </Tab>
 <Tab>
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,

--- a/docs/components/customization/layout.mdx
+++ b/docs/components/customization/layout.mdx
@@ -13,7 +13,7 @@ The layout key can be used to change the layout of the [`<SignIn/>`](/docs/compo
 
 ## Usage
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import { ClerkProvider } from '@clerk/nextjs';
 
 <ClerkProvider

--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -40,20 +40,20 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
 ### Usage
 
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/localizations
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/localizations
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/localizations
   ```
 </CodeBlockTabs>
 
-```tsx filename="_app.tsx" copy
+```tsx filename="_app.tsx"
 import { ClerkProvider } from "@clerk/nextjs";
 import { frFR } from "@clerk/localizations";
 import type { AppProps } from "next/app";
@@ -75,7 +75,7 @@ You can also provide your own localizations for the Clerk Components. This is us
 
 ### Usage
 
-```tsx filename="_app.tsx" copy
+```tsx filename="_app.tsx"
 import { ClerkProvider } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
 

--- a/docs/components/customization/overview.mdx
+++ b/docs/components/customization/overview.mdx
@@ -19,15 +19,15 @@ This applies to all of the React-based packages, like [Next.js](/docs/quickstart
 Clerk offers [a set of themes that can be used with the `appearance` prop](/docs/components/customization/themes). The themes are available as a package called `@clerk/themes`.
 
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/themes
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/themes
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/themes
   ```
 </CodeBlockTabs>
@@ -35,7 +35,7 @@ Clerk offers [a set of themes that can be used with the `appearance` prop](/docs
 #### Usage
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix']}>
-  ```tsx filename="app.tsx" copy
+  ```tsx filename="app.tsx"
   import { dark } from '@clerk/themes';
   import { ClerkProvider, SignIn } from '@clerk/nextjs';
   import type { AppProps } from "next/app";
@@ -55,7 +55,7 @@ Clerk offers [a set of themes that can be used with the `appearance` prop](/docs
   export default MyApp;
   ```
 
-  ```tsx filename="app.tsx" copy
+  ```tsx filename="app.tsx"
   import React from "react";
   import "./App.css";
   import { dark } from '@clerk/themes';
@@ -167,7 +167,7 @@ Using this knowledge about the publicly available classes, you can target the el
 
 Here's an example of how you can target the primary button in a Clerk component:
 
-```css filename="styles/global.css" copy
+```css filename="styles/global.css"
 .cl-formButtonPrimary {
   font-size: 14px;
   text-transform: none;
@@ -195,7 +195,7 @@ cl-formButtonPrimary cl-button 🔒️ cl-internal-1ta0xpz
 
 Remove the `cl-` prefix and use it as the key for a new object in the `elements` property. The value of this object should be the string of classes you want to apply to the element.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import { ClerkProvider, SignIn } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
 
@@ -220,7 +220,7 @@ export default MyApp;
 
 By using the method outlined above, you can use Tailwind classes to style Clerk components.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import { ClerkProvider, SignIn } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
 
@@ -250,7 +250,7 @@ CSS modules are a great way to scope your CSS to a specific component. Clerk com
 
 Simply create your Module file and add the CSS you want to apply.
 
-```css filename="styles/SignIn.module.css" copy
+```css filename="styles/SignIn.module.css"
 .primaryColor {
   background-color: bisque;
   color: black;
@@ -259,7 +259,7 @@ Simply create your Module file and add the CSS you want to apply.
 
 Then you can apply this by importing the file and using the classes whenever required:
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import styles from "../styles/SignIn.module.css";
 import { ClerkProvider, SignIn } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
@@ -285,7 +285,7 @@ export default MyApp;
 
 Using the same method for identifying elements as mentioned previously, you can pass an object of CSS properties to the `elements` property on `appearance` in your `ClerkProvider`.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import { ClerkProvider, SignIn } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
 

--- a/docs/components/customization/variables.mdx
+++ b/docs/components/customization/variables.mdx
@@ -13,7 +13,7 @@ The variables property is used to adjust the general styles of the component's b
 
 ## Usage
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import { ClerkProvider } from '@clerk/nextjs';
 
 <ClerkProvider appearance={{

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -19,7 +19,7 @@ The `<CreateOrganization />` component is used to render an organization creatio
 <Tabs items={['Next.js', 'React', 'Remix']}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="/app/create-organization/[[...create-organization]]/page.[jsx/tsx]"
+      ```jsx filename="/app/create-organization/[[...create-organization]]/page.[jsx/tsx]"
       import { CreateOrganization } from "@clerk/nextjs";
 
       export default function CreateOrganizationPage() {
@@ -27,7 +27,7 @@ The `<CreateOrganization />` component is used to render an organization creatio
       }
       ```
       
-      ```jsx copy filename="/pages/create-organization/[[...index]].[jsx/tsx]"
+      ```jsx filename="/pages/create-organization/[[...index]].[jsx/tsx]"
       import { CreateOrganization } from "@clerk/nextjs";
 
       export default function CreateOrganizationPage() {
@@ -40,7 +40,7 @@ The `<CreateOrganization />` component is used to render an organization creatio
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/create-organization.tsx"
+    ```jsx filename="/create-organization.tsx"
     import { CreateOrganization } from "@clerk/clerk-react";
 
     export default function CreateOrganizationPage() {
@@ -50,7 +50,7 @@ The `<CreateOrganization />` component is used to render an organization creatio
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/route/create-organization/$.tsx"
+    ```jsx filename="/route/create-organization/$.tsx"
     import { CreateOrganization } from "@clerk/remix";
 
     export default function CreateOrganizationPage() {

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -21,7 +21,7 @@ The `<OrganizationProfile />` component is used to render a beautiful, full-feat
     You can embed the `<OrganizationProfile />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application.
   
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="/app/organization-profile/[[...organization-profile]]/page.[jsx/tsx]"
+      ```jsx filename="/app/organization-profile/[[...organization-profile]]/page.[jsx/tsx]"
       import { OrganizationProfile } from "@clerk/nextjs";
 
       export default function OrganizationProfilePage() {
@@ -31,7 +31,7 @@ The `<OrganizationProfile />` component is used to render a beautiful, full-feat
       }
       ```
 
-      ```jsx copy filename="/pages/organization-profile/[[...index]].[jsx/tsx]"
+      ```jsx filename="/pages/organization-profile/[[...index]].[jsx/tsx]"
       import { OrganizationProfile } from "@clerk/nextjs";
 
       export default function OrganizationProfilePage() {
@@ -44,7 +44,7 @@ The `<OrganizationProfile />` component is used to render a beautiful, full-feat
   </Tab>
 
   <Tab>
-    ```jsx copy filename="organization-profile.tsx"
+    ```jsx filename="organization-profile.tsx"
     import { OrganizationProfile } from "@clerk/clerk-react";
 
     export default function OrganizationProfilePage() {
@@ -54,7 +54,7 @@ The `<OrganizationProfile />` component is used to render a beautiful, full-feat
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/pages/organization-profile/$.tsx"
+    ```jsx filename="/pages/organization-profile/$.tsx"
     import { OrganizationProfile } from "@clerk/remix";
 
     export default function OrganizationProfilePage() {

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -19,7 +19,7 @@ The `<OrganizationSwitcher />` component is used to enable the ability to switch
 <Tabs items={['Next.js', 'React', 'Remix']}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="/app/organization-switcher/[[...organization-switcher]]/page.[jsx/tsx]"
+      ```jsx filename="/app/organization-switcher/[[...organization-switcher]]/page.[jsx/tsx]"
       import { OrganizationSwitcher } from "@clerk/nextjs";
 
       export default function OrganizationSwitcherPage() {
@@ -31,7 +31,7 @@ The `<OrganizationSwitcher />` component is used to enable the ability to switch
       }
       ```
 
-      ```jsx copy filename="/pages/organization-switcher/[[...index]].[jsx/tsx]"
+      ```jsx filename="/pages/organization-switcher/[[...index]].[jsx/tsx]"
       import { OrganizationSwitcher } from "@clerk/nextjs";
 
       export default function OrganizationSwitcherPage() {
@@ -46,7 +46,7 @@ The `<OrganizationSwitcher />` component is used to enable the ability to switch
   </Tab>
 
   <Tab>
-    ```jsx copy filename="organization-switcher.tsx"
+    ```jsx filename="organization-switcher.tsx"
     import { OrganizationSwitcher } from "@clerk/clerk-react";
 
     export default function OrganizationSwitcherPage() {
@@ -60,7 +60,7 @@ The `<OrganizationSwitcher />` component is used to enable the ability to switch
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/pages/organization-switcher/$.tsx"
+    ```jsx filename="/pages/organization-switcher/$.tsx"
     import { OrganizationSwitcher } from "@clerk/remix";
 
     export default function OrganizationSwitcherPage() {

--- a/docs/components/unstyled/sign-in-button.mdx
+++ b/docs/components/unstyled/sign-in-button.mdx
@@ -12,7 +12,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
 #### Basic usage
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -25,7 +25,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignInButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -38,7 +38,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton } from "@clerk/remix";
 
   export default function Home() {
@@ -51,7 +51,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton } from "gatsby-plugin-clerk";
 
   export default function Home() {
@@ -70,7 +70,7 @@ The `<SignInButton />` component is a button that links to the sign-in page or d
 In some cases you will want to use your own button, or button text. You can do that by wrapping your button up.
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -85,7 +85,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignInButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -100,7 +100,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton } from "@clerk/remix";
 
   export default function Home() {
@@ -115,7 +115,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInButton } from "gatsby-plugin-clerk";
 
   export default function Home() {

--- a/docs/components/unstyled/sign-in-with-metamask.mdx
+++ b/docs/components/unstyled/sign-in-with-metamask.mdx
@@ -16,7 +16,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
 #### Basic usage
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -29,7 +29,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignInWithMetamaskButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -42,7 +42,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "@clerk/remix";
 
   export default function Home() {
@@ -55,7 +55,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "gatsby-plugin-clerk";
 
   export default function Home() {
@@ -74,7 +74,7 @@ The `<SignInWithMetamaskButton />` component is used to complete a one-click, cr
 In some cases you will want to use your own button, or button text. You can do that by wrapping your button up.
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -91,7 +91,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignInWithMetamaskButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -108,7 +108,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "@clerk/remix";
 
   export default function Home() {
@@ -125,7 +125,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignInWithMetamaskButton } from "gatsby-plugin-clerk";
 
   export default function Home() {

--- a/docs/components/unstyled/sign-out-button.mdx
+++ b/docs/components/unstyled/sign-out-button.mdx
@@ -14,7 +14,7 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
 <Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="app/page.js"
+      ```jsx filename="app/page.js"
       import { SignOutButton } from "@clerk/nextjs";
 
       export default function Home() {
@@ -27,7 +27,7 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
       }
       ```
 
-      ```jsx copy filename="pages/index.js"
+      ```jsx filename="pages/index.js"
       import { SignOutButton } from "@clerk/nextjs";
 
       export default function Home() {
@@ -43,7 +43,7 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
   </Tab>
 
   <Tab>
-    ```jsx copy filename="example.js"
+    ```jsx filename="example.js"
     import { SignOutButton } from "@clerk/clerk-react";
 
     export default function Example() {
@@ -58,7 +58,7 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
   </Tab>
 
   <Tab>
-    ```jsx copy filename="pages/index.js"
+    ```jsx filename="pages/index.js"
     import { SignOutButton } from "@clerk/remix";
 
     export default function Home() {
@@ -73,7 +73,7 @@ The `<SignOutButton />` component is a button that signs a user out. By default,
   </Tab>
 
   <Tab>
-    ```jsx copy filename="pages/index.js"
+    ```jsx filename="pages/index.js"
     import { SignOutButton } from "gatsby-plugin-clerk";
 
     export default function Home() {
@@ -95,7 +95,7 @@ You can create a custom button by wrapping your own button, or button text, in t
 <Tabs items={['Next.js', 'React', 'Remix', 'Gatsby']}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="app/page.js"
+      ```jsx filename="app/page.js"
       import { SignOutButton } from "@clerk/nextjs";
 
       export default function Home() {
@@ -110,7 +110,7 @@ You can create a custom button by wrapping your own button, or button text, in t
       }
       ```
 
-      ```jsx copy filename="pages/index.js"
+      ```jsx filename="pages/index.js"
       import { SignOutButton } from "@clerk/nextjs";
 
       export default function Home() {
@@ -128,7 +128,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   </Tab>
 
   <Tab>
-    ```jsx copy filename="example.js"
+    ```jsx filename="example.js"
     import { SignOutButton } from "@clerk/clerk-react";
 
     export default function Example() {
@@ -145,7 +145,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   </Tab>
 
   <Tab>
-    ```jsx copy filename="pages/index.js"
+    ```jsx filename="pages/index.js"
     import { SignOutButton } from "@clerk/remix";
 
     export default function Home() {
@@ -162,7 +162,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   </Tab>
 
   <Tab>
-    ```jsx copy filename="pages/index.js"
+    ```jsx filename="pages/index.js"
     import { SignOutButton } from "gatsby-plugin-clerk";
 
     export default function Home() {

--- a/docs/components/unstyled/sign-up-button.mdx
+++ b/docs/components/unstyled/sign-up-button.mdx
@@ -12,7 +12,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
 #### Basic usage
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignUpButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -25,7 +25,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignUpButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -38,7 +38,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignUpButton } from "@clerk/remix";
 
   export default function Home() {
@@ -51,7 +51,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignUpButton } from "gatsby-plugin-clerk";
 
   export default function Home() {
@@ -70,7 +70,7 @@ The `<SignUpButton />` component is a button that links to the sign-up page or d
 In some cases you will want to use your own button, or button text. You can do that by wrapping your button up.
 
 <CodeBlockTabs options={['Next.js', 'React', 'Remix', 'Gatsby']}>
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignUpButton } from "@clerk/nextjs";
 
   export default function Home() {
@@ -87,7 +87,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="example.js"
+  ```jsx filename="example.js"
   import { SignUpButton } from "@clerk/clerk-react";
 
   export default function Example() {
@@ -104,7 +104,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignUpButton } from "@clerk/remix";
 
   export default function Home() {
@@ -121,7 +121,7 @@ In some cases you will want to use your own button, or button text. You can do t
   }
   ```
 
-  ```jsx copy filename="pages/index.js"
+  ```jsx filename="pages/index.js"
   import { SignUpButton } from "gatsby-plugin-clerk";
 
   export default function Home() {

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -22,7 +22,7 @@ In this example, `<UserButton />` is mounted inside a header component, which is
 <Tabs items={['Next.js', 'React', 'Remix']}>
   <Tab>
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="userButtonExample.[jsx/tsx]"
+      ```jsx filename="userButtonExample.[jsx/tsx]"
       import {
         ClerkProvider,
         SignedIn,
@@ -58,7 +58,7 @@ In this example, `<UserButton />` is mounted inside a header component, which is
       export default MyApp;
       ```
 
-      ```jsx copy filename="userButtonExample.[jsx/tsx]"
+      ```jsx filename="userButtonExample.[jsx/tsx]"
       import {
         ClerkProvider,
         SignedIn,
@@ -97,7 +97,7 @@ In this example, `<UserButton />` is mounted inside a header component, which is
   </Tab>
 
   <Tab>
-    ```tsx filename="app.tsx" copy
+    ```tsx filename="app.tsx"
     import {
       ClerkProvider,
       SignedIn,
@@ -168,7 +168,7 @@ In this example, `<UserButton />` is mounted inside a header component, which is
   </Tab>
 
   <Tab>
-    ```tsx filename="router/index.tsx" copy
+    ```tsx filename="router/index.tsx"
     import {
       UserButton,
     } from "@clerk/remix";

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -22,7 +22,7 @@ The `<UserProfile />` component is used to render a beautiful, full-featured acc
     You can embed the `<UserProfile />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application.
 
     <CodeBlockTabs options={["App Router", "Pages Router"]}>
-      ```jsx copy filename="/app/user-profile/[[...user-profile]]/page.tsx"
+      ```jsx filename="/app/user-profile/[[...user-profile]]/page.tsx"
       import { UserProfile } from "@clerk/nextjs";
 
       const UserProfilePage = () => (
@@ -32,7 +32,7 @@ The `<UserProfile />` component is used to render a beautiful, full-featured acc
       export default UserProfilePage;
       ```
 
-      ```jsx copy filename="/pages/user-profile/[[...index]].tsx"
+      ```jsx filename="/pages/user-profile/[[...index]].tsx"
       import { UserProfile } from "@clerk/nextjs";
 
       const UserProfilePage = () => (
@@ -45,7 +45,7 @@ The `<UserProfile />` component is used to render a beautiful, full-featured acc
   </Tab>
 
   <Tab>
-    ```jsx copy filename="/user-profile.tsx"
+    ```jsx filename="/user-profile.tsx"
     import { UserProfile } from "@clerk/clerk-react";
 
     const UserProfilePage = () => (
@@ -57,7 +57,7 @@ The `<UserProfile />` component is used to render a beautiful, full-featured acc
   </Tab>
 
   <Tab>
-    ```tsx filename="routes/user/$.tsx" copy
+    ```tsx filename="routes/user/$.tsx"
     import { UserProfile } from "@clerk/remix";
 
     export default function UserProfilePage() {

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -37,7 +37,7 @@ A successful sign-up consists of the following steps:
 
 <Tab>
 <CodeBlockTabs options={['Pages Router', 'App Router']}>
-```tsx copy filename="pages/sign-up/[[...index]].tsx"
+```tsx filename="pages/sign-up/[[...index]].tsx"
 import { useState } from "react";
 import { useSignUp } from "@clerk/nextjs";
 import { useRouter } from "next/router";
@@ -130,7 +130,7 @@ export default function SignUpForm() {
   );
 }
 ```
-```tsx copy filename="app/sign-up/[[...sign-up]].page.tsx"
+```tsx filename="app/sign-up/[[...sign-up]].page.tsx"
 "use client"
 import { useState } from "react";
 import { useSignUp } from "@clerk/nextjs";
@@ -228,7 +228,7 @@ export default function SignUpForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="signup.tsx"
+```tsx filename="signup.tsx"
 import { useState } from "react";
 import { useSignUp } from "@clerk/clerk-react";
 
@@ -321,7 +321,7 @@ export default function SignUpForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="app/routes/sign-up/$.tsx"
+```tsx filename="app/routes/sign-up/$.tsx"
 import { useState } from "react";
 import { useSignUp } from "@clerk/remix";
 
@@ -415,7 +415,7 @@ export default function SignUpForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="sign-up.tsx"
+```tsx filename="sign-up.tsx"
 import { useState } from "react";
 // Use the react package when using Gatsby
 import { useSignUp } from "@clerk/react";
@@ -512,7 +512,7 @@ export default function SignUpForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="SignUpScreen.tsx"
+```tsx filename="SignUpScreen.tsx"
 import * as React from "react";
 import { Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSignUp } from "@clerk/clerk-expo";
@@ -613,7 +613,7 @@ export default function SignUpScreen() {
 </Tab>
 
 <Tab>
-```html copy filename="your-app.html"
+```html filename="your-app.html"
 <!DOCTYPE html>
 <html lang="en">
 
@@ -693,7 +693,7 @@ In email/password authentication, the sign-in is a process that requires users t
 
 <Tab>
 <CodeBlockTabs options={['Pages Router', 'App Router']}>
-```tsx copy filename="pages/sign-in/[[...index]].tsx"
+```tsx filename="pages/sign-in/[[...index]].tsx"
 import { useState } from "react";
 import { useSignIn } from "@clerk/nextjs";
 import { useRouter } from "next/router";
@@ -748,7 +748,7 @@ export default function SignInForm() {
   );
 }
 ```
-```tsx copy filename="app/sign-in/[[...sign-in]].page.tsx"
+```tsx filename="app/sign-in/[[...sign-in]].page.tsx"
 "use client"
 import { useState } from "react";
 import { useSignIn } from "@clerk/nextjs";
@@ -808,7 +808,7 @@ export default function SignInForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="signin.tsx"
+```tsx filename="signin.tsx"
 import { useState } from "react";
 import { useSignIn } from "@clerk/clerk-react";
 
@@ -863,7 +863,7 @@ export default function SignInForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="app/routes/sign-in/$.tsx"
+```tsx filename="app/routes/sign-in/$.tsx"
 import { useState } from "react";
 import { useSignIn } from "@clerk/remix";
 
@@ -918,7 +918,7 @@ export default function SignInForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="sign-in.tsx"
+```tsx filename="sign-in.tsx"
 import { useState } from "react";
 // Use React for Gatsby
 import { useSignIn } from "@clerk/clerk-react";
@@ -974,7 +974,7 @@ export default function SignInForm() {
 </Tab>
 
 <Tab>
-```tsx copy filename="SignUpScreen.tsx"
+```tsx filename="SignUpScreen.tsx"
 import React from "react";
 import { Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSignIn } from "@clerk/clerk-expo";
@@ -1038,7 +1038,7 @@ export default function SignInScreen() {
 </Tab>
 
 <Tab>
-```html copy filename="your-app.html"
+```html filename="your-app.html"
 <!DOCTYPE html>
 <html lang="en">
 

--- a/docs/deployments/migrate-from-firebase.mdx
+++ b/docs/deployments/migrate-from-firebase.mdx
@@ -23,7 +23,7 @@ Migrating your user base from Firebase to Clerk is a 2-part process that can be 
 
 If you haven't already, install the Firebase CLI:
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 npm install -g firebase-tools
 ```
 
@@ -31,7 +31,7 @@ npm install -g firebase-tools
 
 Login into your Firebase account via the CLI.
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 firebase login
 ```
 
@@ -39,7 +39,7 @@ firebase login
 
 Use the firebase CLI to list your projects and find the project ID you want to export.
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 firebase projects:list
 ```
 
@@ -47,7 +47,7 @@ firebase projects:list
 
 Use the firebase CLI to export your users to a JSON file.
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 firebase auth:export firebase-users.json --format=json --project <YOUR_PROJECT_ID>
 ```
 
@@ -77,18 +77,18 @@ Now you have all the information you need to import your Firebase users into Cle
 
 #### init npm
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 npm init -y
 ```
 
 #### Install dependencies
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 node-fetch@2
 ```
 
 #### Create a script
-```js filename="terminal/migrate-to-clerk.js" copy
+```js filename="terminal/migrate-to-clerk.js"
 const fetch = require('node-fetch')
 const firebaseUsers = require('./firebase-users.json')
 
@@ -145,7 +145,7 @@ Here, body will either hold the necessary information to migrate a password-base
 
 ### Run the script
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 node migrate-to-clerk.js
 ```
 

--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -75,7 +75,7 @@ Clerk uses a DNS check to validate this CNAME record. If this subdomain is rever
 
 If you accidently set the wrong domain, you can change it by using our backend API. You can find the Secret key in the settings page of your production instance. You can then use the following curl command to change the domain:
 
-```bash copy
+```bash
 curl -XPOST -H 'Authorization: CLERK-SECRET-KEY' -H "Content-type: application/json" -d '{
 "home_url": "https://www.example.com"
 }' 'https://api.clerk.com/v1/instance/change_domain'

--- a/docs/organizations/managing-roles.mdx
+++ b/docs/organizations/managing-roles.mdx
@@ -18,7 +18,7 @@ Methods for [changing a member's role](/docs/references/backend/organization/upd
 {/* TODO (DOCS-316): Update and validate these examples. */}
 
 <CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
-```tsx filename="pages/organizations/[id].ts" copy
+```tsx filename="pages/organizations/[id].ts"
 import { useState, useEffect } from "react";
 import { useOrganization } from "@clerk/nextjs";
 import type { OrganizationMembershipResource } from "@clerk/types";

--- a/docs/organizations/viewing-memberships.mdx
+++ b/docs/organizations/viewing-memberships.mdx
@@ -20,7 +20,7 @@ You can use the `getOrganizationMembershipList()` method to retrieve a list of m
 {/* TODO (DOCS-316): Update and validate these code examples. */}
 
 <CodeBlockTabs options={["Next.js", "React", "JavaScript"]}>
-```tsx filename="pages/joined-organizations.tsx" copy
+```tsx filename="pages/joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
  
@@ -63,7 +63,7 @@ const JoinedOrganizationList = () => {
 export default JoinedOrganizationList;
 ```
 
-```tsx filename="joined-organizations.tsx" copy
+```tsx filename="joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
  
@@ -106,7 +106,7 @@ const JoinedOrganizationList = () => {
 export default JoinedOrganizationList;
 ```
 
-```js filename="joined-organizations.js" copy
+```js filename="joined-organizations.js"
 <ul id="organizations_list"></ul>
 
 <script>

--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -20,15 +20,15 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 Once you have a Expo application ready, you need to install Clerk's Expo SDK.
 
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/clerk-expo
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/clerk-expo
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/clerk-expo
   ```
 </CodeBlockTabs>
@@ -37,7 +37,7 @@ Once you have a Expo application ready, you need to install Clerk's Expo SDK.
 
 Below is an example of an `app.config.js` file. To get your keys, go to the API Keys page on the [Clerk dashboard](https://dashboard.clerk.com).
 
-```sh copy filename="app.config.js"
+```sh filename="app.config.js"
 module.exports = {
   name: 'MyApp',
   version: '1.0.0',
@@ -56,7 +56,7 @@ module.exports = {
 
 Update your app entry file to include the `<ClerkProvider />` wrapper. The `<ClerkProvider />` component wraps your Expo application to provide active session and user context to Clerk's hooks and other components. It is recommended that the `<ClerkProvider />` wraps everything else to enable the context to be accessible anywhere within the app.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider } from "@clerk/clerk-expo";
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 Clerk offers Control Components that allow you to protect your pages. In the example below, [`<SignedIn />`](/docs/components/control/signed-in) and [`<SignedOut />`](/docs/components/control/signed-out) control components are used.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
@@ -127,7 +127,7 @@ Using expo requires you to create custom flows. Our quickstart guide shows you h
 
 The examples below use email and password to sign a user up. You will notice that there is a conditonal flow in the sign up page for verifying a code called `pendingVerification`. This is an important step, as it verifies that the user owns their email.
 
-```tsx filename="components/SignUpScreen.tsx" copy
+```tsx filename="components/SignUpScreen.tsx"
 import * as React from "react";
 import { Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSignUp } from "@clerk/clerk-expo";
@@ -232,7 +232,7 @@ export default function SignUpScreen() {
 
 Make sure you update your `app` file to use the component that you have created. To keep it simple, this example adds the `<SignUpScreen />` to the `<SignedOut />` component.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
@@ -265,7 +265,7 @@ const styles = StyleSheet.create({
 
 ### Build your sign in
 
-```tsx filename="components/SignInScreen.tsx" copy
+```tsx filename="components/SignInScreen.tsx"
 import React from "react";
 import { Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useSignIn } from "@clerk/clerk-expo";
@@ -327,7 +327,7 @@ export default function SignInScreen() {
 
 Make sure you update your `app` file to use the component that you have created. In the `<SignedOut />` component, replace the `<SignUpScreen />` with the `<SignInScreen />`.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
@@ -362,7 +362,7 @@ const styles = StyleSheet.create({
 
 If you want to add OAuth login flows to your Expo application, Clerk's OAuth hook allows you to handle both sign in and sign up in a single flow.
 
-```tsx filename="hooks/warmUpBrowser.tsx"" copy
+```tsx filename="hooks/warmUpBrowser.tsx"
 import React from "react";
 import * as WebBrowser from "expo-web-browser";
 
@@ -376,7 +376,7 @@ export const useWarmUpBrowser = () => {
 };
 ```
 
-```tsx filename="components/SignInWithOAuth.tsx" copy
+```tsx filename="components/SignInWithOAuth.tsx"
 import React from "react";
 import * as WebBrowser from "expo-web-browser";
 import { Button } from "react-native";
@@ -423,7 +423,7 @@ export default SignInWithOAuth;
 
 Make sure you update your `app` file to use the component that you have created. Replace the `<SignInScreen />` with the `<SignInWithOAuth />` to the `<SignedOut />` component.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
@@ -465,22 +465,22 @@ You can use it as your client JWT storage by setting the `tokenCache` prop in yo
 #### Install expo-secure-store
 
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install expo-secure-store
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add expo-secure-store
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add install expo-secure-store
   ```
 </CodeBlockTabs>
 
 ***
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
@@ -537,7 +537,7 @@ const styles = StyleSheet.create({
 
 To sign a user out, you can use the `signOut` method from the `useAuth` hook. This will remove the JWT from the token cache and remove the session.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import { SafeAreaView, Text, StyleSheet, View, Button } from "react-native";
 import { ClerkProvider, SignedIn, SignedOut,useAuth } from "@clerk/clerk-expo";
@@ -616,7 +616,7 @@ Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) tha
 
 The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx copy filename="components/UseAuthExample.tsx"
+```tsx filename="components/UseAuthExample.tsx"
 import { useAuth } from "@clerk/clerk-expo";
 import { Text } from "react-native";
 
@@ -640,7 +640,7 @@ export default function UseAuthExample() {
 
 The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx copy filename="components/UseUserExample.tsx"
+```tsx filename="components/UseUserExample.tsx"
 import { useUser } from "@clerk/clerk-expo";
 import { Text } from "react-native";
 

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -25,15 +25,15 @@ If you're looking for a more complete example, check out our [Fastify example ap
 ### Install `@clerk/fastify`
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/fastify
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/fastify
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/fastify
   ```
 </CodeBlockTabs>
@@ -45,7 +45,7 @@ Below is an example of an `.env` file. If you are signed into your Clerk Dashboa
 
 <InjectKeys>
 
-```sh copy filename=".env"
+```sh filename=".env"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
@@ -55,18 +55,18 @@ CLERK_SECRET_KEY={{secret}}
 This examples uses `dontenv` to load the environment variables. You can use any other library or method, if you so wish.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @dotenv
   npm install -D types/dotenv
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/fastify
   yarn add -D types/dotenv
   ```
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/fastify
   pnpm add -D types/dotenv
   ```
@@ -76,7 +76,7 @@ This examples uses `dontenv` to load the environment variables. You can use any 
 
 The Clerk plugin can be registered globally or for specific routes. This examples registers the plugin globally.
 
-```ts filename="index.ts" copy
+```ts filename="index.ts"
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -104,7 +104,7 @@ start();
 
 The `getAuth` helper can be used to access the auth state of the current request.
 
-```ts filename="index.ts" copy
+```ts filename="index.ts"
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -143,7 +143,7 @@ start();
 
 To protect a route using Clerk, you can use `getAuth` to check if the user is authenticated. If the user is not authenticated, you can return a 403 error.
 
-```ts filename="index.ts" copy
+```ts filename="index.ts"
 fastify.get("/protected", async (request, reply) => {
   const { userId } = getAuth(request);
   if (!userId) {
@@ -161,7 +161,7 @@ fastify.get("/protected", async (request, reply) => {
 If you want to use Clerk for specific routes only, you can register the plugin for specific routes. In this example, the routes are split into two groups: one for public routes and one for private routes.
 
 
-```ts filename="index.ts" copy
+```ts filename="index.ts"
 import * as dotenv from "dotenv";
 
 dotenv.config();

--- a/docs/quickstarts/gatsby.mdx
+++ b/docs/quickstarts/gatsby.mdx
@@ -18,15 +18,15 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 Once you have a React application ready, you need to install Clerk's React SDK. This gives you access to our prebuilt components and hooks for React applications.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install gatsby-plugin-clerk
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add gatsby-plugin-clerk
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add gatsby-plugin-clerk
   ```
 </CodeBlockTabs>
@@ -37,7 +37,7 @@ Below is an example of your `.env.development` file. If you are signed into your
 
 <InjectKeys>
 
-```sh copy filename=".env.development"
+```sh filename=".env.development"
 GATSBY_CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
@@ -48,7 +48,7 @@ CLERK_SECRET_KEY={{secret}}
 
 To use Clerk, you will need to update your `gatsby-config.ts` in order to resolve `gatsby-plugin-clerk` and load from `.env` files.
 
-```ts filename="gatsby-config.ts" copy
+```ts filename="gatsby-config.ts"
 import type { GatsbyConfig } from "gatsby"
 
 require("dotenv").config({
@@ -74,7 +74,7 @@ export default config
 
 Clerk offers [Control Components](/docs/components/overview) that allow you to protect your pages. These components are used to control the visibility of your pages based on the user's authentication state.
 
-```tsx filename="src/pages/index.tsx" copy
+```tsx filename="src/pages/index.tsx"
 import React from 'react'
 import {
   SignIn,
@@ -107,7 +107,7 @@ Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) tha
 
 The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx copy filename="src/pages/example.tsx"
+```tsx filename="src/pages/example.tsx"
 import { useAuth } from "gatsby-plugin-clerk";
 
 export default function Example() {
@@ -130,7 +130,7 @@ export default function Example() {
 
 The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx copy filename="src/pages/example.tsx"
+```tsx filename="src/pages/example.tsx"
 import { useUser } from "gatsby-plugin-clerk";
 
 export default function Example() {
@@ -146,7 +146,7 @@ export default function Example() {
 
 ### SSR usage
 
-```tsx copy filename="src/pages/SSRPage.tsx"
+```tsx filename="src/pages/SSRPage.tsx"
 import * as React from 'react';
 import { GetServerData } from 'gatsby';
 import { withServerAuth } from 'gatsby-plugin-clerk/ssr';

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -28,15 +28,15 @@ To use the ClerkJS package, you have two options:
 At the root of your project, install the ClerkJS package using your package manager of choice:
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/clerk-js
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/clerk-js
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/clerk-js
   ```
 </CodeBlockTabs>
@@ -65,7 +65,7 @@ To use the ClerkJS package, you'll need an [API Key and frontend API URL from th
 
 <InjectKeys>
 
-```sh copy filename=".env.local"
+```sh filename=".env.local"
 REACT_APP_CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_FRONTEND_API=[your-domain].clerk.accounts.dev
 ```
@@ -79,7 +79,7 @@ CLERK_FRONTEND_API=[your-domain].clerk.accounts.dev
 To use the ClerkJS package, you'll need to initialize the Clerk class with your frontend API URL and publishable key.
 
 <CodeBlockTabs options={['npm Package', 'script Tag']}>
-```js copy filename="index.js"
+```js filename="index.js"
 import Clerk from '@clerk/clerk-js';
 
 const clerkFrontendApi = `pk_{{pub_key}}`;
@@ -89,7 +89,7 @@ await clerk.load({
 });
 ```
 
-```html copy filename="index.html"
+```html filename="index.html"
 <script>
   const clerkFrontendApi = `pk_{{pub_key}}`;
   const frontendApi = '[your-domain].clerk.accounts.dev';

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -14,15 +14,15 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 Once you have a Next.js application ready, you need to install Clerk's Next.js SDK. This gives you access to prebuilt components and hooks, as well as [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and middleware.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/nextjs
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/nextjs
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/nextjs
   ```
 </CodeBlockTabs>
@@ -33,7 +33,7 @@ Below is an example of an `.env.local` file. If you are signed into your Clerk D
 
 <InjectKeys>
 
-```sh copy filename=".env.local"
+```sh filename=".env.local"
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
@@ -53,7 +53,7 @@ Add the [`<ClerkProvider />`](/docs/components/clerk-provider) wrapper to your a
 </Callout>
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
-```tsx copy filename="app/layout.tsx"
+```tsx filename="app/layout.tsx"
 import { ClerkProvider } from '@clerk/nextjs'
 
 export const metadata = {
@@ -75,7 +75,7 @@ export default function RootLayout({
 }
 ```
 
-```tsx filename="_app.tsx" copy
+```tsx filename="_app.tsx"
 import { ClerkProvider } from "@clerk/nextjs";
 import type { AppProps } from "next/app";
 function MyApp({ Component, pageProps }: AppProps) {
@@ -97,7 +97,7 @@ export default MyApp;
 
 Now that Clerk is installed and mounted in your application, it’s time to decide which pages are public and which need to hide behind authentication. We do this by creating a `middleware.ts` file at the root folder (or inside `src/` if that is how you set up your app).
 
-```tsx filename="middleware.ts" copy
+```tsx filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
 
 // This example protects all routes including api/trpc routes
@@ -129,7 +129,7 @@ In addition to the Account Portal, Clerk also offers a set of [prebuilt componen
 
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
-  ```tsx copy filename="app/sign-up/[[...sign-up]]/page.tsx"
+  ```tsx filename="app/sign-up/[[...sign-up]]/page.tsx"
   import { SignUp } from "@clerk/nextjs";
 
   export default function Page() {
@@ -137,7 +137,7 @@ In addition to the Account Portal, Clerk also offers a set of [prebuilt componen
   }
   ```
 
-  ```tsx copy filename="/pages/sign-up/[[...index]].tsx"
+  ```tsx filename="/pages/sign-up/[[...index]].tsx"
   import { SignUp } from "@clerk/nextjs";
 
   export default function Page() {
@@ -150,7 +150,7 @@ In addition to the Account Portal, Clerk also offers a set of [prebuilt componen
 
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
-  ```tsx copy filename="app/sign-in/[[...sign-in]]/page.tsx"
+  ```tsx filename="app/sign-in/[[...sign-in]]/page.tsx"
   import { SignIn } from "@clerk/nextjs";
 
   export default function Page() {
@@ -158,7 +158,7 @@ In addition to the Account Portal, Clerk also offers a set of [prebuilt componen
   }
   ```
 
-  ```tsx copy filename="/pages/sign-in/[[...index]].tsx"
+  ```tsx filename="/pages/sign-in/[[...index]].tsx"
   import { SignIn } from "@clerk/nextjs";
 
   export default function Page() {
@@ -176,7 +176,7 @@ In addition to the Account Portal, Clerk also offers a set of [prebuilt componen
 
 Next, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
 
-```sh copy filename=".env.local"
+```sh filename=".env.local"
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
@@ -192,7 +192,7 @@ The [`<UserButton />`](/docs/components/user/user-button) allows users to manage
 You can add it anywhere you want, but next to the logo in your main application page is a good start.
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
-```tsx copy filename="app/page.tsx"
+```tsx filename="app/page.tsx"
 import { UserButton } from "@clerk/nextjs";
 
 export default function Home() {
@@ -204,7 +204,7 @@ export default function Home() {
 }
 ```
 
-```tsx copy filename="pages/example.tsx"
+```tsx filename="pages/example.tsx"
 import { UserButton } from "@clerk/nextjs";
 
 export default function Example() {
@@ -236,7 +236,7 @@ Clerk provides a set of [hooks and helpers](/docs/references/nextjs/overview#cli
 
 The [`useAuth`](/docs/references/react/use-auth) hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx copy filename="example.tsx"
+```tsx filename="example.tsx"
 "use client";
 import { useAuth } from "@clerk/nextjs";
 
@@ -260,7 +260,7 @@ export default function Example() {
 
 The [`useUser`](/docs/references/react/use-user) hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx copy filename="example.tsx"
+```tsx filename="example.tsx"
 "use client";
 import { useUser } from "@clerk/nextjs";
 
@@ -281,7 +281,7 @@ export default function Example() {
 
 You can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
 
-```tsx copy filename="pages/api/auth.ts"
+```tsx filename="pages/api/auth.ts"
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getAuth } from "@clerk/nextjs/server";
 
@@ -299,7 +299,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 In some cases, you may need the full [`User`](/docs/references/javascript/user/user) object. For example, if you want to access the user's email address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full `User` object.
 
 
-```tsx copy filename="pages/api/auth.ts"
+```tsx filename="pages/api/auth.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -332,7 +332,7 @@ export default async function handler(
 
     Under the hood, this calls `fetch()` so it is automatically deduped per request.
 
-    ```tsx copy filename="page.tsx"
+    ```tsx filename="page.tsx"
     import { currentUser } from "@clerk/nextjs";
     import type { User } from "@clerk/nextjs/api";
 
@@ -348,7 +348,7 @@ export default async function handler(
 
     Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
 
-    ```tsx copy filename="app/page.tsx"
+    ```tsx filename="app/page.tsx"
     import { auth } from "@clerk/nextjs";
 
     export default function Page() {
@@ -365,7 +365,7 @@ export default async function handler(
       Please note the addition of buildClerkProps in the return statement, which informs our React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
     </Callout>
 
-    ```tsx copy filename="pages/example.tsx"
+    ```tsx filename="pages/example.tsx"
     import { getAuth, buildClerkProps } from "@clerk/nextjs/server";
     import { GetServerSideProps } from "next";
 
@@ -383,7 +383,7 @@ export default async function handler(
 
     You can also access the full user object before passing it to the page using the `clerkClient` helper.
 
-    ```tsx copy filename="pages/example.tsx"
+    ```tsx filename="pages/example.tsx"
     import { clerkClient } from "@clerk/nextjs";
     import { getAuth, buildClerkProps } from "@clerk/nextjs/server";
     import { GetServerSideProps } from "next";

--- a/docs/quickstarts/react.mdx
+++ b/docs/quickstarts/react.mdx
@@ -21,15 +21,15 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 Once you have a React application ready, you need to install Clerk's React SDK. This gives you access to our prebuilt components and hooks for React applications.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/clerk-react
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/clerk-react
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/clerk-react
   ```
 </CodeBlockTabs>
@@ -40,7 +40,7 @@ Below is an example of an .env file. If you are signed into your Clerk Dashboard
 
 <InjectKeys>
 
-```sh copy filename=".env"
+```sh filename=".env"
 REACT_APP_CLERK_PUBLISHABLE_KEY={{pub_key}}
 ```
 
@@ -50,7 +50,7 @@ REACT_APP_CLERK_PUBLISHABLE_KEY={{pub_key}}
 
 Clerk requires your React application to be wrapped in the [`<ClerkProvider />`](/docs/components/clerk-provider) component. The `<ClerkProvider />` component provides active session and user context to Clerk's hooks and other components.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import "./App.css";
 import { ClerkProvider } from "@clerk/clerk-react";
@@ -75,7 +75,7 @@ export default App;
 
 Clerk offers [Control Components](/docs/components/overview) that allow you to protect your pages. These components are used to control the visibility of your pages based on the user's authentication state.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import React from "react";
 import "./App.css";
 import {
@@ -123,7 +123,7 @@ Start your React application via `npm run start`, visit `http://localhost:3000`,
 
 Clerk can work with any routing library. Below is an example of how to use Clerk with React Router and how to embed the Clerk components in your application.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import {
   ClerkProvider,
   SignedIn,
@@ -214,7 +214,7 @@ Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) tha
 
 The [`useAuth`](/docs/references/react/use-auth) hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx copy filename="pages/example.tsx"
+```tsx filename="pages/example.tsx"
 import { useAuth } from "@clerk/clerk-react";
 
 export default function Example() {
@@ -237,7 +237,7 @@ export default function Example() {
 
 The [`useUser`](/docs/references/react/use-user) hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx copy filename="pages/example.tsx"
+```tsx filename="pages/example.tsx"
 import { useUser } from "@clerk/clerk-react";
 
 export default function Example() {

--- a/docs/quickstarts/redwood.mdx
+++ b/docs/quickstarts/redwood.mdx
@@ -16,7 +16,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 <Steps>
 ### Create a RedwoodJS application
 
-```sh filename="terminal" copy
+```sh filename="terminal"
 yarn create redwood-app my-redwood-project --typescript
 ```
 
@@ -26,7 +26,7 @@ Below is an example of an .env file. If you are signed into your Clerk Dashboard
 
 <InjectKeys>
 
-```sh copy filename=".env"
+```sh filename=".env"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
@@ -35,7 +35,7 @@ CLERK_SECRET_KEY={{secret}}
 
 #### Update redwood.toml
 
-```toml copy filename="redwood.toml"
+```toml filename="redwood.toml"
 [web]
   includeEnvironmentVariables = ['CLERK_PUBLISHABLE_KEY']
 ```
@@ -44,7 +44,7 @@ CLERK_SECRET_KEY={{secret}}
 
 The next step is to run a Redwood CLI command to install the required packages and generate some boilerplate code:
 
-```sh copy filename="my-redwood-project"
+```sh filename="my-redwood-project"
 yarn rw setup auth clerk --force
 ```
 
@@ -58,7 +58,7 @@ You can now access Clerk functions through the Redwood `useAuth()` hook, which i
 
 Below is an example of using the `useAuth` hook to verify if the user is authenticated. This will open a modal for your user to sign in to their account.
 
-```tsx filename="index.tsx" copy
+```tsx filename="index.tsx"
 import { useAuth } from '../../auth'
 
 const HomePage = () => {
@@ -81,7 +81,7 @@ export default HomePage
 
 ### Using Clerk components directly
 
-```tsx filename="index.tsx" copy
+```tsx filename="index.tsx"
 import { SignInButton, UserButton } from '@clerk/clerk-react'
 import { useAuth } from '../../auth'
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -13,15 +13,15 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 Once you have a Remix application ready, you need to install Clerk's Remix SDK. This gives you access to our prebuilt components and hooks for Remix applications.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/remix
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/remix
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/remix
   ```
 </CodeBlockTabs>
@@ -32,7 +32,7 @@ Below is an example of an `.env` file. If you are signed into your Clerk Dashboa
 
 <InjectKeys>
 
-```sh copy filename=".env"
+```sh filename=".env"
 CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
@@ -43,7 +43,7 @@ CLERK_SECRET_KEY={{secret}}
 
 To configure Clerk in your Remix application, you will need to update your root loader. This will enable you to have access to authentication state in any Remix routes.
 
-```tsx filename="app.tsx" copy
+```tsx filename="app.tsx"
 import type { MetaFunction,LoaderFunction } from "@remix-run/node";
 import {
   Links,
@@ -84,7 +84,7 @@ export default function App() {
 
 If you need to load in additonal data, you can pass your loader directly to the `rootAuthLoader`.
 
-```tsx filename="app/root.tsx" copy
+```tsx filename="app/root.tsx"
 // Imports
 
 
@@ -156,7 +156,7 @@ Clerk uses short lived tokens to keep your application secure. To refresh expire
   If you are seeing a 401 after a short period of time, even though your user is logged in, please verify you have implemented this section.
 </Callout>
 
-```tsx filename="app/root.tsx" copy
+```tsx filename="app/root.tsx"
 import type { MetaFunction,LoaderFunction } from "@remix-run/node";
 
 import {
@@ -205,7 +205,7 @@ export default ClerkApp(App);
 
 If you need to add a custom boundary to your application, you can pass it as an argument to the `V2_ClerkErrorBoundary`.
 
-```tsx filename="app/root.tsx" copy
+```tsx filename="app/root.tsx"
 // Imports
 
 // YourBoundary is passed as an argument to V2_ClerkErrorBoundary
@@ -218,7 +218,7 @@ export const ErrorBoundary = V2_ClerkErrorBoundary(YourBoundary);
 
 If you have not set the `v2_errorBoundary` future flag to `true`, use the `ClerkCatchBoundary` instead.
 
-```ts filename="app/root.tsx" copy
+```ts filename="app/root.tsx"
 export const CatchBoundary = ClerkCatchBoundary();
 ```
 
@@ -230,7 +230,7 @@ The functionality of the components are controlled by the instance settings you 
 
 #### Build your sign-up page
 
-```tsx filename="app/routes/sign-up.$.tsx" copy
+```tsx filename="app/routes/sign-up.$.tsx"
 import { SignUp } from "@clerk/remix";
 
 export default function SignUpPage() {
@@ -245,7 +245,7 @@ export default function SignUpPage() {
 
 #### Build your sign-in page
 
-```tsx filename="app/routes/sign-in.$.tsx" copy
+```tsx filename="app/routes/sign-in.$.tsx"
 import { SignIn } from "@clerk/remix";
 
 export default function SignInPage() {
@@ -262,7 +262,7 @@ export default function SignInPage() {
 
 Next, add environment variables for the `signIn`, `signUp`, `afterSignUp`, and `afterSignIn` paths:
 
-```sh copy filename=".env"
+```sh filename=".env"
 CLERK_SIGN_IN_URL=/sign-in
 CLERK_SIGN_UP_URL=/sign-up
 CLERK_AFTER_SIGN_IN_URL=/
@@ -277,7 +277,7 @@ These values control the behavior of the components when you sign in or sign up 
 
 Clerk offers [Control Components](/docs/components/overview) that allow you to protect your pages. These components are used to control the visibility of your pages based on the user's authentication state.
 
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import {
   SignedIn,
   SignedOut,
@@ -305,7 +305,7 @@ export default function Index() {
 
 To protect your routes, you can use the the loader to check for the `userId` singleton. If it doesn't exist, redirect your user back to the sign-in page.
 
-```tsx filename="routes/index.tsx" copy
+```tsx filename="routes/index.tsx"
 import { UserButton } from "@clerk/remix";
 import { getAuth } from "@clerk/remix/ssr.server";
 import { LoaderFunction, redirect } from "@remix-run/node";
@@ -339,7 +339,7 @@ Clerk provides a set of [hooks and helpers](/docs/references/react/use-user) tha
 
 The `useAuth` hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-```tsx copy filename="routes/example.tsx"
+```tsx filename="routes/example.tsx"
 import { useAuth } from "@clerk/remix";
 
 export default function Example() {
@@ -362,7 +362,7 @@ export default function Example() {
 
 The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
-```tsx copy filename="routes/example.tsx"
+```tsx filename="routes/example.tsx"
 import { useUser } from "@clerk/remix";
 
 export default function Example() {
@@ -382,7 +382,7 @@ export default function Example() {
 
 The `getAuth` hook allows you to retrieve auth state and also provides ways to fetch data using the `getToken` function.
 
-```tsx filename="routes/example.tsx" copy
+```tsx filename="routes/example.tsx"
 export const loader: LoaderFunction = async (args) => {
   // Using getAuth to retrieve data as needed.
   const { userId, sessionId, getToken } = await getAuth(args);
@@ -400,7 +400,7 @@ export const loader: LoaderFunction = async (args) => {
 
 #### Retrieve full user
 
-```tsx filename="routes/example.tsx" copy
+```tsx filename="routes/example.tsx"
 import { LoaderFunction, redirect } from "@remix-run/node";
 import { getAuth } from "@clerk/remix/ssr.server";
 import { createClerkClient } from '@clerk/remix/api.server';

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -20,15 +20,15 @@ There are two ways you can include ClerkJS in your project. You can either [impo
 ### Install ClerkJS as ES module
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/clerk-js
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/clerk-js
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/clerk-js
   ```
 </CodeBlockTabs>

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -9,7 +9,7 @@ The `authMiddleware()` helper integrates Clerk authentication into your Next.js 
 
 ## Usage
 
-```ts filename="middleware.ts" copy
+```ts filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
 
 export default authMiddleware();
@@ -25,7 +25,7 @@ With the recommended matcher, all routes are protected by Clerk's authentication
 
 Some developers will need to handle specific cases such as handling redirects differently or detecting if a user is inside an organization. These cases can be handled with `afterAuth()`.
 
-```ts filename="middleware.ts" copy
+```ts filename="middleware.ts"
 import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
 
 export default authMiddleware({
@@ -47,7 +47,7 @@ export default authMiddleware({
 
 If you need additional middleware handlers to execute before Clerk's authentication middleware, use `beforeAuth()`. An example where the middleware handler from `next-intl` is executed can be seen below.
 
-```ts filename="middleware.ts" copy
+```ts filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
 
 import createMiddleware from "next-intl/middleware";
@@ -77,7 +77,7 @@ export const config = {
 
 By default, Clerk's `authMiddleware()` treats all routes as private if the middleware runs. If you need to make specific routes public, use the `publicRoutes` option.
 
-```ts filename="middleware.ts" copy
+```ts filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware({
   // "/" will be accessible to all users

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -9,7 +9,7 @@ The `auth` helper returns the [`Authentication` object](/docs/references/nextjs/
 
 ## Retrieving userId
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { auth } from '@clerk/nextjs';
 
 export default function Page() {
@@ -22,7 +22,7 @@ const { userId } : { userId: string | null } = auth();
 
 When using a Clerk integration, or if you need to send a JWT along to a server, you can use the `getToken` function.
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs';
 
@@ -42,7 +42,7 @@ export async function GET() {
 
 In some cases, you need to check your user's current organization role before displaying data or allowing certain actions to be performed.
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { auth } from '@clerk/nextjs';
 
 export default async function Page() {

--- a/docs/references/nextjs/build-clerk-props.mdx
+++ b/docs/references/nextjs/build-clerk-props.mdx
@@ -14,7 +14,7 @@ Clerk uses `buildClerkProps` to inform the client side helpers of the authentica
 
 #### Basic usage
 
-```tsx filename="pages/myServerSidePage" copy
+```tsx filename="pages/myServerSidePage"
 import { getAuth, buildClerkProps } from "@clerk/nextjs/server";
 import { GetServerSideProps } from "next";
 
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
 It is important to protect your API routes to ensure that only authenticated users can access them. You can do this by checking if the `userId` is present in the `getAuth()` response.
 
-```tsx filename="pages/api/example.ts" copy
+```tsx filename="pages/api/example.ts"
 import { clerkClient, getAuth, buildClerkProps } from "@clerk/nextjs/server";
 import { GetServerSideProps } from "next";
 
@@ -51,7 +51,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
 The `clerkClient` allows you to access the Clerk API. You can use this to retrieve or update data.
 
-```tsx filename="pages/api/example.ts" copy
+```tsx filename="pages/api/example.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { getAuth, buildClerkProps } from "@clerk/nextjs/server";
 import { GetServerSideProps } from "next";

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -7,7 +7,7 @@ description: Access the User object inside of your server components, actions an
 
 The `currentUser` helper returns the `User` object of the currently active user. This is the same `User` object that is returned by the [`useUser`](/docs/references/react/use-user) hook. However, it can be used in server components, route handlers, and server actions.
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { currentUser } from '@clerk/nextjs';
 
 export default async function Page() {

--- a/docs/references/nextjs/get-auth.mdx
+++ b/docs/references/nextjs/get-auth.mdx
@@ -14,7 +14,7 @@ The `getAuth()` helper retrieves the authentication state, allowing you to prote
 
 #### Basic usage
 
-```tsx filename="pages/api/example.ts" copy
+```tsx filename="pages/api/example.ts"
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -32,7 +32,7 @@ export default async function handler(
 
 It is important to protect your API routes to ensure that only authenticated users can access them. You can do this by checking if the `userId` is present in the `getAuth()` response.
 
-```tsx filename="pages/api/example.ts" copy
+```tsx filename="pages/api/example.ts"
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -53,7 +53,7 @@ export default async function handler(
 
 The `getToken()` function returns a promise that resolves to the current user's session token. You can also use this function to retrieve a custom JWT template.
 
-```tsx filename="pages/api/example.ts" copy
+```tsx filename="pages/api/example.ts"
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -72,7 +72,7 @@ export default async function handler(
 
 The `clerkClient` allows you to access the Clerk API. You can use this to retrieve or update data.
 
-```tsx filename="pages/api/example.ts" copy
+```tsx filename="pages/api/example.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { getAuth } from "@clerk/nextjs/server";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/docs/references/nextjs/route-handlers.mdx
+++ b/docs/references/nextjs/route-handlers.mdx
@@ -10,7 +10,7 @@ Clerk provides helpers to allow you to protect your Route Handlers, fetch the cu
 
 If you aren't protecting your Route Handler using Clerk's middleware, you can check if the user is logged in.
 
-```tsx copy  filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs';
 
@@ -31,7 +31,7 @@ export async function GET() {
 
 Clerk provides integrations with a number of popular databases. Below is an example of retrieving a template to be used.
 
-```tsx copy  filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs';
 export async function GET() {
@@ -50,7 +50,7 @@ export async function GET() {
 
 In some cases, you might need the current user in your Route Handler. Clerk provides an asynchronous helper called `currentUser` to retrieve it.
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { NextResponse } from 'next/server';
 import { currentUser } from '@clerk/nextjs';
 export async function GET() {
@@ -68,7 +68,7 @@ export async function GET() {
 
 The `clerkClient` helper allows you to retrieve and update data from Clerk's API. 
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { NextResponse } from 'next/server';
 import { auth, clerkClient } from '@clerk/nextjs';
 

--- a/docs/references/nextjs/server-actions.mdx
+++ b/docs/references/nextjs/server-actions.mdx
@@ -13,7 +13,7 @@ Below are some examples of usage both in server components or client components.
 
 ### Protect your actions
 
-```tsx copy filename="actions.[js/ts]"
+```tsx filename="actions.[js/ts]"
 import { auth } from '@clerk/nextjs';
 
 export default function AddToCart() {
@@ -43,7 +43,7 @@ export default function AddToCart() {
 
 Current user data is important for data enrichment. You can use the `currentUser()` helper to achieve this.
 
-```tsx copy filename="app/page.[jsx/tsx]"
+```tsx filename="app/page.[jsx/tsx]"
 import { currentUser } from '@clerk/nextjs';
 
 export default function AddHobby() {
@@ -82,7 +82,7 @@ When using client components, you need to make sure you use prop drilling to ens
 
 #### Server Action code
 
-```tsx copy filename="actions.[js/ts]"
+```tsx filename="actions.[js/ts]"
 'use server'
 import { auth } from '@clerk/nextjs';
 
@@ -97,7 +97,7 @@ export async function addItem(formData: FormData) {
 
 #### Server page
 
-```tsx copy filename="page.[jsx/tsx]"
+```tsx filename="page.[jsx/tsx]"
 import UI from "./UI";
 import { addItem } from "./actions"
 export default function Hobby() {
@@ -109,7 +109,7 @@ export default function Hobby() {
 
 #### Client component
 
-```tsx copy filename="ui.[jsx/tsx]"
+```tsx filename="ui.[jsx/tsx]"
 "use client"
 
 export default function UI({ addItem }) {
@@ -130,7 +130,7 @@ export default function UI({ addItem }) {
 
 #### Server Action Code
 
-```tsx copy filename="actions.[js/ts]"
+```tsx filename="actions.[js/ts]"
 'use server'
 import { currentUser } from "@clerk/nextjs";
 
@@ -150,7 +150,7 @@ export async function addHobby(formData: FormData) {
 
 #### Server Page
 
-```tsx copy filename="page.[jsx/tsx]"
+```tsx filename="page.[jsx/tsx]"
 import UI from "./ui";
 import { addHobby } from "./actions"
 export default function Hobby() {
@@ -162,7 +162,7 @@ export default function Hobby() {
 
 #### Client Component
 
-```tsx copy filename="ui.[jsx/tsx]"
+```tsx filename="ui.[jsx/tsx]"
 "use client"
 
 export default function UI({ addHobby }) {

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -20,15 +20,15 @@ Learn how to integrate Clerk into your Next.js application using [tRPC](https://
 Clerk's Next.js SDK gives you access to prebuilt components and hooks, as well as our [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and middleware.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install @clerk/nextjs
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   yarn add @clerk/nextjs
   ```
 
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   pnpm add @clerk/nextjs
   ```
 </CodeBlockTabs>
@@ -39,7 +39,7 @@ Below is an example of an `.env.local` file. If you are signed into your Clerk D
 
 <InjectKeys>
 
-```sh copy filename=".env.local"
+```sh filename=".env.local"
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
 CLERK_SECRET_KEY={{secret}}
 ```
@@ -50,7 +50,7 @@ CLERK_SECRET_KEY={{secret}}
 
 [Middleware](/docs/references/nextjs/auth-middleware) needs to be placed at the root of your project. This allows you to use Clerk server-side APIs.
 
-```ts filename="middleware.ts" copy
+```ts filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
 
 export default authMiddleware();

--- a/docs/references/nextjs/with-clerk-middleware.mdx
+++ b/docs/references/nextjs/with-clerk-middleware.mdx
@@ -20,7 +20,7 @@ The `withClerkMiddleware` wrapper allows Clerk to access session data on the ser
 
 This is the minimal amount of code needed to use Clerk Server Side helpers.
 
-```tsx filename="middleware.ts" copy
+```tsx filename="middleware.ts"
 import { withClerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
@@ -47,7 +47,7 @@ export const config = {
 
 #### Usage with page protection
 
-```tsx filename="middleware.ts" copy
+```tsx filename="middleware.ts"
 import { withClerkMiddleware } from "@clerk/nextjs/server";
 import { getAuth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";

--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -10,7 +10,7 @@ The `useAuth()` hook is a convenient way to access the current auth state. This 
 ## Usage
 
 <CodeBlockTabs options={["Next.js", "React"]}>
-  ```tsx copy filename="pages/index.tsx"
+  ```tsx filename="pages/index.tsx"
   import { useAuth } from '@clerk/nextjs';
 
   export default function ExternalDataPage() {
@@ -32,7 +32,7 @@ The `useAuth()` hook is a convenient way to access the current auth state. This 
 
   ```
 
-  ```tsx copy filename="external-data-page.tsx"
+  ```tsx filename="external-data-page.tsx"
   import { useAuth } from '@clerk/clerk-react';
 
   export default function ExternalDataPage() {

--- a/docs/references/react/use-clerk.mdx
+++ b/docs/references/react/use-clerk.mdx
@@ -18,7 +18,7 @@ The `useClerk` hook provides access to the the [`Clerk`](/docs/references/javasc
 ## Usage
 
 <CodeBlockTabs options={["Next.js", "React"]}>
-  ```tsx copy filename="pages/index.tsx"
+  ```tsx filename="pages/index.tsx"
   import { useClerk } from "@clerk/nextjs";
 
   export default function Home() {
@@ -29,7 +29,7 @@ The `useClerk` hook provides access to the the [`Clerk`](/docs/references/javasc
 
   ```
 
-  ```tsx copy filename="home.tsx"
+  ```tsx filename="home.tsx"
   import { useClerk } from "@clerk/clerk-react";
 
   export default function Home() {

--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -13,7 +13,7 @@ The `useOrganizationList` hook requires developers to opt-in by specifying which
 
 ### Infinite list of joined organizations
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="pages/joined-organizations.tsx"
+```tsx filename="pages/joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
 
@@ -56,7 +56,7 @@ const JoinedOrganizationList = () => {
 export default JoinedOrganizationList;
 ```
 
-```tsx copy filename="joined-organizations.tsx"
+```tsx filename="joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/clerk-react";
 import React from "react";
 
@@ -102,7 +102,7 @@ export default JoinedOrganizationList;
 
 ### Table of invitations
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="pages/joined-organizations.tsx"
+```tsx filename="pages/joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
 
@@ -157,7 +157,7 @@ const InvitationsTable = () => {
 export default InvitationsTable;
 ```
 
-```tsx copy filename="joined-organizations.tsx"
+```tsx filename="joined-organizations.tsx"
 import { useOrganizationList } from "@clerk/nextjs";
 import React from "react";
 

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -14,7 +14,7 @@ The `useSessionList` hook returns an array of `Session` objects that have been r
 ## Usage
 
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="pages/index.tsx"
+```tsx filename="pages/index.tsx"
 import { useSessionList } from "@clerk/nextjs";
 
 export default function Home() {
@@ -34,7 +34,7 @@ export default function Home() {
 }
 ```
 
-```tsx copy filename="home.tsx"
+```tsx filename="home.tsx"
 import { useSessionList } from "@clerk/clerk-react";
 
 export default function Home() {

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -14,7 +14,7 @@ The `useSession` hook provides access to the current user's `Session` object, as
 ## Usage
 
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="pages/index.tsx"
+```tsx filename="pages/index.tsx"
 import { useSession } from "@clerk/nextjs";
 
 export default function Home() {
@@ -39,7 +39,7 @@ export default function Home() {
 }
 ```
 
-```tsx copy filename="home.tsx"
+```tsx filename="home.tsx"
 import { useSession } from "@clerk/clerk-react";
 
 export default function Home() {

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -17,7 +17,7 @@ The `useSignIn` hook provides access to the `SignIn` object, which allows you to
   <Tab>
     #### Check the current sign in status
 
-    ```tsx copy filename="pages/index.tsx"
+    ```tsx filename="pages/index.tsx"
     import { useSignIn } from "@clerk/nextjs";
 
     export default function SignInStep() {
@@ -34,7 +34,7 @@ The `useSignIn` hook provides access to the `SignIn` object, which allows you to
 
     #### Sign in a user with a custom flow
 
-    ```tsx copy filename="pages/signin.tsx"
+    ```tsx filename="pages/signin.tsx"
     import { useSignIn } from "@clerk/nextjs";
     import { useState } from "react";
 
@@ -96,7 +96,7 @@ The `useSignIn` hook provides access to the `SignIn` object, which allows you to
   <Tab>
     #### Check the current sign in status
 
-    ```tsx copy filename="pages/sign-in-step.tsx"
+    ```tsx filename="pages/sign-in-step.tsx"
     import { useSignIn } from "@clerk/clerk-react";
 
     export default function SignInStep() {
@@ -113,7 +113,7 @@ The `useSignIn` hook provides access to the `SignIn` object, which allows you to
 
     #### Sign in a user with a custom flow
 
-    ```tsx copy filename="pages/signin.tsx"
+    ```tsx filename="pages/signin.tsx"
     import { useSignIn } from "@clerk/clerk-react";
     import { useState } from "react";
 

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -16,7 +16,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
   <Tab>
     #### Check the current sign up status
 
-    ```tsx copy filename="pages/sign-up.tsx"
+    ```tsx filename="pages/sign-up.tsx"
     import { useSignUp } from "@clerk/nextjs";
 
     export default function SignUpStep() {
@@ -33,7 +33,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
 
     #### Sign up a user with a custom flow
 
-    ```tsx copy filename="pages/signup.tsx"
+    ```tsx filename="pages/signup.tsx"
     import { useSignUp } from "@clerk/nextjs";
     import { useState } from "react";
 
@@ -98,7 +98,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
   <Tab>
     #### Check the current sign up status
 
-    ```tsx copy filename="sign-up-step.tsx"
+    ```tsx filename="sign-up-step.tsx"
     import { useSignUp } from "@clerk/clerk-react";
 
     export default function SignUpStep() {
@@ -115,7 +115,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
 
     #### Sign up a user with a custom flow
 
-    ```tsx copy filename="signup.tsx"
+    ```tsx filename="signup.tsx"
     import { useSignUp } from "@clerk/clerk-react";
     import { useState } from "react";
 

--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -16,7 +16,7 @@ The `useUser` hook is a convenient way to access the current user data where you
 ### Retrieve the current user data
 
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="pages/index.tsx"
+```tsx filename="pages/index.tsx"
 import { useUser } from "@clerk/nextjs";
 
 export default function Home() {
@@ -35,7 +35,7 @@ export default function Home() {
 
 ```
 
-```tsx copy filename="home.tsx"
+```tsx filename="home.tsx"
 import { useUser } from "@clerk/clerk-react";
 
 export default function Home() {
@@ -58,7 +58,7 @@ export default function Home() {
 ### Update the current user data
 
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx copy filename="app/page.tsx"
+```tsx filename="app/page.tsx"
 import { useUser } from "@clerk/nextjs";
 
 export default function Home() {
@@ -80,7 +80,7 @@ export default function Home() {
 }
 ```
 
-```tsx copy filename="home.tsx"
+```tsx filename="home.tsx"
 import { useUser } from "@clerk/clerk-react";
 
 export default function Home() {
@@ -108,7 +108,7 @@ export default function Home() {
 If you need to retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
 
 <CodeBlockTabs options={['Next.js', 'React']}>
-```tsx filename="app/page.tsx" copy
+```tsx filename="app/page.tsx"
 import { useUser } from "@clerk/nextjs";
 
 export default function Home() {
@@ -132,7 +132,7 @@ export default function Home() {
 }
 ```
 
-```tsx filename="home.tsx" copy
+```tsx filename="home.tsx"
 import { useUser } from "@clerk/clerk-react";
 
 export default function Home() {

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -10,11 +10,11 @@ Clerk currently supports deleting users through our [backend API](https://clerk.
 The [`deleteUser()`](/docs/references/backend/user/delete-user) method takes a single argument: the user ID of the user you want to delete. It can be accessed from the `users` sub-api of the `clerkClient` instance.
 
 <CodeBlockTabs options={["Curl", "Next.js App Router", "Next.js Pages Router", "Node"]}>
-```bash copy filename="curl.sh"
+```bash filename="curl.sh"
 curl -XDELETE -H 'Authorization: CLERK_SECRET_KEY' 'https://api.clerk.com/v1/users/{user_id}'
 ```
 
-```ts copy filename="app/private/route.ts"
+```ts filename="app/private/route.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextResponse } from 'next/server';
 
@@ -32,7 +32,7 @@ export async function DELETE(request: Request) {
 }
 ```
 
-```ts copy filename="pages/api/private.ts"
+```ts filename="pages/api/private.ts"
 import { clerkClient } from "@clerk/nextjs/server";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -50,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 ```
 
-```ts copy filename="private.ts"
+```ts filename="private.ts"
 import { clerk } from "@clerk/clerk-sdk-node";
 
 app.post('/deleteUser', (req, res) => {

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -23,14 +23,14 @@ Private metadata is only accessible by the backend, which makes this useful for 
 ### Setting private metadata
 
 <CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
-```bash copy filename="curl.sh"
+```bash filename="curl.sh"
 curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
   "private_metadata": {
     "stripeId": "12356"
   }
 }' 'https://api.clerk.com/v1/users/{user_id}/metadata'
 ```
-```ts copy filename="pages/api/private.ts"
+```ts filename="pages/api/private.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -47,7 +47,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.status(200).json({ success: true });
 }
 ```
-```ts copy filename="app/route/private.ts"
+```ts filename="app/route/private.ts"
 import { NextResponse } from 'next/server';
 import { clerkClient } from "@clerk/nextjs";
 
@@ -61,7 +61,7 @@ export async function POST() {
   return NextResponse.json({ success: true });
 }
 ```
-```ts copy filename="private.ts"
+```ts filename="private.ts"
 import { clerkClient } from "@clerk/clerk-sdk-node";
 
 app.post('/updateStripe', (req, res) => {
@@ -76,7 +76,7 @@ app.post('/updateStripe', (req, res) => {
 });
 
 ```
-```ts copy filename="private.go"
+```ts filename="private.go"
 var client clerk.Client
 
 func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
@@ -92,7 +92,7 @@ func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
 	}
 }
 ```
-```ts copy filename="private.rb"
+```ts filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
 require 'json'
@@ -112,11 +112,11 @@ clerk.users.updateMetadata("user_xyz", private_metadata: privateMetadata)
 You can retrieve the private metadata for a user by using the [`getUser`](/docs/references/backend/user/get-user) method. This method will return the `User` object which contains the private metadata.
 
 <CodeBlockTabs options={['cURL', 'Next.js App Router', 'Next.js Pages Router', 'Node', 'Go','Ruby']}>
-```bash copy filename="curl.sh"
+```bash filename="curl.sh"
 curl -XGET -H 'Authorization: CLERK_SECRET_KEY' -H "Content-type: application/json" 'https://api.clerk.com/v1/users/{user_id}'
 ```
 
-```ts copy filename="app/private/route.ts"
+```ts filename="app/private/route.ts"
 import { NextResponse } from 'next/server';
 import { clerkClient } from "@clerk/nextjs";
 
@@ -128,7 +128,7 @@ export async function GET(request: Request) {
 }
 ```
 
-```ts copy filename="pages/api/private.ts"
+```ts filename="pages/api/private.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -141,7 +141,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 ```
 
-```ts copy filename="private.ts"
+```ts filename="private.ts"
 import { clerkClient } from "@clerk/clerk-sdk-node";
 
 app.post('/updateStripe', (req, res) => {
@@ -154,7 +154,7 @@ app.post('/updateStripe', (req, res) => {
 
 ```
 
-```ts copy filename="private.go"
+```ts filename="private.go"
 var client clerk.Client
 
 func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
@@ -166,7 +166,7 @@ func GetUserMetadata(user *clerk.User, stripeCustomerID string) error {
 }
 ```
 
-```ts copy filename="private.rb"
+```ts filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
 clerk = Clerk::SDK.new(api_key: "your_clerk_secret_key")
@@ -181,14 +181,14 @@ Public metadata is accessible by both the frontend and the backend. This is usef
 ### Setting public metadata
 
 <CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
-```bash copy filename="curl.sh"
+```bash filename="curl.sh"
 curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
   "public_metadata": {
     "role": "shopper"
   }
 }' 'https://api.clerk.com/v1/users/{user_id}/metadata'
 ```
-```ts copy filename="pages/api/public.ts"
+```ts filename="pages/api/public.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -205,7 +205,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.status(200).json({ success: true });
 }
 ```
-```ts copy filename="app/route/public.ts"
+```ts filename="app/route/public.ts"
 import { NextResponse } from 'next/server';
 import { clerkClient } from "@clerk/nextjs";
 
@@ -220,7 +220,7 @@ export async function POST() {
   return NextResponse.json({ success: true });
 }
 ```
-```ts copy filename="public.ts"
+```ts filename="public.ts"
 import { clerkClient } from "@clerk/clerk-sdk-node";
 
 app.post('/updateRole', (req, res) => {
@@ -236,7 +236,7 @@ app.post('/updateRole', (req, res) => {
 });
 
 ```
-```ts copy filename="public.go"
+```ts filename="public.go"
 var client clerk.Client
 
 func addStripeCustomerID(user *clerk.User, role string) error {
@@ -252,7 +252,7 @@ func addStripeCustomerID(user *clerk.User, role string) error {
 	}
 }
 ```
-```ts copy filename="public.rb"
+```ts filename="public.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
 require 'json'
@@ -288,14 +288,14 @@ The "unsafe" custom attributes can be set upon sign-up when creating or updating
 #### Using the Backend API
 
 <CodeBlockTabs options={['cURL', 'Pages Router', 'App Router', 'Node', 'Go','Ruby']}>
-```bash copy filename="curl.sh"
+```bash filename="curl.sh"
 curl -XPATCH -H 'Authorization: Bearer CLERK_SECRET_KEY' -H "Content-type: application/json" -d '{
   "unsafe_metadata": {
     "birthday": "11-30-1969"
   }
 }' 'https://api.clerk.com/v1/users/{user_id}/metadata'
 ```
-```ts copy filename="pages/api/private.ts"
+```ts filename="pages/api/private.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -312,7 +312,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.status(200).json({ success: true });
 }
 ```
-```ts copy filename="app/route/private.ts"
+```ts filename="app/route/private.ts"
 import { NextResponse } from 'next/server';
 import { clerkClient } from "@clerk/nextjs";
 
@@ -326,7 +326,7 @@ export async function POST() {
   return NextResponse.json({ success: true });
 }
 ```
-```ts copy filename="private.ts"
+```ts filename="private.ts"
 import { clerkClient } from "@clerk/clerk-sdk-node";
 
 app.post('/updateStripe', (req, res) => {
@@ -341,7 +341,7 @@ app.post('/updateStripe', (req, res) => {
 });
 
 ```
-```ts copy filename="private.go"
+```ts filename="private.go"
 var client clerk.Client
 
 func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
@@ -357,7 +357,7 @@ func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {
 	}
 }
 ```
-```ts copy filename="private.rb"
+```ts filename="private.rb"
 // ruby json example with a private metadata and stripe id
 require 'clerk'
 require 'json'
@@ -376,7 +376,7 @@ clerk.users.updateMetadata("user_xyz", unsafe_metadata: unsafeMetadata)
 
 <CodeBlockTabs options={['Pages Router', 'App Router', 'React', 'Remix','Gatsby', 'JavaScript']}>
 
-```tsx copy filename="pages/unsafe.tsx"
+```tsx filename="pages/unsafe.tsx"
 import {useUser} from "@clerk/nextjs";
 import {useState} from "react";
 
@@ -399,7 +399,7 @@ export default function UnSafePage() {
   )
 }
 ```
-```tsx copy filename="app/route/unsafe.tsx"
+```tsx filename="app/route/unsafe.tsx"
 "use client"
 import {useUser} from "@clerk/nextjs";
 import {useState} from "react";
@@ -423,7 +423,7 @@ export default function UnSafePage() {
   )
 }
 ```
-```tsx copy filename="unsafe.tsx"
+```tsx filename="unsafe.tsx"
 import {useUser} from "@clerk/clerk-react";
 import {useState} from "react";
 
@@ -446,7 +446,7 @@ export default function UnSafePage() {
   )
 }
 ```
-```tsx copy filename="unsafe.tsx"
+```tsx filename="unsafe.tsx"
 import {useUser} from "@clerk/remix";
 import {useState} from "react";
 
@@ -467,7 +467,7 @@ export default function UnSafePage() {
   )
 }
 ```
-```tsx copy filename="unsafe.tsx"
+```tsx filename="unsafe.tsx"
 // use Clerk React for gatsby
 import {useUser} from "@clerk/clerk-react";
 import {useState} from "react";
@@ -491,7 +491,7 @@ export default function UnSafePage() {
   )
 }
 ```
-```html copy filename="unsafe.html"
+```html filename="unsafe.html"
 <!DOCTYPE html>
 <html lang="en">
 

--- a/docs/users/sync-data.mdx
+++ b/docs/users/sync-data.mdx
@@ -68,15 +68,15 @@ If you're using Next.js with Pages Router, you can create a webhook endpoint in 
 Svix provides a package for verifying the webhook signature, making it easy to verify the authenticity of the webhook events.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash copy filename="terminal" copy
+  ```bash filename="terminal"
   npm install svix
   ```
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 yarn add svix
 ```
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 pnpm add svix
 ```
 
@@ -86,7 +86,7 @@ Next you will want to retrieve the Webhook signing secret from the Clerk Dashboa
 
 ![signing-secret-example](/docs/images/users/guides/sync-backend/sign-secret.png)
 
-```ts copy filename="pages/api/webhook.ts"
+```ts filename="pages/api/webhook.ts"
 import type { IncomingHttpHeaders } from 'http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { WebhookRequiredHeaders } from 'svix';
@@ -135,15 +135,15 @@ If you're using Next.js with App Router, you can create a webhook endpoint in th
 Svix provides a package for verifying the webhook signature, making it easy to verify the authenticity of the webhook events.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install svix
   ```
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 yarn add svix
 ```
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 pnpm add svix
 ```
 
@@ -153,7 +153,7 @@ Next you will want to retrieve the Webhook signing secret from the Clerk Dashboa
 
 ![signing-secret-example](/docs/images/users/guides/sync-backend/sign-secret.png)
 
-```ts copy filename="app/api/webhook/route.ts"
+```ts filename="app/api/webhook/route.ts"
 import { Webhook } from 'svix'
 import { headers } from 'next/headers'
 import { WebhookEvent } from '@clerk/nextjs/server'
@@ -221,15 +221,15 @@ export async function POST(req: Request) {
 Svix provides a package for verifying the webhook signature, making it easy to verify the authenticity of the webhook events.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
-  ```bash filename="terminal" copy
+  ```bash filename="terminal"
   npm install svix
   ```
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 yarn add svix
 ```
 
-```bash filename="terminal" copy
+```bash filename="terminal"
 pnpm add svix
 ```
 
@@ -239,7 +239,7 @@ Next you will want to retrieve the Webhook signing secret from the Clerk Dashboa
 
 ![signing-secret-example](/docs/images/users/guides/sync-backend/sign-secret.png)
 
-```ts copy
+```ts
 router.post('/webhook', bodyParser.raw({type: 'application/json'}), async function(req, res) {
     try {
         const payload = req.body;

--- a/docs/users/web3.mdx
+++ b/docs/users/web3.mdx
@@ -23,7 +23,7 @@ After signing in with Metamask, you'll be presented with the Next.js default sta
 
 In this example, the [`User`](/docs/references/javascript/user/user) object for the current user can be accessed through the [`useUser()`](/docs/references/react/use-user) hook. The user's primary Web3 address can then be retrieved from the `User` object.
 
-```jsx filename="pages/index.js" copy
+```jsx filename="pages/index.js"
 import { SignIn, SignOutButton, UserButton, useUser } from "@clerk/nextjs";
 
 export default function Home() {
@@ -65,7 +65,7 @@ export default function Home() {
 
 A new Next.js app using Pages Router comes with a sample API route in `/pages/api/hello.js`. Let's modify it to retrieve the user's Web3 address:
 
-```jsx filename="pages/api/hello.ts" copy
+```jsx filename="pages/api/hello.ts"
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getAuth } from "@clerk/nextjs/server";
 import { clerkClient } from "@clerk/nextjs";


### PR DESCRIPTION
The copy button previously was added to code block elements by passing a "copy" attribute to the code block.
This PR removes the "copy" attribute from all code blocks, as a copy button will be automatically be available for all code blocks.

Related to this PR: ["feat: add copy button to all code blocks"](https://github.com/clerkinc/clerk-marketing/pull/769).