### PR TITLE
DOCS-342: fix h1's of /integrations pages for better SEO and clarity

### DIFF
--- a/docs/integrations/analytics/google-analytics.mdx
+++ b/docs/integrations/analytics/google-analytics.mdx
@@ -1,9 +1,9 @@
 ---
-title: Google Analytics
+title: Enable Google Analytics for Clerk
 description: Enable Clerk with Google Analytics to authenticate requests to your application.
 ---
 
-# Google Analytics
+# Enable Google Analytics for Clerk
 
 This integration enables Clerk to send user authentication events to the configured Google Analytics property which corresponds to your application.
 

--- a/docs/integrations/databases/convex.mdx
+++ b/docs/integrations/databases/convex.mdx
@@ -1,9 +1,9 @@
 ---
-title: Convex
+title: Integrate Convex with Clerk
 description: Learn how to integrate Clerk into your Convex application.
 ---
 
-# Getting started
+# Integrate Convex with Clerk
 
 Navigate to the [JWT Templates](https://dashboard.clerk.com/last-active?path=jwt-templates) screen from the Clerk Dashboard. Click on the **New template** button to create a new template based on Convex.
 

--- a/docs/integrations/databases/fauna.mdx
+++ b/docs/integrations/databases/fauna.mdx
@@ -1,9 +1,9 @@
 ---
-title: Fauna
+title: Integrate Fauna with Clerk
 description: Learn how to integrate Clerk into your Fauna application.
 ---
 
-# Getting started
+# Integrate Fauna with Clerk
 
 The first step is to create a new Clerk application from your Clerk Dashboard if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 

--- a/docs/integrations/databases/firebase.mdx
+++ b/docs/integrations/databases/firebase.mdx
@@ -1,9 +1,9 @@
 ---
-title: Firebase
+title: Integrate Firebase with Clerk
 description: Learn how to integrate Clerk into your Firebase application.
 ---
 
-# Getting started
+# Integrate Firebase with Clerk
 
 To enable Firebase integration with your Clerk application, you will need to provide Clerk with the required Firebase configuration attributes depending on the Firebase features you would require authenticated user access to.
 

--- a/docs/integrations/databases/grafbase.mdx
+++ b/docs/integrations/databases/grafbase.mdx
@@ -1,9 +1,9 @@
 ---
-title: Grafbase
+title: Integrate Grafbase with Clerk
 description: Learn how to integrate Clerk and Grafbase into your application
 ---
 
-# Getting started
+# Integrate Grafbase with Clerk
 
 The first step is to create a new Clerk application from your Clerk Dashboard if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 

--- a/docs/integrations/databases/hasura.mdx
+++ b/docs/integrations/databases/hasura.mdx
@@ -1,9 +1,9 @@
 ---
-title: Hasura
+title: Integrate Hasura with Clerk
 description: Learn how to integrate Clerk into your Hasura application.
 ---
 
-# Getting started
+# Integrate Hasura with Clerk
 
 The first step is to create a new Clerk application from your Clerk Dashboard if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 

--- a/docs/integrations/databases/nhost.mdx
+++ b/docs/integrations/databases/nhost.mdx
@@ -1,9 +1,9 @@
 ---
-title: Nhost
+title: Integrate Nhost with Clerk
 description: Learn how to integrate Clerk into your Nhost project.
 ---
 
-# Getting started
+# Integrate Nhost with Clerk
 
 The first step is to create a new Clerk application from your Clerk Dashboard if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 

--- a/docs/integrations/databases/supabase.mdx
+++ b/docs/integrations/databases/supabase.mdx
@@ -1,9 +1,9 @@
 ---
-title: Supabase
+title: Integrate Supabase with Clerk
 description: Learn how to integrate Clerk into your Supabase application.
 ---
 
-# Getting started
+# Integrate Supabase with Clerk
 
 The first step is to create a new Clerk application from your Clerk Dashboard if you haven’t done so already. You can choose whichever authentication strategy and social login providers you prefer. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 


### PR DESCRIPTION
Many of the /integrations pages have `# Getting started` as their H1's

This PR updates the dedicated page's h1 and SEO title for better searchability on the site and better SEO.