### PR TITLE
DOCS-400: Add Arabic to the list (ar-SA)

### DIFF
--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -14,6 +14,7 @@ Clerk offers the ability to override the strings for all of the elements in each
 
 The `@clerk/localizations` package contains predefined localizations for the Clerk Components. Clerk currently supports:
 
+*   ar-SA
 *   cz-CZ
 *   da-DK
 *   de-DE


### PR DESCRIPTION
Arabic translation is added in `@clerk/localizations@1.26.3`