### PR TITLE
Document CAA DNS records in Deployment Troubleshooting section

### DIFF
--- a/docs/deployments/overview.mdx
+++ b/docs/deployments/overview.mdx
@@ -71,6 +71,14 @@ Once you've completed all the above steps, you're ready to go to the home page, 
 
 Clerk uses a DNS check to validate this CNAME record. If this subdomain is reverse proxied behind a service that points to generic hostnames, such as Cloudflare, the DNS check will fail. Please set the DNS record for this subdomain to a "DNS only" mode on your host to prevent proxying.
 
+### Deployment stuck in certificate issuance
+
+If your instance is stuck during TLS certificate issuance for longer than a few minutes, this might be caused due to certain [CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization) set on your primary domain.
+
+CAA are DNS records you may set to denote which certificate authorities (CA) are permitted to issue certificates for your domain, as a security measure against certain attacks. When you deploy your application, Clerk attempts to provision certificates using either the [LetsEncrypt](https://letsencrypt.org/) or [Google Trust Services](https://pki.goog/) certificate authorities.
+
+Therefore, ensure that you don't have any CAA records on your primary domain (e.g. example.com) that prohibit both LetsEncrypt and Google Trust Services to issue certificates for your domain.
+
 ### Incorrect domain
 
 If you accidently set the wrong domain, you can change it by using our backend API. You can find the Secret key in the settings page of your production instance. You can then use the following curl command to change the domain:


### PR DESCRIPTION
Presence of certain CAA DNS records on a root domain can conflict with instance deployment, if they prohibit both LetsEncrypt and Google Trust Services from issuing certificates for that domain.