### PR TITLE
Migrate backend-requests from Sanity to MDX

### DIFF
--- a/docs/backend-requests/handling/gatsby.mdx
+++ b/docs/backend-requests/handling/gatsby.mdx
@@ -1,5 +1,34 @@
 ---
-sanity_slug: /docs/request-authentication/gatsby
+title: Handling requests with Gatsby
+description: Learn how to handle authenticated requests with Gatsby middleware using Clerk.
 ---
 
-# This is a stub
+# Handling requests with Gatsby
+
+## Gatsby Functions
+
+Gatsby Functions provides an [Express-like](https://expressjs.com/) architecture that simplifies building Node.js APIs.
+
+Gatsby Functions can use the `ClerkExpressWithAuth` and `ClerkExpressRequireAuth` middlewares from the [Clerk Node SDK](/docs/backend-requests/handling/nodejs) as shown below.
+
+```js
+import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
+
+const requireAuth = ClerkExpressRequireAuth();
+
+export default async function clerkHandler(req, res) {
+  await new Promise((resolve, reject) => {
+    requireAuth(req, res, result => {
+      if (result instanceof Error) {
+        reject(result);
+      }
+
+      resolve(result);
+    });
+  })
+
+  res.json(`Hi from Gatsby Functions`)
+}
+```
+
+For more information on how to use Express middlewares in Gatsby, refer to the [Gatsby official documentation](https://www.gatsbyjs.com/docs/reference/functions/middleware-and-helpers/#custom-middleware).

--- a/docs/backend-requests/handling/gatsby.mdx
+++ b/docs/backend-requests/handling/gatsby.mdx
@@ -11,7 +11,7 @@ Gatsby Functions provides an [Express-like](https://expressjs.com/) architecture
 
 Gatsby Functions can use the `ClerkExpressWithAuth` and `ClerkExpressRequireAuth` middlewares from the [Clerk Node SDK](/docs/backend-requests/handling/nodejs) as shown below.
 
-```js
+```js filename="src/api/clerk.js"
 import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 
 const requireAuth = ClerkExpressRequireAuth();

--- a/docs/backend-requests/handling/go.mdx
+++ b/docs/backend-requests/handling/go.mdx
@@ -1,5 +1,54 @@
 ---
-sanity_slug: /docs/request-authentication/go
+title: Handling requests with Go
+description: Learn how to handle authenticated requests with Go middleware using Clerk.
 ---
 
-# This is a stub
+# Handling requests with Go
+
+## Go Middleware
+
+The Clerk Go SDK provides a simple middleware that adds the active session to the request’s context.
+
+<InjectKeys>
+
+```go filename=".env"
+package main
+
+import (
+  "net/http"
+  "github.com/clerkinc/clerk-sdk-go/clerk"
+)
+
+func main() {
+	client, _ := clerk.NewClient(sk_test_••••••••••••••••••••••••••••••••••)
+
+	mux := http.NewServeMux()
+
+	injectActiveSession := clerk.WithSession(client)
+	mux.Handle("/hello", injectActiveSession(helloUserHandler(client)))
+
+	http.ListenAndServe(":8080", mux)
+}
+
+func helloUserHandler(client clerk.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		sessClaims, ok := ctx.Value(clerk.ActiveSessionClaims).(*clerk.SessionClaims)
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("Unauthorized"))
+			return
+		}
+
+		user, err := client.Users().Read(sessClaims.Subject)
+		if err != nil {
+			panic(err)
+		}
+
+		w.Write([]byte("Welcome " + *user.FirstName))
+	}
+}
+```
+
+</InjectKeys>

--- a/docs/backend-requests/handling/go.mdx
+++ b/docs/backend-requests/handling/go.mdx
@@ -7,7 +7,7 @@ description: Learn how to handle authenticated requests with Go middleware using
 
 ## Go Middleware
 
-The Clerk Go SDK provides a simple middleware that adds the active session to the request’s context.
+The Clerk Go SDK provides an easy-to-use middleware that adds the active session to the request’s context.
 
 <InjectKeys>
 

--- a/docs/backend-requests/handling/go.mdx
+++ b/docs/backend-requests/handling/go.mdx
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	client, _ := clerk.NewClient(sk_test_••••••••••••••••••••••••••••••••••)
+	client, _ := clerk.NewClient({{secret}})
 
 	mux := http.NewServeMux()
 

--- a/docs/backend-requests/handling/ruby-rails.mdx
+++ b/docs/backend-requests/handling/ruby-rails.mdx
@@ -1,5 +1,40 @@
 ---
-sanity_slug: /docs/request-authentication/rack-rails
+title: Handling requests with Rack and Rails
+description: Learn how to handle authenticated requests with Rack middleware using Clerk.
 ---
 
-# This is a stub
+# Handling requests with Rack and Rails
+
+Rack Middleware for Ruby on Rails
+The Clerk Ruby SDK comes with Rack middleware to lazily load the Clerk session and user. If added as a gem to Rails application, the `Clerk::Authenticatable` concern can be added to your controller.
+
+```ruby
+require "clerk/authenticatable"
+
+class ApplicationController < ActionController::Base
+  include Clerk::Authenticatable
+end
+```
+
+This gives your controller and views access to the following methods:
+
+- `clerk_session`
+- `clerk_user`
+- `clerk_user_signed_in?`
+
+If you want to protect a subset of your controllers (for example, if you have an admin section), you can add a `before_filter` like this:
+
+```ruby
+class AdminController < ApplicationController
+  before_action :require_clerk_session
+
+  private
+  def require_clerk_session
+    redirect_to clerk_sign_in_url unless clerk_session
+  end
+end
+```
+
+<Callout type="warning">
+  Don't forget to set the environment variable `CLERK_SIGN_IN_URL` or the method `clerk_sign_in_url` will fail.
+</Callout>

--- a/docs/backend-requests/handling/ruby-rails.mdx
+++ b/docs/backend-requests/handling/ruby-rails.mdx
@@ -5,7 +5,6 @@ description: Learn how to handle authenticated requests with Rack middleware usi
 
 # Handling requests with Rack and Rails
 
-Rack Middleware for Ruby on Rails
 The Clerk Ruby SDK comes with Rack middleware to lazily load the Clerk session and user. If added as a gem to Rails application, the `Clerk::Authenticatable` concern can be added to your controller.
 
 ```ruby


### PR DESCRIPTION
🔎 [Old Go docs](https://clerk.com/docs/docs/backend-requests/handling/go)
🔎 [Old Gatsby docs](https://clerk.com/docs/docs/backend-requests/handling/gatsby)
🔎 [Old Ruby docs](https://clerk.com/docs/docs/backend-requests/handling/ruby-rails)

🔎 [New docs (this PR)](https://docs-preview-352.clerkpreview.com/docs)

This PR migrates the /backend-requests/handling pages for Go, Gatsby, and Ruby from Sanity to MDX.

Acknowledging that these pages probably need work, and need their code examples updated - but for the scope of "Sanity to MDX Migration", this can be revisited at a later time, with better resources.