### PR TITLE
fix: broken create organization link in reference

### DIFF
--- a/docs/references/javascript/clerk/create-organization.mdx
+++ b/docs/references/javascript/clerk/create-organization.mdx
@@ -249,4 +249,4 @@ All props below are optional.
 
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
-[createorg-ref]: /docs/components/organization/create-organization]
+[createorg-ref]: /docs/components/organization/create-organization


### PR DESCRIPTION
Update a reference to remove an extra character. Fixes a reported broken link.