### PR TITLE
DOCS-434 remove links to outdated FAPI reference

### DIFF
--- a/docs/custom-flows/user-impersonation.mdx
+++ b/docs/custom-flows/user-impersonation.mdx
@@ -58,7 +58,7 @@ Actor tokens are consumed the same way as sign in tokens.
 
 Actor tokens can be [created from the Backend API](https://clerk.com/docs/reference/backend-api/tag/Actor-Tokens#operation/CreateActorToken). Once you've successfully created an actor token, you can use the `url` attribute of the response to consume the token and impersonate a user.
 
-The `url` attribute is a [Clerk Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) URL that will use the token to sign out existing users and prepare the sign-in object for impersonation. You can directly visit the `url` provided in the response to consume the actor token.
+The `url` attribute is a Clerk Frontend API URL that will use the token to sign out existing users and prepare the sign-in object for impersonation. You can directly visit the `url` provided in the response to consume the actor token.
 
 The Clerk Frontend API will redirect you to the /sign-in page of your application, where you can continue the flow by consuming the `__clerk_ticket` parameter.
 

--- a/docs/organizations/metadata.mdx
+++ b/docs/organizations/metadata.mdx
@@ -31,7 +31,7 @@ Metadata allows for custom data to be saved on the `Organization` and `Organizat
     Metadata is limited to **8kb** maximum.
 </Callout>
 
-Both public and private metadata are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) and [Backend API](https://clerk.com/docs/reference/backend-api). These types of metadata can be used to access non-sensitive information about an organization, such as their profile picture or their name. They can be used to build UIs where an organization might not be signed in, but you still want to show some of their profile info.
+Both public and private metadata are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the Frontend API and [Backend API](https://clerk.com/docs/reference/backend-api). These types of metadata can be used to access non-sensitive information about an organization, such as their profile picture or their name. They can be used to build UIs where an organization might not be signed in, but you still want to show some of their profile info.
 
 The `publicMetadata` property should be used if you need to set some metadata from your backend and have them displayed as read-only on the frontend.
 

--- a/docs/references/javascript/clerk/clerk.mdx
+++ b/docs/references/javascript/clerk/clerk.mdx
@@ -74,7 +74,7 @@ Indicates when the [ClerkJS](/docs/references/javascript/overview) library has f
 function load(options?: ClerkOptions): Promise<void>;
 ```
 
-Initializes the `Clerk` object and loads all necessary environment configuration and instance settings from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference).
+Initializes the `Clerk` object and loads all necessary environment configuration and instance settings from the Frontend API.
 
 It is absolutely necessary to call this method before using the `Clerk` object in your code. Refer to the [ClerkJS installation](/docs/quickstarts/javascript) guide for more details.
 

--- a/docs/references/javascript/user/user.mdx
+++ b/docs/references/javascript/user/user.mdx
@@ -9,7 +9,7 @@ The `User` object holds all of the information for a single user of your applica
 
 A user can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
 
-Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can also be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference).
+Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can also be accessed from the Frontend API.
 
 The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to help retrieve and update user information and authentication status.
 
@@ -46,9 +46,9 @@ The ClerkJS SDK provides some helper [methods](#methods) on the `User` object to
 | `backupCodeEnabled` | `boolean` | A boolean indicating whether the user has enabled Backup codes. |
 | `createOrganizationEnabled` | `boolean` | A boolean indicating whether the organization creation is enabled for the user or not. |
 | `deleteSelfEnabled` | `boolean` | A boolean indicating whether the user is able to delete their own account or not. |
-| `publicMetadata` | `{[string]: any} \| null` | Metadata that can be read from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) and [Backend API](https://clerk.com/docs/reference/backend-api) and can be set only from the Backend API . |
+| `publicMetadata` | `{[string]: any} \| null` | Metadata that can be read from the Frontend API and [Backend API](https://clerk.com/docs/reference/backend-api) and can be set only from the Backend API . |
 | `privateMetadata` | `{[string]: any} \| null` | Metadata that can be read and set only from the [Backend API](https://clerk.com/docs/reference/backend-api). |
-| `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference). One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
+| `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the Frontend API. One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
 | `lastSignInAt` | `Date` | Date when the user last signed in. May be empty if the user has never signed in. |
 | `createdAt` | `Date` | Date when the user was first created. |
 | `updatedAt` | `Date` | Date of the last time the user was updated. |
@@ -76,7 +76,7 @@ All props below are optional.
 | `primaryEmailAddressId` | `string` | The unique identifier for the [`EmailAddress`][email-ref] that the user has set as primary. |
 | `primaryPhoneNumberId` | `string` | The unique identifier for the [`PhoneNumber`][phone-ref] that the user has set as primary. |
 | `primaryWeb3WalletId` | `string` | The unique identifier for the [`Web3Wallet`][web3-ref] that the user signed up with. |
-| `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference). One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
+| `unsafeMetadata` | `{[string]: any} \| null` | Metadata that can be read and set from the Frontend API. One common use case for this attribute is to implement custom fields that will be attached to the `User` object.<br />Please note that there is also an `unsafeMetadata` attribute in the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object. The value of that field will be automatically copied to the user's unsafe metadata once the sign up is complete. |
 
 ### `delete()`
 

--- a/docs/troubleshooting/overview.mdx
+++ b/docs/troubleshooting/overview.mdx
@@ -7,7 +7,7 @@ description: Learn how to troubleshoot common issues with Clerk and contact supp
 
 We hope that our documentation is thorough and transparent enough that you won't run into any issues. If you can't find what you're looking for in the navigation sidebar, use the search function of the docs to track down the information you need.
 
-Refer to the [Backend API](https://clerk.com/docs/reference/backend-api) and [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) reference docs for questions about object structures, requests, and responses.
+Refer to the [Backend API](https://clerk.com/docs/reference/backend-api) and Frontend API reference docs for questions about object structures, requests, and responses.
 
 Are you looking for a place to get started? Check out our [Quickstarts & Tutorials](/docs/quickstarts/overview) section.
 

--- a/docs/upgrade-guides/progressive-sign-up.mdx
+++ b/docs/upgrade-guides/progressive-sign-up.mdx
@@ -13,7 +13,7 @@ Progressive Sign Up is a new Sign Up flow introduced in Q2 2022, that aims to im
 
 It can be enabled using the [Instance Settings][instance-settings] endpoint from the Backend API.
 
-Progressive Sign Up involves changes in the responses of the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference). That said, there are no structural changes in the keys of the response payloads or any new types introduced. The changes only apply to some existing fields of the [Sign Up object](https://reference.clerk.dev/reference/frontend-api-reference/user-api/sign-ups), namely `missing_fields`, `unverified_fields`, and `status`. The possible values of those fields also haven not changed - what changes is when each of those values is returned.
+Progressive Sign Up involves changes in the responses of the Frontend API. That said, there are no structural changes in the keys of the response payloads or any new types introduced. The changes only apply to some existing fields of the [`SignUp`](/docs/references/javascript/sign-up/sign-up) object, namely `missing_fields`, `unverified_fields`, and `status`. The possible values of those fields also haven not changed - what changes is when each of those values is returned.
 
 ## What’s changed
 On a high level, Progressive Sign Up contains the following changes:

--- a/docs/users/overview.mdx
+++ b/docs/users/overview.mdx
@@ -13,7 +13,7 @@ The `User` object holds all of the information for a single user of your applica
 
 A user can be contacted at their primary email address or primary phone number. They can have more than one registered email address, but only one of them will be their primary email address. This goes for phone numbers as well; a user can have more than one, but only one phone number will be their primary. At the same time, a user can also have one or more external accounts by connecting to [OAuth providers](/docs/authentication/social-connections/overview) such as Google, Apple, Facebook, and many more.
 
-Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the [Frontend API](https://reference.clerk.dev/reference/frontend-api-reference) as well.
+Finally, a `User` object holds profile data like the user's name, profile picture, and a set of [metadata](/docs/users/metadata) that can be used internally to store arbitrary information. The metadata are split into `publicMetadata` and `privateMetadata`. Both types are set from the [Backend API](https://clerk.com/docs/reference/backend-api), but public metadata can be accessed from the Frontend API as well.
 
 For more information on the `User` object, such as helper methods for retrieving and updating user information and authentication status, checkout the [ClerkJS SDK documentation](/docs/references/javascript/user/user).
 


### PR DESCRIPTION
The FAPI reference is heavily outdated. This PR removes any links to it; we can add links to the reference when it is back up to date.

Link to Slack discussion: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1696009744964919