### PR TITLE
feat: Replace invitationList with invitations in useOrganization

### DIFF
--- a/docs/references/react/use-organization-list.mdx
+++ b/docs/references/react/use-organization-list.mdx
@@ -11,6 +11,10 @@ The `useOrganizationList` hook allows you to retrieve the memberships, invitatio
 
 The `useOrganizationList` hook requires developers to opt-in by specifying which resource they need to fetch and paginate through. It is ideal for infinite lists or tables.
 
+<Callout type="info">
+    Note that your component must be a descendant of [`<ClerkProvider/>`](/docs/components/clerk-provider).
+</Callout>
+
 ### Infinite list of joined organizations
 <CodeBlockTabs options={['Next.js', 'React']}>
 ```tsx filename="pages/joined-organizations.tsx"

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -41,7 +41,7 @@ To keep network usage to a minimum, we require developers to opt-in by specifyin
 
 ```jsx
 const { invitations } = useOrganization();
-// invitationList.data will never be populated
+// invitations.data will never be populated
 
 // Use default values to fetch invitations
 const { invitations } = useOrganization({

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -12,11 +12,11 @@ const {
   isLoaded,
   organization,
   membership,
-  invitationList,
+  invitations,
   memberships,
-  membershipRequest,
+  membershipRequests,
   domains,
-} = useOrganization(useOrganizationParams);
+} = useOrganization();
 ```
 
 <Callout type="info">
@@ -28,13 +28,29 @@ const {
 To keep network usage to a minimum but to also provide a smooth auto-updating experience to developers, we made the `invitationList` attribute available only when its respective parameter is present when calling the hook.
 
 ```jsx
-const { invitationList } = useOrganization();
-// invitationList is undefined.
+const { invitations } = useOrganization();
+// invitationList.data will never be populated
 
-const { invitationList } = useOrganization({ 
- invitationList: {} // Add any pagination params you might need.
+// Use default values to fetch invitations
+const { invitations } = useOrganization({
+ invitations: true
 });
-// invitationList is retrieved and auto-updating as expected.
+
+// Override fetch invitations
+const { invitations } = useOrganization({
+ invitations: {
+    pageSize: 20,
+    initialPage: 2, // skips the first page
+ }
+});
+
+// Aggregate pages in order to render an infinite list
+const { invitations } = useOrganization({
+ invitations: {
+    infinite: true,
+ }
+});
+
 ```
 
 In addition, we support a paginated response with page fetching helper functions for `memberships`, `membershipRequests`, and `domains`. See [usage](#usage) below for an example.
@@ -51,6 +67,7 @@ In the following example, `useOrganization()` is used to map over the `membershi
   Note that your component must be a descendant of [`<ClerkProvider/>`](/docs/components/clerk-provider).
 </Callout>
 
+### Infinite pagination
 ```jsx
 import { useOrganization } from "@clerk/nextjs";
 
@@ -80,16 +97,56 @@ export default function MemberList() {
       </ul>
 
       <button
+        disabled={!memberships.hasNextPage}
+        onClick={memberships.fetchNext}
+      >
+        Load more
+      </button>
+    </div>
+  );
+}
+```
+
+### Simple pagination
+```jsx
+import { useOrganization } from "@clerk/nextjs";
+
+export default function MemberList() {
+  const { memberships } = useOrganization({
+    memberships: {
+      keepPreviousData: true,
+    },
+  });
+
+  if (!memberships) {
+    // loading state
+    return null;
+  }
+
+  return (
+    <div>
+      <h2>Organization members</h2>
+      <ul>
+        {memberships.data?.map((membership) => (
+          <li key={membership.id}>
+            {membership.publicUserData.firstName} {membership.publicUserData.lastName} &lt;
+            {membership.publicUserData.identifier}&gt; :: {membership.role}
+          </li>
+        ))}
+      </ul>
+
+      <button
         disabled={!memberships.hasPreviousPage}
         onClick={memberships.fetchPrevious}
       >
-        Prev
+        Previous page
       </button>
+
       <button
         disabled={!memberships.hasNextPage}
         onClick={memberships.fetchNext}
       >
-        Next
+        Next page
       </button>
     </div>
   );
@@ -104,17 +161,11 @@ To see a demo application utilising the hook and the organizations feature, take
 
 | Properties | Description |
 | --- | --- |
-| `inivtationList?` | [`PaginationParams`](#pagination-params) |
+| `invitations?` | [`CommonPaginatedParams`](#common-paginated-params) and [`OrganizationInvitationStatus[]`](#organization-invitation-status) |
 | `membershipRequests?` | [`CommonPaginatedParams`](#common-paginated-params) and [`OrganizationInvitationStatus`](#organization-invitation-status) |
 | `memberships?` | [`CommonPaginatedParams`](#common-paginated-params) and [`MembershipRole?`](#membership-role) |
 | `domains?` | [`CommonPaginatedParams`](#commonpaginated-params) and [`OrganizationEnrollmentMode`](#organization-enrollment-mode) |
 
-### `PaginationParams`
-
-| Properties | Description |
-| --- | --- |
-| `limit?` | The number of results to return. |
-| `offset?` | The number of results to skip. |
 
 ### `CommonPaginatedParams`
 
@@ -154,7 +205,7 @@ The `memberships`, `membershipRequests`, and `domains` are returned as paginated
 | `isLoaded` | A boolean is set to `false` until Clerk loads and initializes. Once Clerk loads, `isLoaded` will be set to `true`. |
 | `organization` | The current active organization. |
 | `membership` | The current organization membership. |
-| `invitationList` | List of invitations for the current organization. |
+| `invitations` | API for fetching [paginated resources](#paginated-resources). |
 | `memberships` | API for fetching [paginated resources](#paginated-resources). |
 | `membershipRequests` | API for fetching [paginated resources](#paginated-resources). |
 | `domains` | API for fetching [paginated resources](#paginated-resources). |

--- a/docs/references/react/use-organization.mdx
+++ b/docs/references/react/use-organization.mdx
@@ -23,9 +23,21 @@ const {
   These attributes are updating automatically and will re-render their respective components whenever you set a different organization using the [`setActive({ organization })`](/docs/references/javascript/clerk/session-methods#set-active) method or update any of the memberships or invitations. No need for you to manage updating anything manually.
 </Callout>
 
+## Usage
+
+<Callout type="warning">
+  Make sure you've followed the installation guide for [Clerk React](/docs/references/react/overview) before running the snippets below.
+</Callout>
+
+In the following example, `useOrganization()` is used to map over the `memberships` of the current active organization and present membership attributes. In addition, buttons support navigating through the paginated response.
+
+<Callout type="info">
+  Note that your component must be a descendant of [`<ClerkProvider/>`](/docs/components/clerk-provider).
+</Callout>
+
 ### Expanding and paginating attributes
 
-To keep network usage to a minimum but to also provide a smooth auto-updating experience to developers, we made the `invitationList` attribute available only when its respective parameter is present when calling the hook.
+To keep network usage to a minimum, we require developers to opt-in by specifying which resource they need to fetch and paginate through.
 
 ```jsx
 const { invitations } = useOrganization();
@@ -53,19 +65,6 @@ const { invitations } = useOrganization({
 
 ```
 
-In addition, we support a paginated response with page fetching helper functions for `memberships`, `membershipRequests`, and `domains`. See [usage](#usage) below for an example.
-
-## Usage
-
-<Callout type="warning">
-  Make sure you've followed the installation guide for [Clerk React](/docs/references/react/overview) before running the snippets below.
-</Callout>
-
-In the following example, `useOrganization()` is used to map over the `memberships` of the current active organization and present membership attributes. In addition, buttons support navigating through the paginated response.
-
-<Callout type="info">
-  Note that your component must be a descendant of [`<ClerkProvider/>`](/docs/components/clerk-provider).
-</Callout>
 
 ### Infinite pagination
 ```jsx


### PR DESCRIPTION
We exposed invitation from useOrganization from our sdks which replaces the deprecated `invitationList`. 