### PR TITLE
fix: swap dev with com to avoid redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://clerk.com?utm_source=github&utm_medium=clerk_docs" target="_blank" rel="noopener noreferrer">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://images.clerk.dev/static/logo-dark-mode-400x400.png">
+      <source media="(prefers-color-scheme: dark)" srcset="https://images.clerk.com/static/logo-dark-mode-400x400.png">
       <img src="https://images.clerk.com/static/logo-light-mode-400x400.png" height="64">
     </picture>
   </a>

--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -23,7 +23,7 @@ To access authentication state from a satellite domain, users will be transparen
 Currently, multi-domain can be added to any Next.js or Remix application. For other React frameworks, multi-domain is still supported as long as you do not use server rendering or hydration.
 </Callout>
 
-To get started, you need to create an Application from the [Clerk Dashboard](https://dashboard.clerk.dev/). Once you create an instance via the Clerk Dashboard, you will be prompted to choose a domain. This is your primary domain. For the purposes of this guide, the primary domain will be `primary.dev`.
+To get started, you need to create an Application from the [Clerk Dashboard](https://dashboard.clerk.com/). Once you create an instance via the Clerk Dashboard, you will be prompted to choose a domain. This is your primary domain. For the purposes of this guide, the primary domain will be `primary.dev`.
 
 When building your sign-in flow, you must configure it to run within your primary application, e.g. on /sign-in.
 

--- a/docs/authentication/social-connections/apple.mdx
+++ b/docs/authentication/social-connections/apple.mdx
@@ -15,7 +15,7 @@ To make development flow as smooth as possible, Clerk uses pre-configured config
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have an Apple Developer account. To create one, visit the [Apple Developer portal](https://developer.apple.com/).
 
 ## Configuring Apple social connection

--- a/docs/authentication/social-connections/atlassian.mdx
+++ b/docs/authentication/social-connections/atlassian.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Atlassian developer account. To create one, [click here](https://developer.atlassian.com/).
 
 ## Configuring an Atlassian OAuth 2.0 Integration

--- a/docs/authentication/social-connections/bitbucket.mdx
+++ b/docs/authentication/social-connections/bitbucket.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Consumer Key and Co
 
 ## Before you start
 
-*   You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+*   You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 *   You need to have a Bitbucket account. To create one, [click here](https://bitbucket.org/account/signup).
 
 ## Configuring Bitbucket social connection

--- a/docs/authentication/social-connections/box.mdx
+++ b/docs/authentication/social-connections/box.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Box developer account. To create one, [click here](https://developer.box.com/).
 
 ## Configuring Box social connection
@@ -35,7 +35,7 @@ You need to choose an app name and then click **Create application**.
   alt="Adding a name and creating the application"
 />
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Box. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Box. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
 
 <Images
   width={1916}

--- a/docs/authentication/social-connections/coinbase.mdx
+++ b/docs/authentication/social-connections/coinbase.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Coinbase developer account. To create one, [click here](https://www.coinbase.com/).
 
 ## Configuring Coinbase social connection
@@ -35,7 +35,7 @@ You need to set all the required fields and the corresponding **Permitted Redire
   alt="Creating application"
 />
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Coinbase. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Coinbase. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
 
 <Images
   width={1303}

--- a/docs/authentication/social-connections/discord.mdx
+++ b/docs/authentication/social-connections/discord.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Discord account. To create one, [click here](https://discord.com/register).
 
 ## Configuring Discord social connection
@@ -28,7 +28,7 @@ First, you need to register a new OAuth Discord app at the [Discord Developer Po
 
 ![Creating an OAuth Discord app](/docs/images/authentication-providers/discord/79076b03d80901a41644b8956ec42b4620d9a6c4-1920x838.png)
 
-Set a name for your new application and click create. Now that your application has been created, from the left side panel click on **OAuth2**, this is where you also need to add your **Redirect URL.** Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Discord. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect** input and save the changes.
+Set a name for your new application and click create. Now that your application has been created, from the left side panel click on **OAuth2**, this is where you also need to add your **Redirect URL.** Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Discord. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect** input and save the changes.
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/dropbox.mdx
+++ b/docs/authentication/social-connections/dropbox.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Dropbox account. To create one, [click here](https://www.dropbox.com/lp/developers).
 
 ## Configuring Dropbox social connection
@@ -33,7 +33,7 @@ First, you need to register a new OAuth Dropbox app at the [Dropbox App Console]
   alt="Creating a new application"
 />
 
-First you need to choose the API type, the App's type of access and to set a name for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Dropbox. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **OAuth Redirect URIs** input and click create.
+First you need to choose the API type, the App's type of access and to set a name for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Dropbox. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **OAuth Redirect URIs** input and click create.
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/facebook.mdx
+++ b/docs/authentication/social-connections/facebook.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to create your own developer account wit
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Facebook Developer account. To create one, consult the [Register as a Facebook developer](https://developers.facebook.com/docs/development/register) page.
 
 ## Configuring Facebook social connection
@@ -36,7 +36,7 @@ Once you have a OAuth client ID created, click on the newly created ID under **O
 
 ![Retrieving the App ID and App Secret](/docs/images/authentication-providers/facebook/33456604106d3478e0fd6b583bdde7c4f5563641-1467x969.png)
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Facebook. In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Facebook. In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
 
 ![Adding the valid OAuth Redirect URI](/docs/images/authentication-providers/facebook/c0be80ce8fed2b4d14d04fcbf56318b80295093d-1467x989.png)
 

--- a/docs/authentication/social-connections/github.mdx
+++ b/docs/authentication/social-connections/github.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a GitHub account. To create one, [click here](https://github.com/signup).
 
 ## Configuring GitHub social connection
@@ -28,7 +28,7 @@ First, you need to register a new OAuth GitHub app. Follow the official GitHub i
 
 ![Registering an OAuth GitHub app](/docs/images/authentication-providers/github/ff83ad81ca491cf17e5a755376fae9c88148ce7c-1395x799.png)
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable GitHub. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Go back to the GitHub panel, paste the value into the **Authorization callback URL** field and complete the registration.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable GitHub. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Go back to the GitHub panel, paste the value into the **Authorization callback URL** field and complete the registration.
 
 Once registration is complete, you'll get redirected to project's admin panel. Click the **Generate a new client secret** button to get your new client secret. Then, copy the **Client ID** and **Client secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/gitlab.mdx
+++ b/docs/authentication/social-connections/gitlab.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a GitLab account. To create one, [click here](https://gitlab.com/users/sign_up).
 
 ## Configuring GitLab social connection
@@ -28,7 +28,7 @@ First, you need to register a new OAuth GitLab app. Follow the official GitLab i
 
 ![Creating an OAuth GitLab app](/docs/images/authentication-providers/gitlab/7e67b1cb88c1df509cac722d6a6b2d7c624686f8-1919x840.png)
 
-You need to add a name for your new application and the **Redirect URI**. Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable GitLab. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Go back to the GitLab panel, paste the value into the **Redirect URI**, select any scopes that would you like your users to provide and save the application.
+You need to add a name for your new application and the **Redirect URI**. Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable GitLab. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Go back to the GitLab panel, paste the value into the **Redirect URI**, select any scopes that would you like your users to provide and save the application.
 
 Once creation is complete, you'll get redirected to application's panel. Copy the **Application ID** and **Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/google.mdx
+++ b/docs/authentication/social-connections/google.mdx
@@ -19,12 +19,12 @@ For production instances, you will need to create your own developer account wit
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Google Developer account. To create one, visit the [Google Cloud console](https://console.developers.google.com/).
 
 ## Configuring Google social connection
 
-First, go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) of your Clerk dashboard. From the list of OAuth vendors, enable Google. In the modal that opened, make sure **Use custom credentials** is enabled, and copy the value of the **Authorized redirect URI** field (you will have to paste this in the Google Console in a bit). Leave that window open as you will need to fill in the Client ID and Client Secret values that you will retrieve from the Google Cloud Platform console.
+First, go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) of your Clerk dashboard. From the list of OAuth vendors, enable Google. In the modal that opened, make sure **Use custom credentials** is enabled, and copy the value of the **Authorized redirect URI** field (you will have to paste this in the Google Console in a bit). Leave that window open as you will need to fill in the Client ID and Client Secret values that you will retrieve from the Google Cloud Platform console.
 
 In a new window, go to your Google Cloud Platform console. Select your Google project (step 1 in the screenshot) and enable OAuth 2.0 support by following the official instructions on [how to set up up an OAuth 2.0 application](https://support.google.com/cloud/answer/6158849?hl=en). In the **Authorized redirect URIs** setting, paste the value you copied from Clerk's Dashboard (see previous paragraph).
 
@@ -36,7 +36,7 @@ Once you have an OAuth client ID created, click on the newly created ID under **
 
 Go back to your Clerk instance's Dashboard and in the modal that should be opened (see beginning of this section), paste the **Client ID** and **Client Secret** values you obtained during the previous step.
 
-Optionally, you can also set additional OAuth scopes that your application might need, according to your use case. More information about this feature can be found [here](https://clerk.dev/docs/how-to/social-login-oauth), while the list of Google's available scopes can be found [here](https://developers.google.com/identity/protocols/oauth2/scopes).
+Optionally, you can also set additional OAuth scopes that your application might need, according to your use case. More information about this feature can be found [here](https://clerk.com/docs/how-to/social-login-oauth), while the list of Google's available scopes can be found [here](https://developers.google.com/identity/protocols/oauth2/scopes).
 
 As a quick recap, if you followed this guide, you should have done the following:
 

--- a/docs/authentication/social-connections/hubspot.mdx
+++ b/docs/authentication/social-connections/hubspot.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to create your own developer account wit
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a HubSpot Developer account. To create one, [click here](https://app.hubspot.com/signup/developers/step/existing-user?_ga=2.145169076.1430980384.1628431607-741498900.1628431607).
 
 ## Configuring HubSpot social connection
@@ -30,7 +30,7 @@ Once your app is created, click on the **Auth** tab and copy the **App Id** and 
 
 ![Configuring a HubSpot app](/docs/images/authentication-providers/hubspot/02d8bf249b4a6debe85e66ea53b5f88817acdba0-1489x995.png)
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) of your Clerk Dashboard and enable HubSpot. In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) of your Clerk Dashboard and enable HubSpot. In the modal that opened, ensure **Use custom credentials** is enabled and paste the values you obtained during the previous step.
 
 Before you close the modal, copy the **Authorized redirect URI**. Go back to the HubSpot panel and paste it into the **Redirect URL** field and click **Save**.
 

--- a/docs/authentication/social-connections/line.mdx
+++ b/docs/authentication/social-connections/line.mdx
@@ -21,7 +21,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a LINE developer account. To create one, [click here](https://developers.line.biz/en/).
 
 ## Configuring LINE social connection
@@ -39,7 +39,7 @@ The next step is to create a new **LINE Login channel**. You will have to select
 
 In the next screen, after the app has been created, you will find the **Basic settings** of the application. If you want to also make email address available for your application, you will have to apply for **Email address permission** in the bottom of your app's **Basic settings**.
 
-You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) of your Clerk Dashboard and enable LINE. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **LINE login → Callback URL** input.
+You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) of your Clerk Dashboard and enable LINE. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **LINE login → Callback URL** input.
 
 Once all the above are complete, copy the **Channel ID** and **Channel secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/linear.mdx
+++ b/docs/authentication/social-connections/linear.mdx
@@ -19,14 +19,14 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Linear account. To create one, [click here](https://linear.app).
 
 ## Configuring Linear social connection
 
 First, you need to create a new OAuth Linear app. Navigate on your **Settings > Account > API > OAuth applications** and click on **Create new**. On the modal that pops up, enter all the necessary info for your new app such as the name, the logo etc. 
 
-For the Callback URLs field, go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Linear. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste this value in the Callback URLs field of your Linear application.
+For the Callback URLs field, go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Linear. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste this value in the Callback URLs field of your Linear application.
 
 <Images
   width={1399}

--- a/docs/authentication/social-connections/linkedin.mdx
+++ b/docs/authentication/social-connections/linkedin.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a LinkedIn account. To create one, [click here](https://developer.linkedin.com/).
 
 ## Configuring LinkedIn social connection
@@ -28,7 +28,7 @@ First, you need to create a new OAuth LinkedIn app.
 
 ![Creating an OAuth LinkedIn app](/docs/images/authentication-providers/linkedin/148540a6928a19c42d105d50c91bd4a61c1d3326-1096x978.png)
 
-You need to set a name, associate a LinkedIn page with it, and upload a logo for your new application. Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable LinkedIn. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URL** of your LinkedIn app, as shown below.
+You need to set a name, associate a LinkedIn page with it, and upload a logo for your new application. Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable LinkedIn. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URL** of your LinkedIn app, as shown below.
 
 ![Obtaining the Application ID and Client secret](/docs/images/authentication-providers/linkedin/c3532a2089d98362370241bc43355e95035555da-1089x837.png)
 

--- a/docs/authentication/social-connections/microsoft.mdx
+++ b/docs/authentication/social-connections/microsoft.mdx
@@ -17,7 +17,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Microsoft Azure account, you can sign up for one [here](https://azure.microsoft.com/en-us/free/).
 
 ## Limitations

--- a/docs/authentication/social-connections/notion.mdx
+++ b/docs/authentication/social-connections/notion.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Notion developer account. To create one, [click here](https://developers.notion.com/).
 
 ## Configuring Notion social connection
@@ -42,7 +42,7 @@ You need to set a name, a logo, and associate a Notion workspace with it. Make s
   alt="Configuring integration"
 />
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Notion. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URIs**, as shown below, after changing the integration type to **Public**. Fill any other information required from Notion and click Submit.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Notion. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **Redirect URIs**, as shown below, after changing the integration type to **Public**. Fill any other information required from Notion and click Submit.
 
 <Images
   width={1173}

--- a/docs/authentication/social-connections/oauth.mdx
+++ b/docs/authentication/social-connections/oauth.mdx
@@ -29,7 +29,7 @@ The easiest way to add social connections is by using Clerk's [prebuilt componen
 
 ## Configuration
 
-For development instances, Clerk uses pre-configured shared OAuth credentials and redirect URIs to make the development flow as smooth as possible. This means that you can enable any provider without additional configuration. Simply navigate to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections) in your Clerk Dashboard and toggle on the providers you want to use.
+For development instances, Clerk uses pre-configured shared OAuth credentials and redirect URIs to make the development flow as smooth as possible. This means that you can enable any provider without additional configuration. Simply navigate to the [Social Connections page](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections) in your Clerk Dashboard and toggle on the providers you want to use.
 
 <Images
   width={3024}

--- a/docs/authentication/social-connections/slack.mdx
+++ b/docs/authentication/social-connections/slack.mdx
@@ -21,7 +21,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Slack account. To create one, [click here](https://slack.com/get-started#/createnew).
 
 ## Configuring Slack social connection
@@ -35,7 +35,7 @@ First, you need to create a new OAuth Slack app. On the main [Slack apps page](h
   alt="Creating a new application"
 />
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Slack. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Navigate to **OAuth & Permissions > Redirect URLs** and paste the value to add a new record.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Slack. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Navigate to **OAuth & Permissions > Redirect URLs** and paste the value to add a new record.
 
 <Images
   width={1906}

--- a/docs/authentication/social-connections/spotify.mdx
+++ b/docs/authentication/social-connections/spotify.mdx
@@ -11,7 +11,7 @@ Clerk does not currently support preconfigured shared OAuth credentials for Spot
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Spotify developer account. To create one, [click here](https://developer.spotify.com/).
 
 ## Configuration
@@ -42,7 +42,7 @@ Once redirected to the application creation form, you need to set an **App name*
 	
 You can retrieve the **Redirect URI** from the Clerk Dashboard. But first, you need to enable Spotify as a social connection for your Clerk application. 
 	
-Navigate to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections) in your Clerk Dashboard. Toggle on the Spotify option. 
+Navigate to the [Social Connections page](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections) in your Clerk Dashboard. Toggle on the Spotify option. 
 
 <Images
   width={3024}
@@ -78,7 +78,7 @@ Once your Spotify app is created, you'll be redirected to the app dashboard. Fro
 Copy the **Client ID** and **Client Secret**. Go back to the Clerk Dashboard, where the modal should still be open, and paste these values into the respective fields. 
 
 <Callout type="info">
-  If the modal or page is not still open, navigate to the [Social Connections](https://dashboard.clerk.dev/last-active?path=user-authentication/social-connections) page in the Clerk Dashboard and click on the settings cog icon next to the Spotify option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
+  If the modal or page is not still open, navigate to the [Social Connections](https://dashboard.clerk.com/last-active?path=user-authentication/social-connections) page in the Clerk Dashboard and click on the settings cog icon next to the Spotify option. You can now paste the **Client ID** and **Client Secret** into their respective fields.
 </Callout>
 
 <Images

--- a/docs/authentication/social-connections/tiktok.mdx
+++ b/docs/authentication/social-connections/tiktok.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to create your own developer account wit
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a TikTok Developer account. To create one, visit the [TikTok for developers](https://developers.tiktok.com/) page and click on Login ➜ Sign Up
 
 ## Configuring TikTok social connection
@@ -30,7 +30,7 @@ First, you need to create a new TikTok app. Go to the [TikTok for developers](ht
 
 Add an icon and a name for your new project and hit **Start**.
 
-You'll get redirected to the app creation form. Notice that you need to fill the **Callback URL** and **Redirect domain** fields. Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable TikTok. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**.
+You'll get redirected to the app creation form. Notice that you need to fill the **Callback URL** and **Redirect domain** fields. Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable TikTok. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**.
 
 ![Filling in the Callback URL and Redirect Domain fields](/docs/images/authentication-providers/tiktok/135491407e1afeea187644e4450fb77bb659d907-1489x964.png)
 

--- a/docs/authentication/social-connections/twitch.mdx
+++ b/docs/authentication/social-connections/twitch.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Twitch account. To create one, [click here](https://www.twitch.tv/).
 
 ## Configuring Twitch social connection
@@ -30,7 +30,7 @@ First, you need to register a new OAuth Twitch app at the [Twitch Developers Con
 
 ![Creating an OAuth Twitch app](/docs/images/authentication-providers/twitch/b23861d81906f6e2feedd314c520dc3b0d744d70-1891x757.png)
 
-Set a name and a category for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Twitch. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **OAuth Redirect URLs** input and click create.
+Set a name and a category for your new application. You also need to add the **OAuth Redirect URLs.** Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Twitch. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Paste the value into the **OAuth Redirect URLs** input and click create.
 
 Once all the above are complete, copy the **Client ID** and **Client Secret.** Go back to the Clerk Dashboard and paste them into the respective fields.
 

--- a/docs/authentication/social-connections/twitter.mdx
+++ b/docs/authentication/social-connections/twitter.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Twitter Application set up so it can be used for Social connection. If you don't have a Twitter Application, click [here](https://developer.twitter.com/en/docs/apps/overview) for instructions on how to create one. If you already have one, please go to your [Twitter app settings](https://developer.twitter.com/content/developer-twitter/en/docs/basics/developer-portal/guides/apps) and ensure that the *"Allow this app to be used to Sign in with Twitter?*” option is enabled.
 
 ## Configuring Twitter social connection
@@ -30,7 +30,7 @@ To do so, go to "[Projects & Apps](https://developer.twitter.com/en/portal/proje
 
 > You will need your application to be approved for elevated status to be able to use it with Clerk. You can apply for the status in [Twitter developer dashboard](https://developer.twitter.com/en/portal/products/elevated)
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashbord and enable Twitter. In the modal that opened, ensure **Use custom credentials** is enabled and paste the **API Key** and **API Secret** values which you copied in the previous step. Then, copy the **Authorized redirect URI**.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashbord and enable Twitter. In the modal that opened, ensure **Use custom credentials** is enabled and paste the **API Key** and **API Secret** values which you copied in the previous step. Then, copy the **Authorized redirect URI**.
 
 Navigate to your application settings screen and scroll down to the **User authentication settings** section and click **Set up**.
 

--- a/docs/authentication/social-connections/xero.mdx
+++ b/docs/authentication/social-connections/xero.mdx
@@ -19,7 +19,7 @@ For production instances, you will need to generate your own Client ID and Clien
 
 ## Before you start
 
-- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
+- You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/). For more information, check out our [Set up your application guide](/docs/quickstarts/setup-clerk).
 - You need to have a Xero developer account. To create one, [click here](https://developer.xero.com/).
 
 ## Configuring Xero social connection
@@ -33,7 +33,7 @@ First, you need to create a new OAuth2 Xero app. Click New App and fill all the 
   alt="Creating a new application"
 />
 
-Go to the [Social Connections page](https://dashboard.clerk.dev/last-active?path=authentication/social) in your Clerk Dashboard and enable Xero. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
+Go to the [Social Connections page](https://dashboard.clerk.com/last-active?path=authentication/social) in your Clerk Dashboard and enable Xero. In the modal that opened, ensure **Use custom credentials** is enabled and copy **Authorized redirect URI**. Make sure the value matches the **Redirect URIs**, as shown below.
 
 <Images
   width={1909}

--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -12,7 +12,7 @@ description: The <SignIn /> component renders a UI for signing in users.
   alt="Sign in component example"
 />
 
-The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev). You can further customize your `<SignIn />` component by passing additional properties at the time of rendering.
+The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your `<SignIn />` component by passing additional properties at the time of rendering.
 
 ## Usage
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -12,7 +12,7 @@ description: The <SignUp /> component renders a UI for signing up users.
   alt="Sign up component example"
 />
 
-The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev). You can further customize your `<SignUp />` component by passing additional properties at the time of rendering.
+The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your `<SignUp />` component by passing additional properties at the time of rendering.
 
 ## Usage
 

--- a/docs/components/customization/layout.mdx
+++ b/docs/components/customization/layout.mdx
@@ -21,7 +21,7 @@ import { ClerkProvider } from '@clerk/nextjs';
     layout: {
       socialButtonsPlacement: 'bottom',
       socialButtonsVariant: 'iconButton',
-      termsPageUrl: 'https://clerk.dev/terms'
+      termsPageUrl: 'https://clerk.com/terms'
     }
   }}
 >

--- a/docs/custom-flows/email-password.mdx
+++ b/docs/custom-flows/email-password.mdx
@@ -11,7 +11,7 @@ Clerk supports password authentication, which allows users to sign up and sign i
 
 ### Enable password and email
 
-In the Clerk dashboard, you will need to enable both email and password as a sign-in and sign-up method. Navigate to the [Email, Phone, and Username](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username) tab of the **User & Authentication** section in the Clerk Dashboard. Toggle on **Email address** and **Password**.
+In the Clerk dashboard, you will need to enable both email and password as a sign-in and sign-up method. Navigate to the [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) tab of the **User & Authentication** section in the Clerk Dashboard. Toggle on **Email address** and **Password**.
 
 <Images
   width={3024}

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -28,7 +28,7 @@ The rest of this guide will explain how to set up passwordless authentication us
 
 ## Configuration
 
-Passwordless authentication can be configured through the [Clerk Dashboard](https://dashboard.clerk.com/). Navigate to the [Email, Phone, and Username](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username) tab of the **User & Authentication** section in the Clerk Dashboard. In the **Authentication factors** section of this page, choose one of the available passwordless authentication strategies that send one-time codes.
+Passwordless authentication can be configured through the [Clerk Dashboard](https://dashboard.clerk.com/). Navigate to the [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) tab of the **User & Authentication** section in the Clerk Dashboard. In the **Authentication factors** section of this page, choose one of the available passwordless authentication strategies that send one-time codes.
 
 <Images 
   width={3024}

--- a/docs/custom-flows/magic-links.mdx
+++ b/docs/custom-flows/magic-links.mdx
@@ -45,7 +45,7 @@ We take care of the boring stuff, like efficient polling, secure session managem
 
 ## Configuration
 
-Magic link authentication can be configured through the [Clerk Dashboard](https://dashboard.clerk.com/). Navigate to the [Email, Phone, and Username](https://dashboard.clerk.dev/last-active?path=user-authentication/email-phone-username) tab of the **User & Authentication** section in the Clerk Dashboard. In the **Authentication factors** section of this page, choose **Email verification link** as the authentication factor.
+Magic link authentication can be configured through the [Clerk Dashboard](https://dashboard.clerk.com/). Navigate to the [Email, Phone, and Username](https://dashboard.clerk.com/last-active?path=user-authentication/email-phone-username) tab of the **User & Authentication** section in the Clerk Dashboard. In the **Authentication factors** section of this page, choose **Email verification link** as the authentication factor.
 
 <Images 
   width={3024}

--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -61,7 +61,7 @@ At the root of your project, install the ClerkJS package using your package mana
 
 ### Set environment keys
 
-To use the ClerkJS package, you'll need to copy your **Publishable Key** from the [API Keys](https://dashboard.clerk.dev/last-active?path=api-keys) page in the Clerk Dashboard. On this same page, click on the **Advanced** dropdown and copy your **Frontend API URL**. If you are signed into your Clerk Dashboard, your **Publishable key** should be visible.
+To use the ClerkJS package, you'll need to copy your **Publishable Key** from the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. On this same page, click on the **Advanced** dropdown and copy your **Frontend API URL**. If you are signed into your Clerk Dashboard, your **Publishable key** should be visible.
 
 <InjectKeys>
 

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -218,7 +218,7 @@ export const ErrorBoundary = ClerkErrorBoundary(YourBoundary);
 
 In addition to the [Account Portal pages](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign-in, sign-up, and other user management functions into your Remix application. We are going to use the `<SignIn /> `and `<SignUp />` components by utilizing the Remix optional catch-all route.
 
-The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev).
+The functionality of the components are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com).
 
 #### Build your sign-up page
 

--- a/docs/references/javascript/clerk/sign-in.mdx
+++ b/docs/references/javascript/clerk/sign-in.mdx
@@ -7,7 +7,7 @@ description: The <SignIn /> component renders a UI for signing in users. The fun
 
 <Images width={496} height={564} src="/docs/images/ui-components/component-sign_in.svg" alt="Sign in component example" />
 
-The [`<SignIn />`][signin-ref] component renders a UI for signing in users. The functionality of the [`<SignIn />`][signin-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev). You can further customize your [`<SignIn />`][signin-ref] component by passing additional properties at the time of rendering.
+The [`<SignIn />`][signin-ref] component renders a UI for signing in users. The functionality of the [`<SignIn />`][signin-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your [`<SignIn />`][signin-ref] component by passing additional properties at the time of rendering.
 
 > All of these are methods on [an instance of the `Clerk` class](/docs/references/javascript/clerk/clerk).
 

--- a/docs/references/javascript/clerk/sign-up.mdx
+++ b/docs/references/javascript/clerk/sign-up.mdx
@@ -7,7 +7,7 @@ description: The <SignUp /> component renders a UI for signing up users. The fun
 
 <Images width={496} height={780} src="/docs/images/ui-components/component-sign_up.svg" alt="Sign up component example" />
 
-The [`<SignUp />`][signup-ref] component renders a UI for signing up users. The functionality of the [`<SignUp />`][signup-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.dev). You can further customize your [`<SignUp />`][signup-ref] component by passing additional properties at the time of rendering.
+The [`<SignUp />`][signup-ref] component renders a UI for signing up users. The functionality of the [`<SignUp />`][signup-ref] component are controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your [`<SignUp />`][signup-ref] component by passing additional properties at the time of rendering.
 
 > All of these are methods on [an instance of the `Clerk` class](/docs/references/javascript/clerk/clerk).
 

--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -15,7 +15,7 @@ While we typically recommend using one of our framework bindings (such as [our R
 
 There are two ways you can include ClerkJS in your project. You can either [import the ClerkJS npm module](#install-clerk-js-as-es-module) or [load ClerkJS with a script tag](#install-clerk-js-as-script).
 
-> You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.dev/) before you can set up ClerkJS. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
+> You need to create a Clerk Application in your [Clerk Dashboard](https://dashboard.clerk.com/) before you can set up ClerkJS. For more information, check out our [Set up your application](/docs/quickstarts/setup-clerk) guide.
 
 ### Install ClerkJS as ES module
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -46,8 +46,8 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
 | `backupCodeEnabled` | `boolean` | A boolean indicating whether the user has enabled Backup codes. |
 | `createOrganizationEnabled` | `boolean` | A boolean indicating whether the organization creation is enabled for the user or not. |
 | `deleteSelfEnabled` | `boolean` | A boolean indicating whether the user is able to delete their own account or not. |
-| `publicMetadata` | `{[string]: any} \| null` | Metadata that can be read from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) and [Backend API](https://clerk.dev/docs/reference/backend-api) and can be set only from the Backend API . |
-| `privateMetadata` | `{[string]: any} \| null` | Metadata that can be read and set only from the [Backend API](https://clerk.dev/docs/reference/backend-api). |
+| `publicMetadata` | `{[string]: any} \| null` | Metadata that can be read from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) and [Backend API](https://clerk.com/docs/reference/backend-api) and can be set only from the Backend API . |
+| `privateMetadata` | `{[string]: any} \| null` | Metadata that can be read and set only from the [Backend API](https://clerk.com/docs/reference/backend-api). |
 | `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference). One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
 | `lastSignInAt` | `Date` | Date when the user last signed in. May be empty if the user has never signed in. |
 | `createdAt` | `Date` | Date when the user was first created. |

--- a/docs/security/vulnerability-disclosure-policy.mdx
+++ b/docs/security/vulnerability-disclosure-policy.mdx
@@ -22,22 +22,22 @@ If you follow these guidelines when reporting an issue to us, we commit to:
 - Recognize your contribution on our Security Researcher Hall of Fame, if you are the first to report the issue and we make a code or configuration change based on the issue.
 
 ## Scope
-- `https://dashboard.clerk.dev`
+- `https://dashboard.clerk.com`
 - `https://accounts.clerk.dev`
 - `https://api.clerk.dev`
 - `https://clerk.clerk.dev`
-- Production instances created on `https://dashboard.clerk.dev`
+- Production instances created on `https://dashboard.clerk.com`
 
 ## Out of scope
 
 Any services hosted by 3rd party providers and services are excluded from scope. These services include:
 
-- `https://clerk.dev`
+- `https://clerk.com`
 - `https://docs.clerk.dev`
 
 In the interest of the safety of our users, staff, the Internet at large and you as a security researcher, the following test types are excluded from scope:
 
-- Findings in Development or Staging instances created on `https://dashboard.clerk.dev`
+- Findings in Development or Staging instances created on `https://dashboard.clerk.com`
 - Findings from physical testing such as office access (e.g. open doors, tailgating)
 - Findings derived primarily from social engineering (e.g. phishing, vishing)
 - Findings from applications or systems not listed in the ‘Scope’ section

--- a/docs/troubleshooting/email-deliverability.mdx
+++ b/docs/troubleshooting/email-deliverability.mdx
@@ -38,7 +38,7 @@ Email providers check against a pool of IP addresses and domain blacklists to pr
 Every domain name (i.e. `example.com`, `clerk.com`, etc.) has its own reputation score. Newer domains do not have a high score, and this may impact deliverability.
 
 ### Setup a real email address
-Email providers will check if there's an actual mailbox behind the "from address" of an email. By default, Clerk will send your emails from notifications@yourdomain.com. You should make sure that you set up a mailbox at this email address. If you'd like to use a different "from address", you can change its value via our [Backend API](https://clerk.dev/docs/reference/backend-api/tag/Beta-Features#operation/UpdateInstanceAuthConfig).
+Email providers will check if there's an actual mailbox behind the "from address" of an email. By default, Clerk will send your emails from notifications@yourdomain.com. You should make sure that you set up a mailbox at this email address. If you'd like to use a different "from address", you can change its value via our [Backend API](https://clerk.com/docs/reference/backend-api/tag/Beta-Features#operation/UpdateInstanceAuthConfig).
 
 ### Email content
 The email content is scanned by email providers, so this also plays a crucial role in determining if an email clears spam filters. Clerk's default verification email copy is optimized based on trial and error, so, make modifications to the default template at your own risk. However, minor changes are usually ok.


### PR DESCRIPTION
As-is, certain `*clerk.dev` TLDs redirect to `*.clerk.com`. This PR simply removes that redirect.