### PR TITLE
Migrate React reference overview from Sanity to MDX

### DIFF
--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -3,7 +3,7 @@ title: Clerk React SDK
 description: Learn how to integrate React into your Clerk application.
 ---
 
-# Clerk React
+# Clerk React SDK
 
 Clerk React is a wrapper around ClerkJS. It is the recommended way to integrate Clerk into your React application.
 

--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -19,7 +19,7 @@ Clerk React comes loaded with [custom hooks](/docs/references/react/use-user). T
 
 You need to create a Clerk application in your Clerk Dashboard before you can set up Clerk React. For more information, check out the [Set up your application](/docs/quickstarts/setup-clerk) guide.
 
-Once a Clerk application has been created, you can install and then start using Clerk React in your application. Our [quickstart guide](/docs/quickstarts/react) will have all the information you need to get started.
+Once a Clerk application has been created, you can install and then start using Clerk React in your application. The [quickstart guide](/docs/quickstarts/react) will have all the information you need to get started.
 
 
 

--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Clerk React
-description: Learn about Clerk's React SDK and how to utilize Clerk React components in your application.
+title: Clerk React SDK
+description: Learn how to integrate React into your Clerk application.
 ---
 
 # Clerk React

--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -1,3 +1,25 @@
 ---
-sanity_slug: /docs/reference/clerk-react/installation
+title: Clerk React
+description: Learn about Clerk's React SDK and how to utilize Clerk React components in your application.
 ---
+
+# Clerk React
+
+<Callout type="warning">
+  If you are using Next.js, please make sure to install `@clerk/nextjs` as `@clerk/clerk-react` is incompatible. See the [Next.js](/docs/references/nextjs/overview) documentation for more information.
+</Callout>
+
+Clerk React is a wrapper around ClerkJS. It is the recommended way to integrate Clerk into your React application.
+
+Clerk React provides React.js implementations of [Clerk Components](/docs/components/overview); highly customizable, pre-built components that you can use to build beautiful user management applications. You can find display components for building [sign-in](/docs/components/authentication/sign-in), [sign-up](/docs/components/authentication/sign-up), [account switching](/docs/components/user/user-button), and [user profile management](/docs/components/user/user-profile) pages as well as flow [control components](/docs/components/control/signed-in) that act as helpers for implementing a seamless authentication experience.
+
+Clerk React comes loaded with [custom hooks](/docs/references/react/use-user). These hooks give you access to the [Clerk object](/docs/references/javascript/clerk/clerk), and a set of useful helper methods for signing in and signing up.
+
+## Setting up Clerk React
+
+You need to create a Clerk application in your Clerk Dashboard before you can set up Clerk React. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
+
+Once a Clerk application has been created, you can install and then start using Clerk React in your application. Our [quickstart guide](/docs/quickstarts/react) will have all the information you need to get started.
+
+
+

--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -5,11 +5,11 @@ description: Learn about Clerk's React SDK and how to utilize Clerk React compon
 
 # Clerk React
 
+Clerk React is a wrapper around ClerkJS. It is the recommended way to integrate Clerk into your React application.
+
 <Callout type="warning">
   If you are using Next.js, please make sure to install `@clerk/nextjs` as `@clerk/clerk-react` is incompatible. See the [Next.js](/docs/references/nextjs/overview) documentation for more information.
 </Callout>
-
-Clerk React is a wrapper around ClerkJS. It is the recommended way to integrate Clerk into your React application.
 
 Clerk React provides React.js implementations of [Clerk Components](/docs/components/overview); highly customizable, pre-built components that you can use to build beautiful user management applications. You can find display components for building [sign-in](/docs/components/authentication/sign-in), [sign-up](/docs/components/authentication/sign-up), [account switching](/docs/components/user/user-button), and [user profile management](/docs/components/user/user-profile) pages as well as flow [control components](/docs/components/control/signed-in) that act as helpers for implementing a seamless authentication experience.
 

--- a/docs/references/react/overview.mdx
+++ b/docs/references/react/overview.mdx
@@ -17,7 +17,7 @@ Clerk React comes loaded with [custom hooks](/docs/references/react/use-user). T
 
 ## Setting up Clerk React
 
-You need to create a Clerk application in your Clerk Dashboard before you can set up Clerk React. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
+You need to create a Clerk application in your Clerk Dashboard before you can set up Clerk React. For more information, check out the [Set up your application](/docs/quickstarts/setup-clerk) guide.
 
 Once a Clerk application has been created, you can install and then start using Clerk React in your application. Our [quickstart guide](/docs/quickstarts/react) will have all the information you need to get started.
 


### PR DESCRIPTION
🔎 [Old Go docs](https://clerk.com/docs/references/react/overview)
🔎 [New docs (this PR)](https://docs-preview-353.clerkpreview.com/docs/references/react/overview)

This PR migrates the React reference overview page from Sanity to MDX.
Redundant information was cut and reference links were used as replacements.

Acknowledging that these pages probably need work, and need their code examples updated - but for the scope of "Sanity to MDX Migration", this can be revisited at a later time, with better resources.