### PR TITLE
clean up react hook reference pages

### DIFF
--- a/docs/references/react/use-auth.mdx
+++ b/docs/references/react/use-auth.mdx
@@ -1,6 +1,6 @@
 ---
 title: useAuth()
-description: The useAuth hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
+description: The useAuth() hook is a convenient way to access the current auth state. This hook provides the minimal information needed for data-loading and helper methods to manage the current active session.
 ---
 
 # `useAuth()`
@@ -55,45 +55,16 @@ The `useAuth()` hook is a convenient way to access the current auth state. This 
   ```
 </CodeBlockTabs>
 
-<Tables
-  headings={["Variables", "Description"]}
-  headingsMeta={[{}, {maxWidth:'300px'}]}
-  rows={[
-    {
-      cells: [
-        "isSignedIn",
-        "A boolean that returns true if the user is signed in.",
-      ],
-    },
-    {
-      cells: [
-        "isLoaded",
-        "A boolean that until Clerk loads and initializes, will be set to false. Once Clerk loads, isLoaded will be set to true",
-      ],
-    },
-    {
-      cells: ["userId", "The current user's ID"],
-    },
-    {
-      cells: ["sessionId", "The current user's session ID"],
-    },
-    {
-      cells: ["signOut", "A function that signs the user out"],
-    },
-    {
-      cells: [
-        "getToken",
-        "A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template.",
-      ],
-    },
-    {
-      cells: ["orgId", "The current user's organization ID"],
-    },
-    {
-      cells: ["orgRole", "The current user's organization role"],
-    },
-    {
-      cells: ["orgSlug", "The current user's organization slug"],
-    },
-  ]}
-/>
+## Returns
+
+| Variables | Description |
+| --- | --- |
+| `isSignedIn` | A boolean that returns true if the user is signed in. |
+| `isLoaded` | A boolean that until Clerk loads and initializes, will be set to `false`. Once Clerk loads, `isLoaded` will be set to `true`. |
+| `userId` | The current user's ID. |
+| `sessionId` | The current user's session ID. |
+| `signOut` | A function that signs the user out. |
+| `getToken` | A function that returns a promise that resolves to the current user's session token. Can also be used to retrieve a custom JWT template. |
+| `orgId` | The current user's organization ID. |
+| `orgRole` | The current user's organization role. |
+| `orgSlug` | The current user's organization slug. |

--- a/docs/references/react/use-clerk.mdx
+++ b/docs/references/react/use-clerk.mdx
@@ -1,15 +1,11 @@
 ---
 title: useClerk()
-description: The `useClerk` hook provides access to the Clerk object, giving you the ability to build alternatives to any Clerk Component.
+description: The useClerk() hook provides access to the Clerk object, giving you the ability to build alternatives to any Clerk Component.
 ---
-
-import { Callout } from "nextra-theme-docs";
-import { Tables } from "@/components/Table";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
 
 # `useClerk()`
 
-The `useClerk` hook provides access to the the [`Clerk`](/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
+The `useClerk()` hook provides access to the the [`Clerk`](/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
 
 <Callout type="warning">
   This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch giving access to lower-level APIs.

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -5,7 +5,7 @@ description: The useSessionList() hook returns an array of Session objects that 
 
 # `useSessionList()`
 
-The useSessionList() hook returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
+The `useSessionList()` hook returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
 
 ## Usage
 

--- a/docs/references/react/use-session-list.mdx
+++ b/docs/references/react/use-session-list.mdx
@@ -1,15 +1,11 @@
 ---
 title: useSessionList()
-description: The `useSessionList` hook returns an array of Session objects that have been registered on the client device.
+description: The useSessionList() hook returns an array of Session objects that have been registered on the client device.
 ---
-
-import { Callout } from "nextra-theme-docs";
-import { Tables } from "@/components/Table";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
 
 # `useSessionList()`
 
-The `useSessionList` hook returns an array of `Session` objects that have been registered on the client device.
+The useSessionList() hook returns an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device.
 
 ## Usage
 
@@ -57,7 +53,7 @@ export default function Home() {
 
 | Values | Description |
 | --- | --- |
-| `isLoaded` | A boolean that is set to false until Clerk loads and initializes. |
+| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
 | `setActive()` | A function that sets the active session. In most cases, this should be used over `setSession()`. |
 | `setSession()` | A function that sets the active session. |
-| `sessions` | Holds an array of `Session` objects that have been registered on the client device. |
+| `sessions` | Holds an array of [`Session`](/docs/references/javascript/session) objects that have been registered on the client device. |

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -1,15 +1,11 @@
 ---
 title: useSession()
-description: The `useSession` hook provides access to the the current user Session object, and helpers to set the active session.
+description: The useSession() hook provides access to the the current user Session object, and helpers to set the active session.
 ---
-
-import { Callout } from "nextra-theme-docs";
-import { Tables } from "@/components/Table";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
 
 # `useSession()`
 
-The `useSession` hook provides access to the current user's `Session` object, as well as helpers for setting the active session.
+The useSession() hook provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
 ## Usage
 
@@ -67,7 +63,7 @@ export default function Home() {
 
 | Values | Description |
 | --- | --- |
-| `isLoaded` | A boolean that is set to false until Clerk loads and initializes. |
+| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
 | `setActive()` | A function that sets the active session. In most cases, this should be used over `setSession()`. |
 | `setSession()` | A function that sets the active session. |
 | `session` | Holds the current active session for the user. |

--- a/docs/references/react/use-session.mdx
+++ b/docs/references/react/use-session.mdx
@@ -5,7 +5,7 @@ description: The useSession() hook provides access to the the current user Sessi
 
 # `useSession()`
 
-The useSession() hook provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
+The `useSession()` hook provides access to the current user's [`Session`](/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
 ## Usage
 

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -5,7 +5,7 @@ description: The useSignIn() hook provides access to the SignIn object, which al
 
 # `useSignIn()`
 
-The useSignIn() hook provides access to the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
+The `useSignIn()` hook provides access to the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
 ## Usage
 

--- a/docs/references/react/use-sign-in.mdx
+++ b/docs/references/react/use-sign-in.mdx
@@ -1,21 +1,17 @@
 ---
 title: useSignIn()
-description: The `useSignIn` hook provides access to the SignIn object, which allows you to check the current state of a sign in and sign in users with custom flows.
+description: The useSignIn() hook provides access to the SignIn object, which allows you to check the current state of a sign-in and for creating custom sign-in flows.
 ---
-
-import { Tab, Tabs } from "nextra-theme-docs";
-import { Callout } from "nextra-theme-docs";
-import { Tables } from "@/components/Table";
 
 # `useSignIn()`
 
-The `useSignIn` hook provides access to the `SignIn` object, which allows you to check the current state of a sign in. This is also useful for creating a custom sign in flow.
+The useSignIn() hook provides access to the [`SignIn`](/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
 ## Usage
 
 <Tabs items={['Next.js', 'React']}>
   <Tab>
-    #### Check the current sign in status
+    #### Check the current sign-in status
 
     ```tsx filename="pages/index.tsx"
     import { useSignIn } from "@clerk/nextjs";
@@ -94,7 +90,7 @@ The `useSignIn` hook provides access to the `SignIn` object, which allows you to
   </Tab>
 
   <Tab>
-    #### Check the current sign in status
+    #### Check the current sign-in status
 
     ```tsx filename="pages/sign-in-step.tsx"
     import { useSignIn } from "@clerk/clerk-react";
@@ -175,7 +171,7 @@ The `useSignIn` hook provides access to the `SignIn` object, which allows you to
 
 | Values | Description |
 | --- | --- |
-| `isLoaded` | A boolean that is set to false until Clerk loads and initializes. |
+| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
 | `setActive()` | A function that sets the active session. In most cases, this should be used over `setSession()`. |
 | `setSession()` | A function that sets the active session. |
-| `signIn` | An object that contains the current sign in attempt status and methods to create a new sign in attempt. |
+| `signIn` | An object that contains the current sign-in attempt status and methods to create a new sign-in attempt. |

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -1,20 +1,16 @@
 ---
 title: useSignUp()
-description: The `useSignUp` hook gives you access to the SignUp object, which allows you to check the current state of a sign up and sign up users with custom flows.
+description: The useSignUp() hook gives you access to the SignUp object, which allows you to check the current state of a sign-up and create custom sign-up flows.
 ---
-
-import { Callout } from "nextra-theme-docs";
-import { Tables } from "@/components/Table";
-
 # `useSignUp()`
 
-The `useSignUp` hook gives you access to the `SignUp` object, which allows you to check the current state of a sign up. This is also useful for creating a custom sign up flow.
+The useSignUp() hook gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## Usage
 
 <Tabs items={['Next.js', 'React']}>
   <Tab>
-    #### Check the current sign up status
+    #### Check the current sign-up status
 
     ```tsx filename="pages/sign-up.tsx"
     import { useSignUp } from "@clerk/nextjs";
@@ -27,7 +23,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
         return null;
       }
 
-      return <div>The current sign up attempt status is {signUp.status}.</div>;
+      return <div>The current sign-up attempt status is {signUp.status}.</div>;
     }
     ```
 
@@ -96,7 +92,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
   </Tab>
 
   <Tab>
-    #### Check the current sign up status
+    #### Check the current sign-up status
 
     ```tsx filename="sign-up-step.tsx"
     import { useSignUp } from "@clerk/clerk-react";
@@ -109,7 +105,7 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
         return null;
       }
 
-      return <div>The current sign up attempt status is {signUp.status}.</div>;
+      return <div>The current sign-up attempt status is {signUp.status}.</div>;
     }
     ```
 
@@ -180,8 +176,8 @@ The `useSignUp` hook gives you access to the `SignUp` object, which allows you t
 
 | Values | Description |
 | --- | --- |
-| `isLoaded` | A boolean that is set to false until Clerk loads and initializes. |
+| `isLoaded` | A boolean that is set to `false` until Clerk loads and initializes. |
 | `setActive()` | A function that sets the active session. In most cases, this should be used over `setSession()`. |
 | `setSession()` | A function that sets the active session. |
-| `signUp` | An object that contains the current sign up attempt status and methods to create a new sign up attempt. |
+| `signUp` | An object that contains the current sign-up attempt status and methods to create a new sign-up attempt. |
 

--- a/docs/references/react/use-sign-up.mdx
+++ b/docs/references/react/use-sign-up.mdx
@@ -4,7 +4,7 @@ description: The useSignUp() hook gives you access to the SignUp object, which a
 ---
 # `useSignUp()`
 
-The useSignUp() hook gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
+The `useSignUp()` hook gives you access to the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
 ## Usage
 

--- a/docs/references/react/use-user.mdx
+++ b/docs/references/react/use-user.mdx
@@ -1,11 +1,11 @@
 ---
 title: useUser()
-description: The `useUser` hook is used to get the current user object and to update the user's data on the client side.
+description: The useUser() hook is used to get the current user object and to update the user's data on the client side.
 ---
 
 # `useUser()`
 
-The `useUser` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
+The `useUser()` hook is a convenient way to access the current user data where you need it. This hook provides the user data and helper methods to manage the current active session.
 
 ## Usage
 
@@ -159,17 +159,8 @@ export default function Home() {
 
 ## Return value
 
-<Tables 
-  headings={["Variables", "Description"]} 
-  headingsMeta={[{}, {maxWidth:'300px'}]}
-  rows={[
-    {
-      cells: ["isSignedIn", "A boolean that returns true if the user is signed in."]
-    },
-    {
-      cells: ["isLoaded", "A boolean that until Clerk loads and initializes, will be set to false. Once Clerk loads, isLoaded will be set to true"]
-    },
-    {
-      cells: ["user", "An object containing the user's data. If the user is not signed in, user will be null."]
-    },
-  ]} />
+| Variables | Description |
+| --- | --- |
+| `isSignedIn` | A boolean that returns `true` if the user is signed in. |
+| `isLoaded` | A boolean that until Clerk loads and initializes, will be set to `false`. Once Clerk loads, `isLoaded` will be set to `true`. |
+| `user` | An object containing the user's data. If the user is not signed in, `user` will be `null`. |


### PR DESCRIPTION
markdown was removed from SEO descriptions
in copy, we reference hooks like: `hook()`
table components were migrated to markdown tables
reference links were added where necessary, such as when referencing to the `Session` object.
code snippets were added where necessary.
correct parts of speech were used for sign in vs sign-in and sign up vs sign-up