### PR TITLE
DOCS-336 lead examples with app router

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -272,10 +272,11 @@ export default function Example() {
 
 [`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are App Router-specific helpers that you can use inside of your Route Handlers, Middleware, Server Components, and Server Actions.
 
-
 The [`auth()`][auth-ref] helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Now that request data is available in the global scope through Next.js's `headers()` and `cookies()` methods, passing the request object to Clerk is no longer required.
 
 The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-object] object of the currently active user. This is helpful if you want to render information, like their first and last name, directly from the server.
+
+ Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backend/overview) wrapper to make a call to Clerk's Backend API. This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits). This also uses `fetch()` so it is automatically deduped per request.
 
 <Callout type="info">
   Any requests from a Client Component to a Route Handler will automatically include the user's current token as the Bearer token.
@@ -283,17 +284,16 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
 
 <Tabs items={["Server components and actions", "Route Handler", "Route Handler w/ User Fetch"]}>
   <Tab>
-      Clerk has introduced new [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) helpers for use in server components and server actions. The `auth()` helper returns the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of the user. The `currentUser()` helper loads the [`User`][user-object] object for the authenticated user. This is helpful if you want to render information, like their first and last name, directly from the server.
-
-    Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backend/overview) wrapper to make a call to Clerk's Backend API. This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits). This also uses `fetch()` so it is automatically deduped per request.
-
+    This example uses the new `auth()` helper to validate an authenticated user and the new `currentUser()` helper to access the [`User`][user-object] object for the authenticated user.
 
     ```tsx filename="app/page.tsx"
     import { auth, currentUser } from "@clerk/nextjs";
 
     export default async function Page() {
 
-      // Get the userId from auth() -- if null the user is not logged in
+      // Get the userId from auth() -- if null, the user is not logged in
+      const { userId } = auth();
+
       if (userId) {
         // Query DB for user specific information or display assets only to logged in users 
       }
@@ -328,8 +328,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
   <Tab>
     A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
-    In some cases, you may need the full [`User`][user-object] object to retrieve information such as the user's email address or name. You can access the [`User`][user-object] object by using the [`currentUser()`](/docs/references/nextjs/current-user) helper. Under the hood, this helper calls `fetch()` so it is automatically deduped per request.
-
+    In this example, the `auth()` helper is used to validate an authenticated user and the `currentUser()` helper is used to access the [`User`][user-object] object for the authenticated user.
 
    ```tsx filename="app/api/user/route.ts"
     import { NextResponse } from 'next/server';

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -472,3 +472,5 @@ Now that your Next.js application is integrated with Clerk, you will want to rea
 [user-object]: /docs/references/javascript/user/user
 [auth-ref]: /docs/references/nextjs/auth
 [currentuser-ref]: /docs/references/nextjs/current-user
+[get-auth]: /docs/references/nextjs/get-auth
+[clerk-client]: /docs/references/backend/overview

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -386,7 +386,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     You can access the active session and user data in your `getServerSideProps` using the [`getAuth`](/docs/references/nextjs/get-auth) helper.
 
     <Callout type="info" emoji="ℹ️">
-      Please note the addition of `buildClerkProps` in the return statement, which informs our React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
+      Please note the addition of `buildClerkProps` in the return statement, which informs the Clerk React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
+
     </Callout>
 
     ```tsx filename="pages/example.tsx"

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -283,7 +283,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
 
 <Tabs items={["Route Handler", "Route Handler w/ User Fetch"]}>
   <Tab>
-    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected by [middleware](/docs/references/nextjs/auth-middleware). 
+    A Route Hanlder added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
     ```tsx filename="app/api/user/route.[jsx/tsx]"
     import { NextResponse } from 'next/server';
@@ -304,7 +304,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     ```
   </Tab>
   <Tab>
-    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected by [middleware](/docs/references/nextjs/auth-middleware). 
+    A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
     In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use  [`currentUser()`](/docs/references/nextjs/current-user) helper to get the full [`User`][user-object] object. Under the hood, this calls `fetch()` so it is automatically deduped per request.
 
@@ -334,7 +334,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
 
 <Tabs items={["API Route", "API Route w/ User Fetch", "getServerSideProps"]}>
   <Tab>
-    For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
+    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
     ```tsx filename="pages/api/auth.ts"
     import type { NextApiRequest, NextApiResponse } from "next";
@@ -354,8 +354,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     ```
   </Tab>
   <Tab>
-    For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
-     
+    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+
     In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 
     ```tsx filename="pages/api/auth.ts"

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -312,7 +312,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     import { NextResponse } from 'next/server';
     import { currentUser, auth } from "@clerk/nextjs";
 
-    export async function GET(req: Request, res: NextResponse) {
+    export async function GET() {
+
       const { userId } = auth();
 
       if (!userId) {

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -113,18 +113,13 @@ export const config = {
 
 With this middleware, your entire application is protected. If you try to access it, the middleware will redirect you to your Sign Up page. If you want to make other routes public, check out the [authMiddleware reference page](/docs/references/nextjs/auth-middleware).
 
-
-
-
-
-### Build your own sign in and sign up pages
+### Build your own sign-in and sign-up pages
 
 At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of the box. You can start your Next.js application via `npm run dev`, visit `http://localhost:3000`, and sign up to get access to your application. 
 
 Clerk also offers a set of [prebuilt components](/docs/components/overview) and [custom flows](/docs/custom-flows/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components by utilizing the Next.js optional catch-all route.
 
-#### Build your sign up page
-
+#### Build your sign-up page
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
   ```tsx filename="app/sign-up/[[...sign-up]]/page.tsx"
@@ -144,8 +139,7 @@ Clerk also offers a set of [prebuilt components](/docs/components/overview) and 
   ```
 </CodeBlockTabs>
 
-#### Build your sign in page
-
+#### Build your sign-in page
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
   ```tsx filename="app/sign-in/[[...sign-in]]/page.tsx"
@@ -168,7 +162,6 @@ Clerk also offers a set of [prebuilt components](/docs/components/overview) and 
 <Callout type="info" emoji="ℹ️">
   By default, the Clerk components inherit the font family. `create-next-app` does not apply a global font family. When you launch your application, you may notice that the font family is different.
 </Callout>
-
 
 #### Update your environment variables
 
@@ -277,11 +270,11 @@ export default function Example() {
 
 #### App Router
 
-[`getAuth()`](/docs/references/nextjs/get-auth) will retrieve the userId of a authenticated user in your Route Handlers. Any requests from a Client Component will automatically include the user's current token as the Bearer token. [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can user inside of your Server Components and Actions.
+[`getAuth()`](/docs/references/nextjs/get-auth) will retrieve the `userId` of an authenticated user in your Route Handlers. Any requests from a Client Component will automatically include the user's current token as the Bearer token. [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can use inside of your Server Components and Actions.
 
 <Tabs items={["Route Handler", "Route Handler w/ User Fetch", "auth()", "currentUser()"]}>
   <Tab>
-    For Next.js applications using the App Router, you can protect your API routes by using the [`auth`](/docs/references/nextjs/auth) helper. 
+    You can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. 
 
     ```tsx filename="app/api/user/route.[jsx/tsx]"
     import { NextResponse } from 'next/server';
@@ -301,7 +294,9 @@ export default function Example() {
     ```
   </Tab>
   <Tab>
-    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
+    You can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. 
+
+    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 
    ```tsx filename="app/api/user/route.ts"
    import { NextResponse } from 'next/server';
@@ -323,9 +318,6 @@ export default function Example() {
   ```
   </Tab>
   <Tab>
-    
-    #### **`auth()`**
-
     Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the same [`Authentication` Object](/docs/references/nextjs/authentication-object) as [`getAuth(req)`](/docs/references/nextjs/get-auth) in middleware, getServerSideProps, and API routes.
 
     Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
@@ -341,9 +333,7 @@ export default function Example() {
     </Tab>
 
     <Tab>
-    #### **`currentUser()`**
-
-    [`currentUser()`](/docs/references/nextjs/current-user) loads the [`User`][user-object] object for the authenticated user from Clerk's backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
+    Clerk has introduced a new [`currentUser()`](/docs/references/nextjs/current-user) helper that loads the [`User`][user-object] object for the authenticated user from Clerk's Backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
 
     Under the hood, this calls `fetch()` so it is automatically deduped per request.
 
@@ -361,7 +351,7 @@ export default function Example() {
 
 #### Pages Router
 
-<Tabs items={["Api Route", "Api Route w/ User Fetch", "getServerSideProps"]}>
+<Tabs items={["API Route", "API Route w/ User Fetch", "getServerSideProps"]}>
 
   <Tab>
     For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
@@ -385,6 +375,9 @@ export default function Example() {
     ```
   </Tab>
   <Tab>
+    For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
+     
+    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 
     ```tsx filename="pages/api/auth.ts"
     import { clerkClient } from "@clerk/nextjs";
@@ -450,7 +443,6 @@ export default function Example() {
     };
     ```
   </Tab>
-
 
 </Tabs>
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -275,104 +275,54 @@ export default function Example() {
 
 ### Server side
 
-#### API Routes
+#### App Router
 
-<Tabs items={["App Router", "Pages Router"]}>
-<Tab>
-For Next.js applications using the App Router, you can protect your API routes by using the [`auth`](/docs/references/nextjs/auth) helper. 
+[`getAuth()`](/docs/references/nextjs/get-auth) will retrieve the userId of a authenticated user in your Route Handlers. Any requests from a Client Component will automatically include the user's current token as the Bearer token. [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can user inside of your Server Components and Actions.
 
-```tsx filename="app/api/user/route.[jsx/tsx]"
-import { NextResponse } from 'next/server';
-import { getAuth } from '@clerk/nextjs/server';
- 
-export async function POST(req: Request, res: NextResponse) {  
-  const { userId } = getAuth(req);
-  
-  if(!userId){
-    return NextResponse("Unauthorized", { status: 401 });
-  }
-
-  // Perform your Route Handler's logic
-
-  return NextResponse.json({ userId }, { status: 200 });
-}
-```
-</Tab>
-
-<Tab>
-For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
-
-```tsx filename="pages/api/auth.ts"
-import type { NextApiRequest, NextApiResponse } from "next";
-import { getAuth } from "@clerk/nextjs/server";
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { userId } = getAuth(req);
-
-  if (!userId) {
-    res.status(401).json({ error: "Unauthorized" });
-    return;
-  }
-
-  // retrieve data from your database
-
-  res.status(200).json({});
-}
-```
-</Tab>
-</Tabs>
-
-In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
-
-<CodeBlockTabs options={["App Router", "Pages Router"]}>
-```tsx filename="app/api/user/route.ts"
-import { NextResponse } from 'next/server';
-import { clerkClient, getAuth } from "@clerk/nextjs/server";
-
-export async function POST(req: Request, res: NextResponse) {  
-  const { userId } = getAuth(req);
-  
-  if(!userId){
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
-
-  const user = await clerkClient.users.getUser(userId);
-
-  // Perform your Route Handler's logic with the returned user object
-
-  return NextResponse.json({"user": user}, { status: 200})
-}
-````
-
-```tsx filename="pages/api/auth.ts"
-import { clerkClient } from "@clerk/nextjs";
-import { getAuth } from "@clerk/nextjs/server";
-import type { NextApiRequest, NextApiResponse } from "next";
-
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const { userId } = getAuth(req);
-
-  if (!userId) {
-    return res.status(401).json({ error: "Unauthorized" });
-  }
-
-  const user = userId ? await clerkClient.users.getUser(userId) : null;
-
-  // use the user object to decide what data to return
-
-  return res.status(200).json({});
-}
-```
-</CodeBlockTabs>
-
-### Server side render user data
-
-<Tabs items={["App Router", "Pages Router"]}>
+<Tabs items={["Route Handler", "Route Handler w/ User Fetch", "auth()", "currentUser()"]}>
   <Tab>
-    [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can user inside of your Server Components and Actions.
+    For Next.js applications using the App Router, you can protect your API routes by using the [`auth`](/docs/references/nextjs/auth) helper. 
+
+    ```tsx filename="app/api/user/route.[jsx/tsx]"
+    import { NextResponse } from 'next/server';
+    import { getAuth } from '@clerk/nextjs/server';
+ 
+    export async function POST(req: Request, res: NextResponse) {  
+      const { userId } = getAuth(req);
+  
+      if(!userId){
+        return NextResponse("Unauthorized", { status: 401 });
+      }
+
+      // Perform your Route Handler's logic
+
+      return NextResponse.json({ userId }, { status: 200 });
+    }
+    ```
+  </Tab>
+  <Tab>
+    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
+
+   ```tsx filename="app/api/user/route.ts"
+   import { NextResponse } from 'next/server';
+    import { clerkClient, getAuth } from "@clerk/nextjs/server";
+
+    export async function POST(req: Request, res: NextResponse) {  
+      const { userId } = getAuth(req);
+  
+      if(!userId){
+        return new NextResponse("Unauthorized", { status: 401 });
+      }
+
+     const user = await clerkClient.users.getUser(userId);
+
+      // Perform your Route Handler's logic with the returned user object
+
+     return NextResponse.json({"user": user}, { status: 200})
+    }
+  ```
+  </Tab>
+  <Tab>
     
     #### **`auth()`**
 
@@ -388,7 +338,9 @@ export default async function handler(
       // ...
     }
     ```
+    </Tab>
 
+    <Tab>
     #### **`currentUser()`**
 
     [`currentUser()`](/docs/references/nextjs/current-user) loads the [`User`][user-object] object for the authenticated user from Clerk's backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
@@ -403,7 +355,60 @@ export default async function handler(
       // ...
     }
     ```
-     </Tab>
+  </Tab>
+
+</Tabs>
+
+#### Pages Router
+
+<Tabs items={["Api Route", "Api Route w/ User Fetch", "getServerSideProps"]}>
+
+  <Tab>
+    For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
+
+    ```tsx filename="pages/api/auth.ts"
+    import type { NextApiRequest, NextApiResponse } from "next";
+    import { getAuth } from "@clerk/nextjs/server";
+
+    export default function handler(req: NextApiRequest, res: NextApiResponse) {
+      const { userId } = getAuth(req);
+
+      if (!userId) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+
+      // retrieve data from your database
+  
+      res.status(200).json({});
+    }
+    ```
+  </Tab>
+  <Tab>
+
+    ```tsx filename="pages/api/auth.ts"
+    import { clerkClient } from "@clerk/nextjs";
+    import { getAuth } from "@clerk/nextjs/server";
+    import type { NextApiRequest, NextApiResponse } from "next";
+
+    export default async function handler(
+      req: NextApiRequest,
+      res: NextApiResponse
+    ) {
+      const { userId } = getAuth(req);
+
+      if (!userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      const user = userId ? await clerkClient.users.getUser(userId) : null;
+
+      // use the user object to decide what data to return
+
+      return res.status(200).json({});
+    }
+    ```
+  </Tab>
 
   <Tab>
     You can access the active session and user data in your `getServerSideProps` using the [`getAuth`](/docs/references/nextjs/get-auth) helper.
@@ -445,7 +450,10 @@ export default async function handler(
     };
     ```
   </Tab>
+
+
 </Tabs>
+
 
 ## Next steps
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -11,7 +11,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 ### Install `@clerk/nextjs`
 
-Once you have a Next.js application ready, you need to install Clerk's Next.js SDK. This gives you access to prebuilt components and hooks, as well as [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and middleware.
+Once you have a Next.js application ready, you need to install Clerk's Next.js SDK. This gives you access to prebuilt components and hooks, as well as [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and Middleware.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
   ```bash filename="terminal"
@@ -102,7 +102,7 @@ import { authMiddleware } from "@clerk/nextjs";
 
 // This example protects all routes including api/trpc routes
 // Please edit this to allow other routes to be public as needed.
-// See https://clerk.com/docs/references/nextjs/auth-middleware for more information about configuring your middleware
+// See https://clerk.com/docs/references/nextjs/auth-middleware for more information about configuring your Middleware
 export default authMiddleware({});
 
 export const config = {
@@ -111,7 +111,7 @@ export const config = {
 
 ```
 
-With this middleware, your entire application is protected. If you try to access it, the middleware will redirect you to your Sign Up page. If you want to make other routes public, check out the [authMiddleware reference page](/docs/references/nextjs/auth-middleware).
+With this Middleware, your entire application is protected. If you try to access it, the Middleware will redirect you to your Sign Up page. If you want to make other routes public, check out the [authMiddleware reference page](/docs/references/nextjs/auth-middleware).
 
 ### Build your own sign-in and sign-up pages
 
@@ -270,7 +270,7 @@ export default function Example() {
 
 #### App Router
 
-[`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are App Router-specific helpers that you can use inside of your Route Handlers, middleware, Server Components, and Server Actions.
+[`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are App Router-specific helpers that you can use inside of your Route Handlers, Middleware, Server Components, and Server Actions.
 
 
 The [`auth()`][auth-ref] helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Now that request data is available in the global scope through Next.js's `headers()` and `cookies()` methods, passing the request object to Clerk is no longer required.
@@ -283,7 +283,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
 
 <Tabs items={["Route Handler", "Route Handler w/ User Fetch"]}>
   <Tab>
-    A Route Hanlder added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+    A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
     ```tsx filename="app/api/user/route.[jsx/tsx]"
     import { NextResponse } from 'next/server';
@@ -334,7 +334,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
 
 <Tabs items={["API Route", "API Route w/ User Fetch", "getServerSideProps"]}>
   <Tab>
-    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth()`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
     ```tsx filename="pages/api/auth.ts"
     import type { NextApiRequest, NextApiResponse } from "next";
@@ -354,7 +354,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     ```
   </Tab>
   <Tab>
-    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth()`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
     In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 
@@ -383,7 +383,7 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
   </Tab>
 
   <Tab>
-    You can access the active session and user data in your `getServerSideProps` using the [`getAuth`](/docs/references/nextjs/get-auth) helper.
+    You can access the active session and user data in your `getServerSideProps` using the [`getAuth()`](/docs/references/nextjs/get-auth) helper.
 
     <Callout type="info" emoji="ℹ️">
       Please note the addition of `buildClerkProps` in the return statement, which informs the Clerk React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -289,7 +289,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     import { NextResponse } from 'next/server';
     import { auth } from '@clerk/nextjs';
 
-    export async function GET(req: Request, res: NextResponse) {
+    export async function GET() {
+
       const { userId } = auth();
 
       if (!userId) {

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -281,7 +281,26 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
   Any requests from a Client Component to a Route Handler will automatically include the user's current token as the Bearer token.
 </Callout>
 
-<Tabs items={["Route Handler", "Route Handler w/ User Fetch"]}>
+<Tabs items={["Server components and actions", "Route Handler", "Route Handler w/ User Fetch"]}>
+  <Tab>
+      Clerk has introduced new [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) helpers for use in server components and server actions. The `auth()` helper returns the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of the user. The `currentUser()` helper loads the [`User`][user-object] object for the authenticated user. This is helpful if you want to render information, like their first and last name, directly from the server.
+
+    Under the hood, `currentUser()` uses the `clerkClient` wrapper to make a call to Clerk's Backend API. This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits). This also uses `fetch()` so it is automatically deduped per request.
+
+    ```tsx filename="app/page.tsx"
+    import { auth, currentUser } from "@clerk/nextjs";
+
+    export default async function Page() {
+
+      // Get the userId from auth() -- if null the user is not logged in
+      const { userId } = auth();
+
+      // Get the User object when you need access to the user's information
+      const user = await currentUser()
+      // ...
+    }
+    ```
+  </Tab>
   <Tab>
     A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -376,7 +376,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     ```
   </Tab>
   <Tab>
-    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth()`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+    For Next.js applications using the Pages Router, you can retrieve information about the user and their authentication state, or control access to some or all of your API routes by using the [`getAuth()`][get-auth] helper. The [`getAuth()`][get-auth] helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+
 
     In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -432,7 +432,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     };
     ```
 
-    You can also access the full [`User`][user-object] object before passing it to the page by using the `clerkClient` helper.
+    You can also access the full [`User`][user-object] object before passing it to the page by using the [`clerkClient`][clerk-client] helper.
+
 
     ```tsx filename="pages/example.tsx"
     import { clerkClient } from "@clerk/nextjs";

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -273,7 +273,7 @@ export default function Example() {
 [`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are App Router-specific helpers that you can use inside of your Route Handlers, middleware, Server Components, and Server Actions.
 
 
-The [`auth()`][auth-ref] helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
+The [`auth()`][auth-ref] helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Now that request data is available in the global scope through Next.js's `headers()` and `cookies()` methods, passing the request object to Clerk is no longer required.
 
 The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-object] object of the currently active user. This is helpful if you want to render information, like their first and last name, directly from the server.
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -285,7 +285,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
   <Tab>
       Clerk has introduced new [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) helpers for use in server components and server actions. The `auth()` helper returns the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of the user. The `currentUser()` helper loads the [`User`][user-object] object for the authenticated user. This is helpful if you want to render information, like their first and last name, directly from the server.
 
-    Under the hood, `currentUser()` uses the `clerkClient` wrapper to make a call to Clerk's Backend API. This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits). This also uses `fetch()` so it is automatically deduped per request.
+    Under the hood, `currentUser()` uses the [`clerkClient`](/docs/references/backend/overview) wrapper to make a call to Clerk's Backend API. This does count towards the [Backend API Request Rate Limit](/docs/backend-requests/resources/rate-limits#rate-limits). This also uses `fetch()` so it is automatically deduped per request.
+
 
     ```tsx filename="app/page.tsx"
     import { auth, currentUser } from "@clerk/nextjs";

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -405,7 +405,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
   </Tab>
 
   <Tab>
-    You can access the active session and user data in your `getServerSideProps` using the [`getAuth()`](/docs/references/nextjs/get-auth) helper.
+    You can access the active session and user data in your `getServerSideProps` using the [`getAuth()`][get-auth] helper.
+
 
     <Callout type="info" emoji="ℹ️">
       Please note the addition of `buildClerkProps` in the return statement, which informs the Clerk React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -326,7 +326,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
   <Tab>
     A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler. The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
-    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use  [`currentUser()`](/docs/references/nextjs/current-user) helper to get the full [`User`][user-object] object. Under the hood, this calls `fetch()` so it is automatically deduped per request.
+    In some cases, you may need the full [`User`][user-object] object to retrieve information such as the user's email address or name. You can access the [`User`][user-object] object by using the [`currentUser()`](/docs/references/nextjs/current-user) helper. Under the hood, this helper calls `fetch()` so it is automatically deduped per request.
+
 
    ```tsx filename="app/api/user/route.ts"
     import { NextResponse } from 'next/server';

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -270,7 +270,8 @@ export default function Example() {
 
 #### App Router
 
-[`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are new helpers that you can use inside of your Route Handlers, middleware, Server Components, and Server Actions.
+[`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are App Router-specific helpers that you can use inside of your Route Handlers, middleware, Server Components, and Server Actions.
+
 
 The [`auth()`][auth-ref] helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -42,13 +42,13 @@ CLERK_SECRET_KEY={{secret}}
 
 ### Mount `<ClerkProvider />`
 
-Add the [`<ClerkProvider />`](/docs/components/clerk-provider) wrapper to your application. The `<ClerkProvider />` component wraps your Next.js application to provide active session and user context to Clerk's hooks and other components. A reasonable default approach is to have `<ClerkProvider />` wrap the `<body/>` to enable the context to be accessible anywhere within the app.
+Add the [`<ClerkProvider />`][clerk-provider] wrapper to your application. The [`<ClerkProvider />`][clerk-provider] component wraps your Next.js application to provide active session and user context to Clerk's hooks and other components. A reasonable default approach is to have [`<ClerkProvider />`][clerk-provider] wrap the `<body/>` to enable the context to be accessible anywhere within the app.
 
 
 <Callout type="info">
-  The `<ClerkProvider />` component needs to access [headers](https://nextjs.org/docs/app/api-reference/functions/headers) to authenticate correctly. This means anything wrapped by the provider will be opted into [dynamic rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering) at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are <em>not</em> wrapped by `<ClerkProvider />`.
+  The [`<ClerkProvider />`][clerk-provider] component needs to access [headers](https://nextjs.org/docs/app/api-reference/functions/headers) to authenticate correctly. This means anything wrapped by the provider will be opted into [dynamic rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering) at request time. If you have static-optimized or ISR pages that you would prefer not to be opted into dynamic rendering, make sure they are <em>not</em> wrapped by [`<ClerkProvider />`][clerk-provider].
   
-  This is easiest to accomplish by ensuring that `<ClerkProvider />` is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires login, you would create separate `(marketing)` and `(dashboard)` route groups. Adding `<ClerkProvider />` to the `(dashboard)/layout.jsx` layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
+  This is easiest to accomplish by ensuring that [`<ClerkProvider />`][clerk-provider] is added further down the tree to wrap route groups that explicitly need authentication instead of having the provider wrap your application root as recommended above. For example, if your project includes a set of landing/marketing pages as well as a dashboard that requires login, you would create separate `(marketing)` and `(dashboard)` route groups. Adding [`<ClerkProvider />`][clerk-provider] to the `(dashboard)/layout.jsx` layout file will ensure that only those routes are opted into dynamic rendering, allowing the marketing routes to be statically optimized.
 
 </Callout>
 
@@ -90,7 +90,7 @@ export default MyApp;
 </CodeBlockTabs>
 
 <Callout type="warning">
-  The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
+  The root layout is a server component. If you plan to use the [`<ClerkProvider />`][clerk-provider] outside the root layout, it will need to be a server component as well.
 </Callout>
 
 ### Protect your application
@@ -116,14 +116,14 @@ With this middleware, your entire application is protected. If you try to access
 
 
 <Callout type="info" emoji="🎉">
- At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of box.
+ At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of the box.
  Start your Next.js application via `npm run dev`, visit `http://localhost:3000`, and sign up to get access to your application.
 </Callout>
 
 
 ### Build your own sign in and sign up pages
 
-In addition to the Account Portal, Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the `<SignIn />` and `<SignUp />` components by utilizing the Next.js optional catch-all route.
+In addition to the [Account Portal](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components by utilizing the Next.js optional catch-all route.
 
 #### Build your sign up page
 
@@ -279,7 +279,28 @@ export default function Example() {
 
 #### API Routes
 
-You can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
+<Tabs items={["App Router", "Pages Router"]}>
+<Tab>
+For Next.js applications using the App Router, you can protect your API routes by using the [`auth`](/docs/references/nextjs/auth) helper. 
+
+```tsx filename="app/page.[jsx/tsx]"
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs';
+ 
+export async function Page() {
+  const { userId } : { userId: string | null } = auth();
+  
+  if(!userId){
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return NextResponse.json({});
+}
+```
+</Tab>
+
+<Tab>
+For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
 
 ```tsx filename="pages/api/auth.ts"
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -287,18 +308,23 @@ import { getAuth } from "@clerk/nextjs/server";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { userId } = getAuth(req);
+
   if (!userId) {
     res.status(401).json({ error: "Unauthorized" });
     return;
   }
+
   // retrieve data from your database
+
   res.status(200).json({});
 }
 ```
+</Tab>
+</Tabs>
 
-In some cases, you may need the full [`User`](/docs/references/javascript/user/user) object. For example, if you want to access the user's email address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full `User` object.
+In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 
-
+<CodeBlockTabs options={["App Router", "Pages Router"]}>
 ```tsx filename="pages/api/auth.ts"
 import { clerkClient } from "@clerk/nextjs";
 import { getAuth } from "@clerk/nextjs/server";
@@ -322,13 +348,37 @@ export default async function handler(
 }
 ```
 
+```tsx filename="pages/api/auth.ts"
+import { clerkClient } from "@clerk/nextjs";
+import { getAuth } from "@clerk/nextjs/server";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { userId } = getAuth(req);
+
+  if (!userId) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const user = userId ? await clerkClient.users.getUser(userId) : null;
+
+  // use the user object to decide what data to return
+
+  return res.status(200).json({});
+}
+```
+</CodeBlockTabs>
+
 ### Server side render user data
 
 <Tabs items={["App Router", "Pages Router"]}>
   <Tab>
     #### **`currentUser()`**
 
-    [`currentUser()`](/docs/references/nextjs/current-user) loads the `User` object for the authenticated user from Clerk's backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
+    [`currentUser()`](/docs/references/nextjs/current-user) loads the [`User`][user-object] object for the authenticated user from Clerk's backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
 
     Under the hood, this calls `fetch()` so it is automatically deduped per request.
 
@@ -362,7 +412,7 @@ export default async function handler(
     You can access the active session and user data in your `getServerSideProps` using the [`getAuth`](/docs/references/nextjs/get-auth) helper.
 
     <Callout type="info" emoji="ℹ️">
-      Please note the addition of buildClerkProps in the return statement, which informs our React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
+      Please note the addition of `buildClerkProps` in the return statement, which informs our React helpers of the authentication state during server-side rendering (like `useAuth()`, `<SignedIn>`, and `<SignedOut>`).
     </Callout>
 
     ```tsx filename="pages/example.tsx"
@@ -377,11 +427,12 @@ export default async function handler(
       }
 
       // Load any data your application needs for the page using the userId
+
       return { props: { ...buildClerkProps(ctx.req) } };
     };
     ```
 
-    You can also access the full user object before passing it to the page using the `clerkClient` helper.
+    You can also access the full [`User`][user-object] object before passing it to the page using the `clerkClient` helper.
 
     ```tsx filename="pages/example.tsx"
     import { clerkClient } from "@clerk/nextjs";
@@ -414,3 +465,6 @@ Now that your Next.js application is integrated with Clerk, you will want to rea
     <Cards title="Next.js SDK Reference" description="Learn more about additional Next.js methods." link="/docs/references/nextjs/overview" cta="Learn More" />
   </div>
 </div>
+
+[clerk-provider]: /docs/components/clerk-provider
+[user-object]: /docs/references/javascript/user/user

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -270,21 +270,21 @@ export default function Example() {
 
 #### App Router
 
-[`getAuth()`](/docs/references/nextjs/get-auth) will retrieve the `userId` of an authenticated user in your Route Handlers. Any requests from a Client Component will automatically include the user's current token as the Bearer token. [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can use inside of your Server Components and Actions.
+[`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can use inside of your application. [`auth()`](/docs/references/nextjs/auth) will retrieve the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of a user in your Route Handlers, middleware, Server Components and Server Actions. [`currentUser()`](/docs/references/nextjs/current-user) will work in the same places and return the [`User`][user-object] object. Any requests from a Client Component to a Route Handler will automatically include the user's current token as the Bearer token. 
 
 <Tabs items={["Route Handler", "Route Handler w/ User Fetch", "auth()", "currentUser()"]}>
   <Tab>
-    You can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. 
+    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected my [middleware](/docs/references/nextjs/auth-middleware). 
 
     ```tsx filename="app/api/user/route.[jsx/tsx]"
     import { NextResponse } from 'next/server';
-    import { getAuth } from '@clerk/nextjs/server';
- 
-    export async function POST(req: Request, res: NextResponse) {  
-      const { userId } = getAuth(req);
-  
-      if(!userId){
-        return NextResponse("Unauthorized", { status: 401 });
+    import { auth } from '@clerk/nextjs';
+
+    export async function GET(req: Request, res: NextResponse) {
+      const { userId } = auth();
+
+      if (!userId) {
+        return new NextResponse("Unauthorized", { status: 401 });
       }
 
       // Perform your Route Handler's logic
@@ -294,31 +294,31 @@ export default function Example() {
     ```
   </Tab>
   <Tab>
-    You can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper. 
+    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected my [middleware](/docs/references/nextjs/auth-middleware). 
 
-    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
+    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use  [`currentUser()`](/docs/references/nextjs/current-user) helper to get the full [`User`][user-object] object.
 
    ```tsx filename="app/api/user/route.ts"
-   import { NextResponse } from 'next/server';
-    import { clerkClient, getAuth } from "@clerk/nextjs/server";
+    import { NextResponse } from 'next/server';
+    import { currentUser, auth } from "@clerk/nextjs";
 
-    export async function POST(req: Request, res: NextResponse) {  
-      const { userId } = getAuth(req);
-  
-      if(!userId){
+    export async function GET(req: Request, res: NextResponse) {
+      const { userId } = auth();
+
+      if (!userId) {
         return new NextResponse("Unauthorized", { status: 401 });
       }
 
-     const user = await clerkClient.users.getUser(userId);
+      const user = await currentUser();
 
       // Perform your Route Handler's logic with the returned user object
 
-     return NextResponse.json({"user": user}, { status: 200})
+      return NextResponse.json({ "user": user }, { status: 200 })
     }
   ```
   </Tab>
   <Tab>
-    Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the same [`Authentication` Object](/docs/references/nextjs/authentication-object) as [`getAuth(req)`](/docs/references/nextjs/get-auth) in middleware, getServerSideProps, and API routes.
+    Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of the user.
 
     Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
 

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -355,7 +355,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
 
 <Tabs items={["API Route", "API Route w/ User Fetch", "getServerSideProps"]}>
   <Tab>
-    For Next.js applications using the Pages Router, you can get user information or authentication state, or control access to some or all of your API routes by using the [`getAuth()`](/docs/references/nextjs/get-auth) helper. The `getAuth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+    For Next.js applications using the Pages Router, you can retrieve information about the user and their authentication state, or control access to some or all of your API routes by using the [`getAuth()`][get-auth] helper. The [`getAuth()`][get-auth] helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+
 
     ```tsx filename="pages/api/auth.ts"
     import type { NextApiRequest, NextApiResponse } from "next";

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -270,11 +270,19 @@ export default function Example() {
 
 #### App Router
 
-[`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can use inside of your application. [`auth()`](/docs/references/nextjs/auth) will retrieve the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of a user in your Route Handlers, middleware, Server Components and Server Actions. [`currentUser()`](/docs/references/nextjs/current-user) will work in the same places and return the [`User`][user-object] object. Any requests from a Client Component to a Route Handler will automatically include the user's current token as the Bearer token. 
+[`auth()`][auth-ref] and [`currentUser()`][currentuser-ref] are new helpers that you can use inside of your Route Handlers, middleware, Server Components, and Server Actions.
 
-<Tabs items={["Route Handler", "Route Handler w/ User Fetch", "auth()", "currentUser()"]}>
+The [`auth()`][auth-ref] helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
+
+The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-object] object of the currently active user. This is helpful if you want to render information, like their first and last name, directly from the server.
+
+<Callout type="info">
+  Any requests from a Client Component to a Route Handler will automatically include the user's current token as the Bearer token.
+</Callout>
+
+<Tabs items={["Route Handler", "Route Handler w/ User Fetch"]}>
   <Tab>
-    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected my [middleware](/docs/references/nextjs/auth-middleware). 
+    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected by [middleware](/docs/references/nextjs/auth-middleware). 
 
     ```tsx filename="app/api/user/route.[jsx/tsx]"
     import { NextResponse } from 'next/server';
@@ -294,9 +302,9 @@ export default function Example() {
     ```
   </Tab>
   <Tab>
-    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected my [middleware](/docs/references/nextjs/auth-middleware). 
+    You can protect your API routes by using the [`auth()`](/docs/references/nextjs/auth) helper, if the route is not protected by [middleware](/docs/references/nextjs/auth-middleware). 
 
-    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use  [`currentUser()`](/docs/references/nextjs/current-user) helper to get the full [`User`][user-object] object.
+    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use  [`currentUser()`](/docs/references/nextjs/current-user) helper to get the full [`User`][user-object] object. Under the hood, this calls `fetch()` so it is automatically deduped per request.
 
    ```tsx filename="app/api/user/route.ts"
     import { NextResponse } from 'next/server';
@@ -317,42 +325,11 @@ export default function Example() {
     }
   ```
   </Tab>
-  <Tab>
-    Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the [`Authentication` Object](/docs/references/nextjs/authentication-object) status of the user.
-
-    Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
-
-    ```tsx filename="app/page.tsx"
-    import { auth } from "@clerk/nextjs";
-
-    export default function Page() {
-      const { userId } = auth();
-      // ...
-    }
-    ```
-    </Tab>
-
-    <Tab>
-    Clerk has introduced a new [`currentUser()`](/docs/references/nextjs/current-user) helper that loads the [`User`][user-object] object for the authenticated user from Clerk's Backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
-
-    Under the hood, this calls `fetch()` so it is automatically deduped per request.
-
-    ```tsx filename="page.tsx"
-    import { currentUser } from "@clerk/nextjs";
-
-    export default async function Page() {
-      const user = await currentUser();
-      // ...
-    }
-    ```
-  </Tab>
-
 </Tabs>
 
 #### Pages Router
 
 <Tabs items={["API Route", "API Route w/ User Fetch", "getServerSideProps"]}>
-
   <Tab>
     For Next.js apps using the Pages Router, you can protect your API routes by using the [`getAuth`](/docs/references/nextjs/get-auth) helper and retrieve data from your own systems.
 
@@ -364,8 +341,7 @@ export default function Example() {
       const { userId } = getAuth(req);
 
       if (!userId) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
+        return res.status(401).json({ error: "Unauthorized" });
       }
 
       // retrieve data from your database
@@ -427,7 +403,7 @@ export default function Example() {
     };
     ```
 
-    You can also access the full [`User`][user-object] object before passing it to the page using the `clerkClient` helper.
+    You can also access the full [`User`][user-object] object before passing it to the page by using the `clerkClient` helper.
 
     ```tsx filename="pages/example.tsx"
     import { clerkClient } from "@clerk/nextjs";
@@ -443,7 +419,6 @@ export default function Example() {
     };
     ```
   </Tab>
-
 </Tabs>
 
 
@@ -465,3 +440,5 @@ Now that your Next.js application is integrated with Clerk, you will want to rea
 
 [clerk-provider]: /docs/components/clerk-provider
 [user-object]: /docs/references/javascript/user/user
+[auth-ref]: /docs/references/nextjs/auth
+[currentuser-ref]: /docs/references/nextjs/current-user

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -115,15 +115,13 @@ With this middleware, your entire application is protected. If you try to access
 
 
 
-<Callout type="info" emoji="🎉">
- At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of the box.
- Start your Next.js application via `npm run dev`, visit `http://localhost:3000`, and sign up to get access to your application.
-</Callout>
 
 
 ### Build your own sign in and sign up pages
 
-In addition to the [Account Portal](/docs/account-portal/overview), Clerk also offers a set of [prebuilt components](/docs/components/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components by utilizing the Next.js optional catch-all route.
+At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of the box. You can start your Next.js application via `npm run dev`, visit `http://localhost:3000`, and sign up to get access to your application. 
+
+Clerk also offers a set of [prebuilt components](/docs/components/overview) and [custom flows](/docs/custom-flows/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components by utilizing the Next.js optional catch-all route.
 
 #### Build your sign up page
 
@@ -283,18 +281,20 @@ export default function Example() {
 <Tab>
 For Next.js applications using the App Router, you can protect your API routes by using the [`auth`](/docs/references/nextjs/auth) helper. 
 
-```tsx filename="app/page.[jsx/tsx]"
+```tsx filename="app/api/user/route.[jsx/tsx]"
 import { NextResponse } from 'next/server';
-import { auth } from '@clerk/nextjs';
+import { getAuth } from '@clerk/nextjs/server';
  
-export async function Page() {
-  const { userId } : { userId: string | null } = auth();
+export async function POST(req: Request, res: NextResponse) {  
+  const { userId } = getAuth(req);
   
   if(!userId){
-    return new Response("Unauthorized", { status: 401 });
+    return NextResponse("Unauthorized", { status: 401 });
   }
 
-  return NextResponse.json({});
+  // Perform your Route Handler's logic
+
+  return NextResponse.json({ userId }, { status: 200 });
 }
 ```
 </Tab>
@@ -325,28 +325,24 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name. You can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
 
 <CodeBlockTabs options={["App Router", "Pages Router"]}>
-```tsx filename="pages/api/auth.ts"
-import { clerkClient } from "@clerk/nextjs";
-import { getAuth } from "@clerk/nextjs/server";
-import type { NextApiRequest, NextApiResponse } from "next";
+```tsx filename="app/api/user/route.ts"
+import { NextResponse } from 'next/server';
+import { clerkClient, getAuth } from "@clerk/nextjs/server";
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export async function POST(req: Request, res: NextResponse) {  
   const { userId } = getAuth(req);
-
-  if (!userId) {
-    return res.status(401).json({ error: "Unauthorized" });
+  
+  if(!userId){
+    return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const user = userId ? await clerkClient.users.getUser(userId) : null;
+  const user = await clerkClient.users.getUser(userId);
 
-  // use the user object to decide what data to return
+  // Perform your Route Handler's logic with the returned user object
 
-  return res.status(200).json({});
+  return NextResponse.json({"user": user}, { status: 200})
 }
-```
+````
 
 ```tsx filename="pages/api/auth.ts"
 import { clerkClient } from "@clerk/nextjs";
@@ -376,22 +372,8 @@ export default async function handler(
 
 <Tabs items={["App Router", "Pages Router"]}>
   <Tab>
-    #### **`currentUser()`**
-
-    [`currentUser()`](/docs/references/nextjs/current-user) loads the [`User`][user-object] object for the authenticated user from Clerk's backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
-
-    Under the hood, this calls `fetch()` so it is automatically deduped per request.
-
-    ```tsx filename="page.tsx"
-    import { currentUser } from "@clerk/nextjs";
-    import type { User } from "@clerk/nextjs/api";
-
-    export default async function Page() {
-      const user: User | null = await currentUser();
-      // ...
-    }
-    ```
-
+    [`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are new helpers that you can user inside of your Server Components and Actions.
+    
     #### **`auth()`**
 
     Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the same [`Authentication` Object](/docs/references/nextjs/authentication-object) as [`getAuth(req)`](/docs/references/nextjs/get-auth) in middleware, getServerSideProps, and API routes.
@@ -406,7 +388,22 @@ export default async function handler(
       // ...
     }
     ```
-  </Tab>
+
+    #### **`currentUser()`**
+
+    [`currentUser()`](/docs/references/nextjs/current-user) loads the [`User`][user-object] object for the authenticated user from Clerk's backend API. This is helpful if you want to render information, like their first and last name, directly from the server.
+
+    Under the hood, this calls `fetch()` so it is automatically deduped per request.
+
+    ```tsx filename="page.tsx"
+    import { currentUser } from "@clerk/nextjs";
+
+    export default async function Page() {
+      const user = await currentUser();
+      // ...
+    }
+    ```
+     </Tab>
 
   <Tab>
     You can access the active session and user data in your `getServerSideProps` using the [`getAuth`](/docs/references/nextjs/get-auth) helper.

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -294,11 +294,13 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     export default async function Page() {
 
       // Get the userId from auth() -- if null the user is not logged in
-      const { userId } = auth();
+      if (userId) {
+        // Query DB for user specific information or display assets only to logged in users 
+      }
 
       // Get the User object when you need access to the user's information
       const user = await currentUser()
-      // ...
+      // Use `user` to render user details or create UI elements
     }
     ```
   </Tab>

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -379,7 +379,8 @@ The [`currentUser()`][currentuser-ref] helper will return the [`User`][user-obje
     For Next.js applications using the Pages Router, you can retrieve information about the user and their authentication state, or control access to some or all of your API routes by using the [`getAuth()`][get-auth] helper. The [`getAuth()`][get-auth] helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
 
 
-    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`](/docs/references/backend/overview) helper to get the full [`User`][user-object] object.
+    In some cases, you may need the full [`User`][user-object] object. For example, if you want to access the user's email address address or name, you can use the [`clerkClient`][clerk-client] helper to get the full [`User`][user-object] object.
+
 
     ```tsx filename="pages/api/auth.ts"
     import { clerkClient } from "@clerk/nextjs";

--- a/docs/references/nextjs/auth.mdx
+++ b/docs/references/nextjs/auth.mdx
@@ -5,7 +5,11 @@ description: Access minimal authentication data for managing sessions and data f
 
 # `auth()`
 
-The `auth` helper returns the [`Authentication` object](/docs/references/nextjs/authentication-object) of the currently active user. This is the same `Authentication` object that is returned by the [`getAuth`](/docs/references/nextjs/get-auth) hook. However, it can be used in server components, route handlers, and server actions.
+The `auth()` helper returns the [`Authentication`][auth-object] object of the currently active user. This is the same [`Authentication`][auth-object] object that is returned by the [`getAuth()`](/docs/references/nextjs/get-auth) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
+
+The `auth()` helper does require [Middleware](/docs/references/nextjs/auth-middleware). 
+
+A Route Handler added to [`publicRoutes`](/docs/references/nextjs/auth-middleware#making-pages-public-using-public-routes) can still use the [`auth()`](/docs/references/nextjs/auth) helper to return information about the user or their authentication state, or to control access to some or all of the Route Handler.
 
 ## Retrieving userId
 
@@ -54,3 +58,5 @@ export default async function Page() {
   )
 }
 ```
+
+[auth-object]: /docs/references/nextjs/authentication-object

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -1,11 +1,11 @@
 ---
 title: currentUser()
-description: Access the User object inside of your server components, actions and route handlers.
+description: Access the User object inside of your Server Components, Route Handlers, and Server Actions.
 ---
 
 # `currentUser()`
 
-The `currentUser` helper returns the `User` object of the currently active user. This is the same `User` object that is returned by the [`useUser`](/docs/references/react/use-user) hook. However, it can be used in server components, route handlers, and server actions.
+The `currentUser` helper returns the [`User`][user-object] object of the currently active user. This is the same [`User`][user-object] object that is returned by the [`useUser`](/docs/references/react/use-user) hook. However, it can be used in Server Components, Route Handlers, and Server Actions. Under the hood, this helper calls `fetch()` so it is automatically deduped per request.
 
 ```tsx filename="app/page.[jsx/tsx]"
 import { currentUser } from '@clerk/nextjs';
@@ -18,3 +18,5 @@ if (!user) return <div>Not logged in</div>;
 return <div>Hello {user?.firstName}</div>;
 }
 ```
+
+[user-object]: /docs/references/javascript/user/user


### PR DESCRIPTION
From the [linear issue](https://linear.app/clerk/issue/DOCS-336/use-auth-example-before-getauth-example): "The first server side section begins with only getAuth(). Based on support questions at least, the vast majority of customers are using Next 13 + App Router. It feels like we should start the Server Side content with auth() as that's the preferred way with App router."