### PR TITLE
Fix broken link on testing overview

### DIFF
--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -5,7 +5,7 @@ description: Learn about testing with Clerk.
 
 # Testing
 
-Testing is an important part of every application. Clerk has built some helpers to make testing your application with Clerk easier, with more on the way. End-to-end (E2E) tests should be possible in any framework, however each framework may require a slightly different setup. If you're having trouble getting testing to work properly, [send us a message](https://clerk.com/support) and we'll be able to help.
+Testing is an important part of every application. Clerk has built some helpers to make testing your application with Clerk easier, with more on the way. End-to-end (E2E) tests should be possible in any framework. However, each framework may require a slightly different setup. If you're having trouble getting testing to work properly, [send us a message](https://clerk.com/support) and we'll be able to help.
 
 <Callout type="warning">
   Clerk's APIs do have Rate limits per IP address, you should write your e2e tests in a way that does not sign in on each test, and instead, you should sign in once for all, or most, of your tests

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -13,9 +13,7 @@ Testing is an important part of every application. Clerk has built some helpers 
 
 ## Testing with one time passcodes
 
-To confirm that your integration works correctly, you can simulate verification flows without sending an email or SMS, by using reserved values in test mode.
-
-To avoid sending an email or SMS message with a one time passcode (OTP) during testing, you can use a faux email address or phone number that has fixed verification values. Read the complete documentation [here](https://clerk.com/docs/testing/test-emails-and-phones).
+To avoid sending an email or SMS message with a one time passcode (OTP) during testing, you can use a faux email address or phone number that has a fixed code. Read the complete documentation [here](https://clerk.com/docs/testing/test-emails-and-phones).
 
 ## Testing Frameworks
 

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -5,15 +5,17 @@ description: Learn about testing with Clerk.
 
 # Testing
 
-Testing is an important part of every application. Clerk has built some helpers to make testing your application with Clerk easier, with more on the way. E2E tests should be possible in any framework / setup, however, each framework may require a slightly different setup. If you're having any trouble getting testing to work properly, [send us a message](https://clerk.com/support) and we'll be able to help.
+Testing is an important part of every application. Clerk has built some helpers to make testing your application with Clerk easier, with more on the way. End-to-end (E2E) tests should be possible in any framework, however each framework may require a slightly different setup. If you're having trouble getting testing to work properly, [send us a message](https://clerk.com/support) and we'll be able to help.
 
 <Callout type="warning">
   Clerk's APIs do have Rate limits per IP address, you should write your e2e tests in a way that does not sign in on each test, and instead, you should sign in once for all, or most, of your tests
 </Callout>
 
-## Testing with OTPs
+## Testing with one time passcodes
 
-To avoid actually sending emails/SMS messages with OTPs during testing, you can use faux-emails that will have fixed verification values. Read the complete documentation [here](https://clerk.com/docs/testing/e2e-testing).
+To confirm that your integration works correctly, you can simulate verification flows without sending an email or SMS, by using reserved values in test mode.
+
+To avoid sending an email or SMS message with a one time passcode (OTP) during testing, you can use a faux email address or phone number that has fixed verification values. Read the complete documentation [here](https://clerk.com/docs/testing/test-emails-and-phones).
 
 ## Testing Frameworks
 


### PR DESCRIPTION
URL https://clerk.com/docs/testing/e2e-testing doesn't exist

Also cleaned up some phrasing IMO