### PR TITLE
Added missing docs for chaining middleware

### DIFF
--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -104,6 +104,36 @@ If you define an `afterAuth` function, it will run even if the request correspon
 
 ![Execution order of `beforeAuth`, `publicRoutes`, and `afterAuth`](/docs/images/nextjs/middleware-flow-chart.png)
 
+
+### Chaining Middleware together
+
+If you need to chain middleware's together you can do so by using the beforeAuth if you need it to happen before Clerk. Below is an example of Clerk & next-intl.
+
+```ts filename="middleware.ts"
+import { authMiddleware } from "@clerk/nextjs";
+
+import createMiddleware from "next-intl/middleware";
+
+const intlMiddleware = createMiddleware({
+  locales: ["en", "el"],
+
+  defaultLocale: "en",
+});
+
+export default authMiddleware({
+  beforeAuth: (req) => {
+    return intlMiddleware(req);
+  },
+
+  publicRoutes: ["/", "/:locale/sign-in"],
+});
+
+export const config = {
+  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+};
+```
+
+
 ## Options
 
 <Tables


### PR DESCRIPTION
The section from https://clerk.sanity.studio/desk/doc;2550b734-3774-4367-860e-a844a4edfe61 for chaining middleware wasn't ported to the new docs. Added it in. directly from Sanity.