### PR TITLE
DOCS-341 replace '->' with the arrow symbol or with links

### DIFF
--- a/docs/account-portal/direct-links.mdx
+++ b/docs/account-portal/direct-links.mdx
@@ -42,7 +42,7 @@ In production, the default is your application homepage.
   
 ### Configure fallback redirects
 
-Specify the fallback redirects under **Account Portal -> Redirects** in the Clerk Dashboard.
+Specify the fallback redirects under the **Redirects** tab on the [Account Portal](https://dashboard.clerk.com/last-active?path=account-portal) page in the Clerk Dashboard.
 
 <Images 
   width={3248}

--- a/docs/account-portal/disable-account-portal.mdx
+++ b/docs/account-portal/disable-account-portal.mdx
@@ -5,7 +5,7 @@ description: Learn how to disable the Account Portal.
 
 # Disabling the Account Portal
 
-If you would like to disable the Account Portal, you may do so under **Account Portal -> Danger** in the [Clerk Dashboard](https://dashboard.clerk.com). Please ensure that you set up an authentication flow for your users via the instructions below first, as applying this setting will immediately result in a 404 for all Account Portal pages.
+If you would like to disable the Account Portal, you may do so under the **Danger** tab on the [Account Portal](https://dashboard.clerk.com/last-active?path=account-portal) page in the Clerk Dashboard. Please ensure that you set up an authentication flow for your users via the instructions below first, as applying this setting will immediately result in a 404 for all Account Portal pages.
 
 <Callout type="danger">
   We recommend leaving the Account Portal enabled, even if you do choose to set up your own authentication flow. This helps with testing as well as providing an alternative path for users when needed.

--- a/docs/account-portal/getting-started.mdx
+++ b/docs/account-portal/getting-started.mdx
@@ -27,4 +27,4 @@ https://accounts.<your-domain>.com/organization
 https://accounts.<your-domain>.com/create-organization
 ```
 
-You can access these links under **Account Portal -> Pages** in your Clerk dashboard.
+You can access these links under the **Pages** tab on the [Account Portal](https://dashboard.clerk.com/last-active?path=account-portal) page in the Clerk Dashboard.

--- a/docs/authentication/social-connections/apple.mdx
+++ b/docs/authentication/social-connections/apple.mdx
@@ -139,7 +139,7 @@ After the registration is finished, go back to configure the newly-created Servi
 
 This configuration screen is where you tell Apple what domain and redirect URIs your application will use. Choose the App ID you created before, and in the domain enter `clerk.<your-domain>`.
 
-Next, go to Clerk's [Dashboard](https://dashboard.clerk.dev/), select your application and instance and go to **Authentication -> Social Connections**. Click the gear icon next to the Apple provider and copy the **Authorized redirect URI** value. Paste the value into the **Return URLs** in Apple Developer Portal and click **Next**.
+Next, go to the [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections) page in the Clerk Dashboard. Click the gear icon next to the Apple provider and copy the **Authorized redirect URI** value. Paste the value into the **Return URLs** in Apple Developer Portal and click **Next**.
 
 <Images
   width={704}

--- a/docs/authentication/social-connections/line.mdx
+++ b/docs/authentication/social-connections/line.mdx
@@ -39,7 +39,7 @@ The next step is to create a new **LINE Login channel**. You will have to select
 
 In the next screen, after the app has been created, you will find the **Basic settings** of the application. If you want to also make email address available for your application, you will have to apply for **Email address permission** in the bottom of your app's **Basic settings**.
 
-You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) of your Clerk Dashboard and enable LINE. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **LINE login -> Callback URL** input.
+You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) of your Clerk Dashboard and enable LINE. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **LINE login → Callback URL** input.
 
 Once all the above are complete, copy the **Channel ID** and **Channel secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 


### PR DESCRIPTION
In the docs, there is copy that has "->" for explaining navigation. We can do better by using links, and even using this symbol → in the case where a link cannot be used.