### PR TITLE
fix: change reference to Remix

### DIFF
--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -216,7 +216,7 @@ export const ErrorBoundary = ClerkErrorBoundary(YourBoundary);
 
 ### Build your own sign-in and sign-up pages
 
-In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Next.js application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Next.js optional catch-all route.
+In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Remix application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Remix optional catch-all route.
 
 The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev).
 


### PR DESCRIPTION
The instructions for Remix had references to Next.js