### PR TITLE
Update nextjs.mdx : ClerkProvider Section

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -93,6 +93,23 @@ export default MyApp;
   The root layout is a server component. If you plan to use the `<ClerkProvider />` outside the root layout, it will need to be a server component as well.
 </Callout>
 
+<Callout type="info">
+ You can pass the publishableKey from your environment directly to  `<ClerkProvider />` component as a prop in case you want to be able to change it directly from your React Code.
+</Callout>
+
+```tsx filename="_app.tsx"
+import { ClerkProvider } from "@clerk/nextjs";
+import type { AppProps } from "next/app";
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider {...pageProps} publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}>
+      <Component {...pageProps} />
+    </ClerkProvider>
+  );
+}
+export default MyApp;
+```
+
 ### Protect your application
 
 Now that Clerk is installed and mounted in your application, it’s time to decide which pages are public and which need to hide behind authentication. We do this by creating a `middleware.ts` file at the root folder (or inside `src/` if that is how you set up your app).


### PR DESCRIPTION
This feature needs to be clearly stated in the documentation that we have two options for the reading of the publishable key.
1. Automatic from the `.env` and directly as a prop on the `<ClerkProvider>` component