### PR TITLE
Migrate /references/go from Sanity to MDX

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -613,7 +613,8 @@
     [
       ["Overview", "references/go/overview"],
       ["Verifying sessions", "references/go/verifying-sessions"],
-      ["Other examples", "references/go/other-examples"]
+      ["Backend examples", "references/go/other-examples"],
+      ["Go example repository", "https://github.com/clerkinc/clerk-sdk-go"]
     ]
   ],
   [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -614,7 +614,7 @@
       ["Overview", "references/go/overview"],
       ["Verifying sessions", "references/go/verifying-sessions"],
       ["Backend examples", "references/go/other-examples"],
-      ["Go example repository", "https://github.com/clerkinc/clerk-sdk-go"]
+      ["Go SDK repository", "https://github.com/clerkinc/clerk-sdk-go"]
     ]
   ],
   [

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -1,5 +1,60 @@
 ---
-sanity_slug: /docs/reference/golang/other-examples
+title: Examples | Go
+description: Explore different examples of how to utilize Clerk with Go.
 ---
 
-# This is a stub
+# Examples
+
+Below are some various code snippets of what you can do from your backend with Clerk. Look at the [API reference](/docs/references/backend/overview) for a full list of requests you can make from your backend.
+
+## Transactional SMS
+
+Send an SMS to a user after they sign up.
+
+```go
+var client clerk.Client
+
+func afterSignup(user *clerk.User) error {
+	if user.PrimaryPhoneNumberID == nil {
+		return nil
+	}
+	
+	message := clerk.SMSMessage{
+		Message:       "Thanks for joining!",
+		PhoneNumberID: *user.PrimaryPhoneNumberID,
+	}
+
+	_, err := hd.client.SMS().Create(message)
+	if err != nil {
+		return err
+	}
+	
+	return nil	
+}
+```
+
+## Update metadata
+
+Add a new key/value to the private metadata stored on a user.
+
+```go
+var client clerk.Client
+
+func addStripeCustomerID(user *clerk.User, stripeCustomerID string) error {	
+	currPrivMetadata := user.PrivateMetadata.(map[string]interface{})	
+	currPrivMetadata["stripe_customer_id"] = stripeCustomerID
+
+	var keyValStrings []string
+	for key, value := range currPrivMetadata {
+		keyValStrings = append(keysString, fmt.Sprintf("\"%s\": \"%s\"", key, value))
+	}
+	finalStr := fmt.Sprintf("{%s}", strings.Join(keysString, ","))
+	user, err := s.clerkClient.Users().Update(sess.UserID, &clerk.UpdateUser{
+		PrivateMetadata: finalStr,
+	})
+
+	if err != nil {
+		panic(err)
+	}
+}
+```

--- a/docs/references/go/other-examples.mdx
+++ b/docs/references/go/other-examples.mdx
@@ -1,5 +1,5 @@
 ---
-title: Examples | Go
+title: Examples | Clerk Go SDK
 description: Explore different examples of how to utilize Clerk with Go.
 ---
 

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -5,7 +5,7 @@ description: Learn how to integrate Go into your Clerk application.
 
 # Go
 
-Clerk's Go SDK is a thin wrapper over our Backend API. Add the following import statement:
+Clerk's Go SDK is a thin wrapper over the Clerk Backend API. Add the following import statement:
 
 ```go
 import "github.com/clerkinc/clerk-sdk-go/clerk"

--- a/docs/references/go/overview.mdx
+++ b/docs/references/go/overview.mdx
@@ -1,5 +1,36 @@
 ---
-sanity_slug: /docs/reference/golang/getting-started
+title: Clerk Go SDK
+description: Learn how to integrate Go into your Clerk application.
 ---
 
-# This is a stub
+# Go
+
+Clerk's Go SDK is a thin wrapper over our Backend API. Add the following import statement:
+
+```go
+import "github.com/clerkinc/clerk-sdk-go/clerk"
+```
+
+Go doesn't automatically add the module. You can explicitly add it with:
+
+```go
+$ go get github.com/clerkinc/clerk-sdk-go
+```
+
+## `Clerk` client
+
+Now, you can create a `Clerk` client by calling the `clerk.NewClient` function. This function requires your Clerk secret key. If you are signed into your Clerk Dashboard, your keys should become visible by clicking on the eye icon. You can also retrieve your Clerk secret key from the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard.
+
+With your Clerk secret key, create a `Client` object to use the various services Clerk provides.
+
+<InjectKeys>
+
+```go filename=".env"
+client, err := clerk.NewClient({{secret}})
+if err != nil {
+    // handle error
+} 
+```
+
+</InjectKeys>
+

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Veryifing a session | Go
+title: Veryifing a session | Clerk Go SDK
 description: Learn how to verify a session with Clerk in your Go application.
 ---
 

--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -1,5 +1,102 @@
 ---
-sanity_slug: /docs/reference/golang/verifying-a-session
+title: Veryifing a session | Go
+description: Learn how to verify a session with Clerk in your Go application.
 ---
 
-# This is a stub
+# Verifying a session in Go
+
+## Protect Your Backend APIs
+
+Go makes it really easy to create a simple HTTP server, and Clerk makes it simple to authenticate any request. The following examples shows how to verify a session and retrieve the corresponding user.
+
+<InjectKeys>
+
+```go
+package main
+
+import (
+	"net/http"
+	"strings"
+	
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+)
+
+func main() {
+	client, _ := clerk.NewClient({{secret}})
+
+	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		// get session token from Authorization header
+		sessionToken := r.Header.Get("Authorization")
+		sessionToken = strings.TrimPrefix(sessionToken, "Bearer ")
+		
+		// verify the session
+		sessClaims, err := client.VerifyToken(sessionToken)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("Unauthorized"))
+			return
+		}
+
+		// get the user, and say welcome!
+		user, err := client.Users().Read(sessClaims.Claims.Subject)
+		if err != nil {
+			panic(err)
+		}
+
+		w.Write([]byte("Welcome " + *user.FirstName))
+	})
+
+	http.ListenAndServe(":8080", nil)
+}
+```
+
+</InjectKeys>
+
+## Using middleware
+
+The Clerk SDK also provides a simple middleware that adds the active session to the request's context.
+
+<InjectKeys>
+
+```go
+package main
+
+import (
+	"net/http"
+	
+	"github.com/clerkinc/clerk-sdk-go/clerk"
+)
+
+func main() {
+	client, _ := clerk.NewClient({{secret}})
+	
+	mux := http.NewServeMux()
+
+	injectActiveSession := clerk.WithSession(client)
+	mux.Handle("/hello", injectActiveSession(helloUserHandler(client)))
+
+	http.ListenAndServe(":8080", mux)
+}
+
+func helloUserHandler(client clerk.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		
+		sessClaims, ok := ctx.Value(clerk.ActiveSessionClaims).(*clerk.SessionClaims)
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("Unauthorized"))
+			return
+		}
+
+		user, err := client.Users().Read(sessClaims.Claims.Subject)
+		if err != nil {
+			panic(err)
+		}
+
+		w.Write([]byte("Welcome " + *user.FirstName))
+	}
+}
+```
+
+</InjectKeys>


### PR DESCRIPTION
Migrates the /references/go pages from Sanity to MDX.

Adds the Go SDK repository to the /go nav