### PR TITLE
DOCS-403 elaborate on Nextjs middleware

### DIFF
--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -9,7 +9,7 @@ The `authMiddleware()` helper integrates Clerk authentication into your Next.js 
 
 ## Usage
 
-The `middleware.ts` file should be created in the root folder of your application (or inside src/ if that is how you set up your app). 
+Create the `middleware.ts` file in the root folder of your application, or inside the src/ if that is how your app is set up.
 
 <Callout type="info">
   For more information about middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -9,6 +9,12 @@ The `authMiddleware()` helper integrates Clerk authentication into your Next.js 
 
 ## Usage
 
+The `middleware.ts` file should be created in the root folder of your application (or inside src/ if that is how you set up your app). 
+
+<Callout type="info">
+  For more information about middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
+</Callout>
+
 ```ts filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
 


### PR DESCRIPTION
This PR addresses [this Linear ticket](https://linear.app/clerk/issue/DOCS-403/feedback-for-referencesnextjsauth-middlewareoptions).
Adds copy that specifies that middleware should be added to root folder.
Adds callout to address the NextJS middleware docs for more information on middleware in NextJS.
