### PR TITLE
clean up javascript reference pages for email address, phone number, and web3 wallet

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -549,7 +549,7 @@
         [
           ["Phone Number", "/references/javascript/phone-number/phone-number"],
           ["Verification", "/references/javascript/phone-number/verification"],
-          ["SecondFactor", "/references/javascript/phone-number/second-factor"]
+          ["Second factor", "/references/javascript/phone-number/second-factor"]
         ]
       ],
       [

--- a/docs/references/javascript/email-address/email-address.mdx
+++ b/docs/references/javascript/email-address/email-address.mdx
@@ -5,29 +5,24 @@ description: The EmailAddress object is a model around an email address. Email a
 
 # `EmailAddress`
 
-The EmailAddress object is a model around an email address. Email addresses are used to provide identification for users.
+The `EmailAddress` object is a model around an email address. Email addresses are used to provide identification for users.
 
-Email addresses must be verified to ensure that they can be assigned to their rightful owners. The EmailAddress object holds all necessary state around the verification process.
+Email addresses must be verified to ensure that they can be assigned to their rightful owners. The `EmailAddress` object holds all necessary state around the verification process.
 
-The verification process always starts with the [EmailAddress.prepareVerification()](/docs/references/javascript/email-address/verification#prepare-verification) method, which will send a one-time verification code via an email message. The second and final step involves an attempt to complete the verification by calling the [EmailAddress.attemptVerification()](/docs/references/javascript/email-address/verification#attempt-verification) method, passing the one-time code as a parameter.
+The verification process always starts with the [`EmailAddress.prepareVerification()`](/docs/references/javascript/email-address/verification#prepare-verification) method, which will send a one-time verification code via an email message. The second and final step involves an attempt to complete the verification by calling the [`EmailAddress.attemptVerification()`](/docs/references/javascript/email-address/verification#attempt-verification) method, passing the one-time code as a parameter.
 
 Finally, email addresses can be linked to other identifications.
 
 ## Attributes
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>id</code>, <code>string</code>, <>A unique identifier for this email address.</>]},
-{cells: [<code>emailAddress</code>, <code>string</code>, <>The value of this email address, the actual email box address.</>]},
-{cells: [<code>verification</code>, <a href="/docs/references/javascript/verification"><code>Verification</code></a>, <>An object holding information on the verification of this email address.</>]},
-{cells: [<code>linkedTo</code>, <code>{"Array<{id: string, type: string}>"}</code>, <>An array of objects containing information about any identifications that might be linked to this email address </>]},
-  ]}
-/>
+| Name | Type | Description |
+|  --- | --- | --- |
+| `id` | `string` | A unique identifier for this email address. |
+| `emailAddress` | `string` | The value of this email address. |
+| `verification` | [`Verification`](/docs/references/javascript/verification) | An object holding information on the verification of this email address. |
+| `linkedTo` | `Array<{id: string, type: string}>` | An array of objects containing information about any identifications that might be linked to this email address. |
 
 ## Methods
-
 
 ### `create()`
 
@@ -43,7 +38,7 @@ Creates a new email address for the current user.
 function destroy(): Promise<void>;
 ```
 
-Delete this email address.
+Deletes this email address.
 
 ### `toString()`
 
@@ -73,25 +68,16 @@ The second function can be used to stop polling at any time, allowing for full c
 
 `createMagicLinkFlow` returns an object with two functions:
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-    {cells: [<code>startMagicLinkFlow</code>, <code>(params: <a href="#start-magic-link-flow-params">StartMagicLinkFlowParams</a>) {"=>"} Promise{"<"}<a href="/docs/references/javascript/sign-up/sign-up">SignUp</a>{">"}</code>, <>Function to start the magic link flow. It prepares a magic link verification and polls for the verification result.</>]},
-    {cells: [<code>cancelMagicLinkFlow</code>, <code>{"() => void"}</code>, <>Function to cleanup the magic link flow. Stops waiting for verification results.</>]},
-  ]}
-/>
+| Name | Type | Description |
+|  --- | --- | --- |
+| `startMagicLinkFlow` | `(params: StartMagicLinkFlowParams) => Promise<EmailAddress>` | Function to start the magic link flow. It prepares a magic link verification and polls for the verification result. |
+| `cancelMagicLinkFlow` | `() => void` | Function to cleanup the magic link flow. Stops waiting for verification results. |
 
 #### `StartMagicLinkFlowParams`
 
-
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-    {cells: [<code>redirectUrl</code>, <code>string</code>, <>The magic link target URL. Users will be redirected here once they click the magic link from their email.</>]}
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `redirectUrl` | `string` | The magic link target URL. Users will be redirected here once they click the magic link from their email. |
 
 ## Additional methods
 

--- a/docs/references/javascript/email-address/verification.mdx
+++ b/docs/references/javascript/email-address/verification.mdx
@@ -5,7 +5,7 @@ description: These are all methods on the EmailAddress class that allow you to v
 
 # `EmailAddress` Verification
 
-These are all methods on [the `EmailAddress` class](/docs/references/javascript/email-address/email-address) that allow you to verify a user's email address.
+These are all methods on the [`EmailAddress`](/docs/references/javascript/email-address/email-address) class that allow you to verify a user's email address.
 
 ## `prepareVerification()`
 
@@ -17,20 +17,10 @@ Kick off the verification process for this email address. An email message with 
 
 ### `PrepareEmailAddressVerificationParams`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-    {cells: [<code>strategy </code>, <code>string</code>, <>
-    The verification strategy. Possible strategy values are:
-    <ul>
-    <li><code>email_link</code>:  User will receive an email magic link via email.</li>
-    <li><code>email_code</code>: User will receive a one-time authentication code via email.</li>
-    </ul>
-    </>]},
-    {cells: [<code>redirectUrl</code>, <code>string | undefined</code>, <>The magic link target URL. Users will be redirected here once they click the magic link from their email. This param only applies if <code>strategy</code> is <code>email_link</code></>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `strategy` | `'email_link' \| 'email_code'` | The verification strategy.<br/>Possible strategy values are:<br/><ul><li>`email_link`: User will receive an email magic link via email.</li><li>`email_code`: User will receive a one-time authentication code via email.</li></ul> |
+| `redirectUrl` | `string \| undefined` | The magic link target URL. Users will be redirected here once they click the magic link from their email. This param only applies if `strategy` is `email_link`. |
 
 ## `attemptVerification()`
 
@@ -42,11 +32,6 @@ Attempts to verify this email address, passing the one-time code that was sent a
 
 ### `AttemptEmailAddressVerificationParams`
 
-
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-    {cells: [<code>code</code>, <code>string</code>, <>The one-time code that was sent to the user's email address when prepareVerification was called with <code>strategy</code> set to <code>email_code</code></>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `code` | `string` | The one-time code that was sent to the user's email address when [EmailAddress.prepareVerification()](#prepare-verification) was called with `strategy` set to `email_code`. |

--- a/docs/references/javascript/phone-number/phone-number.mdx
+++ b/docs/references/javascript/phone-number/phone-number.mdx
@@ -3,35 +3,27 @@ title: PhoneNumber
 description: The PhoneNumber object describes a phone number. Phone numbers can be used as a proof of identification for users, or simply as a means of contacting users.
 ---
 
-import { Tables } from "@/components/Table";
-import { Images } from "@/components/Images";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `PhoneNumber`
 
 The `PhoneNumber` object describes a phone number. Phone numbers can be used as a proof of identification for users, or simply as a means of contacting users.
 
 Phone numbers must be verified to ensure that they can be assigned to their rightful owners. The `PhoneNumber` object holds all the necessary state around the verification process.
 
-The verification process always starts with the [PhoneNumber.prepareVerification()](/docs/references/javascript/phone-number/verification#prepare-verification) method, which will send a one-time verification code via an SMS message. The second and final step involves an attempt to complete the verification by calling the [PhoneNumber.attemptVerification()](/docs/references/javascript/phone-number/verification#attempt-verification) method, passing the one-time code as a parameter.
+The verification process always starts with the [`PhoneNumber.prepareVerification()`](/docs/references/javascript/phone-number/verification#prepare-verification) method, which will send a one-time verification code via an SMS message. The second and final step involves an attempt to complete the verification by calling the [`PhoneNumber.attemptVerification()`](/docs/references/javascript/phone-number/verification#attempt-verification) method, passing the one-time code as a parameter.
 
 Finally, phone numbers are used as part of [multi-factor authentication](/docs/custom-flows/mfa). Users receive an SMS message with a one-time code that they need to provide as an extra verification step.
 
 ## Attributes
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>id</code>, <code>string</code>, <>A unique identifier for this phone number.</>]},
-{cells: [<code>phoneNumber</code>, <code>string</code>, <>The value of this phone number, in <a href="https://en.wikipedia.org/wiki/E.164" target="_blank" rel="noopener">E.164</a> format.</>]},
-{cells: [<code>reservedForSecondFactor</code>, <code>boolean</code>, <>Value will be true if this phone number is reserved for multi-factor authentication (2FA), false otherwise.</>]},
-{cells: [<code>defaultSecondFactor</code>, <code>boolean</code>, <>Value will be true if this phone number is the default second factor, false otherwise. A user must have exactly one default second factor, if multi-factor authentication (2FA) is enabled.</>]},
-{cells: [<code>verification</code>, <a href="/docs/references/javascript/verification"><code>Verification</code></a>, <>An object holding information on the verification of this phone number.</>]},
-{cells: [<code>linkedTo</code>, <code>{"Array<{id: string, type: string}>"}</code>, <>An object containing information about any other identification that might be linked to this phone number.</>]},
-{cells: [<code>backupCodes</code>, <code>string[] | undefined</code>, <>A list of backup codes in case of lost phone number access.</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | A unique identifier for this phone number. |
+| `phoneNumber` | `string` | The value of this phone number, in [E.164 format](https://en.wikipedia.org/wiki/E.164). |
+| `reservedForSecondFactor` | `boolean` | Set to `true` if this phone number is reserved for multi-factor authentication (2FA). Set to `false` otherwise. |
+| `defaultSecondFactor` | `boolean` | Set to `true` if this phone number is the default second factor. Set to `false` otherwise. A user must have exactly one default second factor, if multi-factor authentication (2FA) is enabled. |
+| `verification` | [`Verification`](/docs/references/javascript/verification) | An object holding information on the verification of this phone number. |
+| `linkedTo` | `Array<{id: string, type: string}>` | An object containing information about any other identification that might be linked to this phone number. |
+| `backupCodes` | `string[] | undefined` | A list of backup codes in case of lost phone number access. |
 
 ## Methods
 
@@ -49,7 +41,7 @@ Creates a new phone number for the current user.
 function destroy(): Promise<void>;
 ```
 
-Delete this phone number.
+Deletes this phone number.
 
 ### `toString()`
 
@@ -57,9 +49,7 @@ Delete this phone number.
 function toString(): string;
 ```
 
-Returns the phone number value in [E.164 format](https://en.wikipedia.org/wiki/E.164).
-
-The value is taken from the PhoneNumber.phoneNumber attribute.
+Returns the phone number value in [E.164 format](https://en.wikipedia.org/wiki/E.164). Can also be accessed via the `PhoneNumber.phoneNumber` attribute.
 
 ## Additional methods
 

--- a/docs/references/javascript/phone-number/second-factor.mdx
+++ b/docs/references/javascript/phone-number/second-factor.mdx
@@ -1,11 +1,11 @@
 ---
-title: PhoneNumber Second Factor
+title: PhoneNumber second factor
 description: These are all methods on the PhoneNumber class that allow you configure the configuration of a phone number as a second factor for multi-factor authentication (MFA).
 ---
 
 # `PhoneNumber` second factor
 
-These are all methods on [the `PhoneNumber` class](/docs/references/javascript/phone-number/phone-number) that allow you configure the configuration of a phone number as a second factor for multi-factor authentication (MFA).
+These are all methods on the [`PhoneNumber`](/docs/references/javascript/phone-number/phone-number) class that allow you configure the configuration of a phone number as a second factor for multi-factor authentication (MFA).
 
 ## `makeDefaultSecondFactor()`
 
@@ -25,10 +25,6 @@ Marks this phone number as reserved for [multi-factor authentication](/docs/cust
 
 ### `SetReservedForSecondFactorParams`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>reserved</code>, <code>boolean</code>, <>Pass <code>true</code> to mark this phone number as reserved for 2FA, or <code>false</code> to disable 2FA for this phone number.</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `reserved` | `boolean` | Pass `true` to mark this phone number as reserved for 2FA, or `false` to disable 2FA for this phone number. |

--- a/docs/references/javascript/phone-number/verification.mdx
+++ b/docs/references/javascript/phone-number/verification.mdx
@@ -3,13 +3,9 @@ title: PhoneNumber Verification
 description: These are all methods on the PhoneNumber class that allow you to verify a user's phone number.
 ---
 
-import { Tables } from "@/components/Table";
-import { Images } from "@/components/Images";
-import { CodeBlockTabs } from "@/components/CodeBlockTabs";
-
 # `PhoneNumber` verification
 
-These are all methods on [the `PhoneNumber` class](/docs/references/javascript/phone-number/phone-number) that allow you to verify a user's phone number.
+These are all methods on the [`PhoneNumber`](/docs/references/javascript/phone-number/phone-number) class that allow you to verify a user's phone number.
 
 ## `prepareVerification()`
 
@@ -25,14 +21,10 @@ Kick off the verification process for this phone number. An SMS message with a o
 function attemptVerification(params: AttemptPhoneNumberVerificationParams): Promise<PhoneNumber>;
 ```
 
-Attempts to verify this phone number, passing the one-time code that was sent as an SMS message. The code will be sent when calling the [PhoneNumber.prepareVerification()](/docs/references/javascript/phone-number/verification#prepare-verification) method.
+Attempts to verify this phone number, passing the one-time code that was sent as an SMS message. The code will be sent when calling the [`PhoneNumber.prepareVerification()`](/docs/references/javascript/phone-number/verification#prepare-verification) method.
 
 ### `AttemptPhoneNumberVerificationParams`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>code</code>, <code>string</code>, <>The one-time code that was sent to the user's phone number when <code>prepareVerification</code> was called.</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `code` | `string` | The one-time code that was sent to the user's phone number when `prepareVerification` was called. |

--- a/docs/references/javascript/web3-wallet/verification.mdx
+++ b/docs/references/javascript/web3-wallet/verification.mdx
@@ -5,7 +5,7 @@ description: These are all methods on the Web3Wallet class that allow you to ver
 
 # `Web3Wallet` verification
 
-These are all methods on [the `Web3Wallet` class](/docs/references/javascript/web3-wallet/web3-wallet) that allow you to verify a user's web3 wallet.
+These are all methods on the [`Web3Wallet`](/docs/references/javascript/web3-wallet/web3-wallet) class that allow you to verify a user's web3 wallet.
 
 ## `prepareVerification()`
 
@@ -18,18 +18,9 @@ Kick off the verification process for this web3 wallet. The user will be prompte
 
 ### `PrepareWeb3WalletVerificationParams`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>strategy</code>, <code>string</code>, <>
-The verification strategy. Possible strategy values are:
-<ul>
-<li><code>web3_metamask_signature</code>: User will need to sign a message and generate a signature using MetaMask browser extension.</li>
-</ul>
-</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `strategy` | `'web3_metamask_signature'` | The verification strategy.<br/>Possible strategy values are:<br/><ul><li>`web3_metamask_signature`: User will need to sign a message and generate a signature using MetaMask browser extension.</li></ul> |
 
 ## `attemptVerification()`
 
@@ -41,10 +32,6 @@ Attempts to verify this web3 wallet, by passing the generated signature.
 
 ### `AttemptWeb3WalletVerificationParams`
 
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>signature</code>, <code>string</code>, <>The signature that was generated after prepareVerification was called</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `signature` | `string` | The signature that was generated after [`prepareVerification`](#prepare-verification) was called. |

--- a/docs/references/javascript/web3-wallet/web3-wallet.mdx
+++ b/docs/references/javascript/web3-wallet/web3-wallet.mdx
@@ -7,24 +7,19 @@ description: The Web3Wallet object describes a Web3 wallet address. The address 
 
 The `Web3Wallet` object describes a Web3 wallet address. The address can be used as a proof of identification for users.
 
-Web3 addresses must be verified to ensure that they can be assigned to their rightful owners. The verification is completed via Web3 wallet browser extensions such as [Metamask](https://metamask.io/). The `Web3Wallet3` object holds all the necessary state around the verification process.
+Web3 addresses must be verified to ensure that they can be assigned to their rightful owners. The verification is completed via Web3 wallet browser extensions, such as [Metamask](https://metamask.io/). The `Web3Wallet3` object holds all the necessary state around the verification process.
 
-The verification process always starts with the [Web3Wallet.prepareVerification()](/docs/references/javascript/web3-wallet/verification#prepare-verification) or [signIn.prepareFirstFactor()](/docs/references/javascript/sign-in/first-factor#prepare-first-factor) method, which will send the wallet address to Clerk Frontend API and will receive a nonce that needs to be signed by the Web3 wallet browser extension.
+The verification process always starts with the [`Web3Wallet.prepareVerification()`](/docs/references/javascript/web3-wallet/verification#prepare-verification) or [`signIn.prepareFirstFactor()`](/docs/references/javascript/sign-in/first-factor#prepare-first-factor) method, which will send the wallet address to Clerk Frontend API and will receive a nonce that needs to be signed by the Web3 wallet browser extension.
 
-The second and final step involves an attempt to complete the verification by calling [Web3Wallet.attemptVerification()](/docs/references/javascript/web3-wallet/verification#attempt-verification) method, passing the generated signature as a parameter.
+The second and final step involves an attempt to complete the verification by calling [`Web3Wallet.attemptVerification()`](/docs/references/javascript/web3-wallet/verification#attempt-verification) method, passing the generated signature as a parameter.
 
 ## Attributes
 
-
-<Tables
-  headings={["Name", "Type", "Description"]}
-  headingsMeta={[{maxWidth:'300px'},{maxWidth: '300px'},{maxWidth: '300px'}]}
-  rows={[
-{cells: [<code>id</code>, <code>string</code>, <>A unique identifier for this web3 wallet.</>]},
-{cells: [<code>web3Wallet</code>, <code>string</code>, <>In <a href="https://docs.metamask.io/guide/common-terms.html#address-public-key">Ethereum</a>, the address is made up of <code>0x + 40 hexadecimal characters</code>. </>]},
-{cells: [<code>verification</code>, <a href="/docs/references/javascript/verification"><code>Verification</code></a>, <>An object holding information on the verification of this web3 wallet.</>]},
-  ]}
-/>
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | A unique identifier for this web3 wallet. |
+| `web3Wallet` | `string` | In [Ethereum](https://docs.metamask.io/guide/common-terms.html#address-public-key), the address is made up of `0x + 40 hexadecimal characters`. |
+| `verification` | [`Verification`](/docs/references/javascript/verification) | An object holding information on the verification of this web3 wallet. |
 
 ## Methods
 
@@ -42,7 +37,7 @@ Creates a new web3 wallet.
 function destroy(): Promise<void>;
 ```
 
-Delete this web3 walllet.
+Deletes this web3 walllet.
 
 ### `toString()`
 


### PR DESCRIPTION
Cleaning up the JavaScript reference docs.

This PR

- migrates components to markdown tables
- removes unnecessary imports
- adds links to references where necessary
- typical clean up / consistency thingssss

🔎 [Old email address page](https://clerk.com/docs/references/javascript/email-address/email-address)

🔎 [Old email address verification page](https://clerk.com/docs/references/javascript/email-address/verification)

🔎 [Old phone number page](https://clerk.com/docs/references/javascript/phone-number/phone-number)

🔎 [Old phone number verification page](https://clerk.com/docs/references/javascript/phone-number/verification)

🔎 [Old phone number second factor page](https://clerk.com/docs/references/javascript/phone-number/second-factor)

🔎 [Old web3 wallet page](https://clerk.com/docs/references/javascript/web3-wallet/web3-wallet)

🔎 [Old web3 wallet verification page](https://clerk.com/docs/references/javascript/web3-wallet/verification)