### PR TITLE
Added mailto to DMARC example.

### DIFF
--- a/docs/troubleshooting/email-deliverability.mdx
+++ b/docs/troubleshooting/email-deliverability.mdx
@@ -59,7 +59,7 @@ name:
 _dmarc<.example.com>
 
 content:
-v=DMARC1; p=reject; pct=100; rua=mailto:you@example.com; ruf=you@example.com;
+v=DMARC1; p=reject; pct=100; rua=mailto:you@example.com; ruf=mailto:you@example.com;
 ```
 
 This policy will reject all emails that weren't sent from you. There are other [policies](https://dmarc.org/overview/) that you can use.


### PR DESCRIPTION
Dmarc exmaple was missing `mailto:`