### PR TITLE
Migrate /references/ruby from Sanity to MDX

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -633,7 +633,8 @@
     [
       ["Overview", "references/ruby/overview"],
       ["Available Methods", "references/ruby/available-methods"],
-      ["Rack/Rails integration", "references/ruby/rack-rails"]
+      ["Rack/Rails integration", "references/ruby/rack-rails"],
+      ["Ruby SDK repository", "https://github.com/clerkinc/clerk-sdk-ruby"]
     ]
   ],
   [

--- a/docs/references/ruby/overview.mdx
+++ b/docs/references/ruby/overview.mdx
@@ -1,5 +1,124 @@
 ---
-sanity_slug: /docs/reference/ruby/getting-started
+title: Clerk Ruby SDK
+description: Learn how to integrate Ruby into your Clerk application.
 ---
 
-# This is a stub
+# Clerk Ruby SDK
+
+<Steps>
+
+### Create a Clerk application 
+
+You need to create a Clerk application in your Clerk Dashboard before you can set up Clerk Ruby. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
+
+### Install Ruby
+
+Once a Clerk application has been created, you can install and then start using Clerk Ruby in your application.
+
+Add this line to your application's Gemfile.
+
+```ruby
+gem 'clerk-sdk-ruby', require: "clerk"
+```
+
+And then execute:
+
+```sh filename="terminal"
+$ bundle install
+```
+
+Or install it yourself as:
+
+```sh filename="terminal"
+$ gem install clerk-sdk-ruby
+```
+
+### Instantiate a `Clerk::SDK` instance
+
+To access all [Backend API endpoints](https://clerk.com/docs/reference/backend-api), you need to instantiate a `Clerk::SDK` instance.
+
+You will need your Clerk secret key to instantiate an instance. Navigate to the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page of the Clerk Dashboard and copy your secret key.
+
+This examples shows how to instantiate an instance of `Clerk::SDK` with your secret key and then send your first user a welcome email.
+
+<InjectKeys>
+
+```ruby
+clerk = Clerk::SDK.new(secret_key: {{secret}})
+
+# List all users
+clerk.users.all
+
+# Get your first user
+user = clerk.users.all(limit: 1).first
+
+# Extract their primary email address ID
+email_id = user["primary_email_address_id"]
+
+# Send them a welcome email
+clerk.emails.create(
+    email_address_id: email_id,
+    from_email_name: "welcome",
+    subject: "Welcome to MyApp",
+    body: "Welcome to MyApp, #{user["first_name"]}",
+)
+```
+
+</InjectKeys>
+
+### Configuration
+
+The SDK can be configured in three ways: environment variables, configuration singleton and constructor arguments. The priority goes like this:
+
+- Constructor arguments
+- Configuration object
+- Environment variables
+
+#### Constructor arguments
+
+You can customize each instance of the `Clerk::SDK` object by passing keyword arguments to the constructor:
+
+<InjectKeys>
+
+```ruby
+clerk = Clerk::SDK.new(
+    secret_key: {{secret}},
+    base_url: "Y",
+    logger: Logger.new()
+)
+```
+
+#### Configuration object
+
+If an argument is not provided, the configuration object is looked up, which falls back to the associated environment variable. Here's an example with all supported configuration settings their environment variable equivalents:
+
+<InjectKeys>
+
+```ruby
+Clerk.configure do |c|
+  c.secret_key = {{secret}} # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
+  c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
+  c.logger = Logger.new(STDOUT) # if omitted, no logging
+  c.middleware_cache_store = Rails.cache # if omitted: no caching
+end
+```
+
+</InjectKeys>
+
+</InjectKeys>
+
+Refer to the [Faraday documentation](https://lostisland.github.io/faraday/#/) for details.
+
+#### Environment variables
+
+Here's a list of all environment variables the SDK uses:
+
+| Variable name | Usage |
+| --- | --- |
+| `CLERK_API_BASE` | Overrides the default API base URL: `https://api.clerk.com/v1/` |
+| `CLERK_API_KEY` | The Secret key of your instance (required) |
+| `CLERK_SIGN_IN_URL` | Rails view helper: `clerk_sign_in_url` |
+| `CLERK_SIGN_IN_UP` | Rails view helper: `clerk_sign_up_url` |
+| `CLERK_USER_PROFILE_URL` | Rails view helper: `clerk_user_profile_url` |
+
+</Steps>

--- a/docs/references/ruby/rack-rails.mdx
+++ b/docs/references/ruby/rack-rails.mdx
@@ -1,5 +1,45 @@
 ---
-sanity_slug: /docs/reference/ruby/rack-rails-integration
+title: Rack/Rails integration | Clerk Ruby SDK
+description: The Clerk SDK comes with Rack middleware and a gem that can be used in Rails apps.
 ---
 
-# This is a stub
+# Rack/Rails integration
+
+## Rack middleware
+
+The SDK comes with a Rack middleware which lazily loads the Clerk session and user. It inserts a clerk key in the Rack environment, which is an instance of `Clerk::Proxy`. To get the session or the user of the session, you call `session` or `user` respectively. In case there is no session, you can retrieve the API error with the `error` getter method.
+
+## Rails integration
+
+If you add the gem in a Rails app, the Rack middleware will be included automatically in the middleware stack. For easier access to the Clerk session and user, include the `Clerk::Authenticatable` concern in your controller:
+
+```ruby
+require "clerk/authenticatable"
+
+class ApplicationController < ActionController::Base
+  include Clerk::Authenticatable
+end
+```
+
+This gives your controller and views access to the following methods:
+
+- `clerk_session`
+- `clerk_user`
+- `clerk_user_signed_in?`
+
+## Protected controllers
+
+If you want to protect a subset of your controllers (for example, if you have an admin section), you can add a `before_filter` like this:
+
+```ruby
+class AdminsController < ApplicationController
+  before_action :require_clerk_session
+
+  private
+  def require_clerk_session
+    redirect_to clerk_sign_in_url unless clerk_session
+  end
+end
+```
+
+Don't forget to set the environment variable `CLERK_SIGN_IN_URL` or the method `clerk_sign_in_url` will fail.


### PR DESCRIPTION
Migrates the /references/ruby pages from Sanity to MDX.

Adds the Ruby SDK repository to the /go nav