### PR TITLE
Migrate /backend-requests/handling/go from Sanity to MDX

### DIFF
--- a/docs/backend-requests/handling/go.mdx
+++ b/docs/backend-requests/handling/go.mdx
@@ -1,5 +1,54 @@
 ---
-sanity_slug: /docs/request-authentication/go
+title: Handling requests with Go
+description: Learn how to handle authenticated requests with Node.js and Express middleware using Clerk.
 ---
 
-# This is a stub
+# Handling requests with Go
+
+## Go Middleware
+
+The Clerk Go SDK provides a simple middleware that adds the active session to the request’s context.
+
+<InjectKeys>
+
+```go filename=".env"
+package main
+
+import (
+  "net/http"
+  "github.com/clerkinc/clerk-sdk-go/clerk"
+)
+
+func main() {
+	client, _ := clerk.NewClient(sk_test_••••••••••••••••••••••••••••••••••)
+	
+	mux := http.NewServeMux()
+
+	injectActiveSession := clerk.WithSession(client)
+	mux.Handle("/hello", injectActiveSession(helloUserHandler(client)))
+
+	http.ListenAndServe(":8080", mux)
+}
+
+func helloUserHandler(client clerk.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		
+		sessClaims, ok := ctx.Value(clerk.ActiveSessionClaims).(*clerk.SessionClaims)
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("Unauthorized"))
+			return
+		}
+
+		user, err := client.Users().Read(sessClaims.Subject)
+		if err != nil {
+			panic(err)
+		}
+
+		w.Write([]byte("Welcome " + *user.FirstName))
+	}
+}
+```
+
+</InjectKeys>


### PR DESCRIPTION
🔎 [Old docs](https://clerk.com/docs/docs/backend-requests/handling/go)
🔎 [New docs (this PR)]()

This PR migrates this page from Sanity to MDX.

Acknowledging that these pages probably need work, and need their code examples updated - but for the scope of "Sanity to MDX Migration", this can be revisited at a later time, with better resources.