### PR TITLE
Relocate NextJS' clerkClient documentation to its own page

### DIFF
--- a/docs/references/nextjs/interacting-with-clerks-api.mdx
+++ b/docs/references/nextjs/interacting-with-clerks-api.mdx
@@ -1,0 +1,26 @@
+---
+title: Interacting with Clerk's API
+description: Learn how to use Clerk's backend API
+---
+
+# Interacting with Clerk's API
+
+The `clerkClient` helper allows you to retrieve and update data from Clerk's API. 
+
+```tsx filename="app/page.[jsx/tsx]"
+import { NextResponse } from 'next/server';
+import { auth, clerkClient } from '@clerk/nextjs';
+
+export async function POST() {
+  const { userId } = auth();
+
+  if (!userId) return NextResponse.redirect('/sign-in');
+  
+  const params = { firstName: 'John', lastName: 'Wick' };
+
+  const user = await clerkClient.users.updateUser(userId, params);
+
+  return NextResponse.json({ user });
+}
+
+```

--- a/docs/references/nextjs/route-handlers.mdx
+++ b/docs/references/nextjs/route-handlers.mdx
@@ -63,25 +63,3 @@ export async function GET() {
   return NextResponse.json({ user });
 }
 ```
-
-## Interacting with Clerk's API
-
-The `clerkClient` helper allows you to retrieve and update data from Clerk's API. 
-
-```tsx filename="app/page.[jsx/tsx]"
-import { NextResponse } from 'next/server';
-import { auth, clerkClient } from '@clerk/nextjs';
-
-export async function POST() {
-  const { userId } = auth();
-
-  if (!userId) return NextResponse.redirect('/sign-in');
-  
-  const params = { firstName: 'John', lastName: 'Wick' };
-
-  const user = await clerkClient.users.updateUser(userId, params);
-
-  return NextResponse.json({ user });
-}
-
-```


### PR DESCRIPTION
I find it confusing that this part of the documentation is under the Route Handlers page. I think it should be easier to find.