### PR TITLE
Added Next App Router examples to Email/OTP SignUp Custom Flow

### DIFF
--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -248,9 +248,12 @@ export default function Page() {
       });
 
       // Filter the returned array to find the 'phone_code' entry
-      const phoneCodeFactor = supportedFirstFactors.find(factor => {
-        return factor.strategy === 'phone_code'
-      })
+      const isPhoneCodeFactor = (
+        factor: SignInFirstFactor
+      ): factor is PhoneCodeFactor => {
+        return factor.strategy === "phone_code";
+      };
+      const phoneCodeFactor = supportedFirstFactors?.find(isPhoneCodeFactor);
 
       if (phoneCodeFactor) {
         // Grab the phoneNumberId

--- a/docs/custom-flows/email-sms-otp.mdx
+++ b/docs/custom-flows/email-sms-otp.mdx
@@ -59,7 +59,96 @@ A successful sign-up consists of the following steps:
 
 Let's see the above in action. If you want to learn more about sign-ups, check out our documentation on Clerk's [sign-up flow](/docs/custom-flows/overview#sign-up-flow).
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs options={["Next App Router", "React", "JavaScript"]}>
+```ts filename="app/sign-up/page.tsx"
+'use client'
+
+import * as React from 'react'
+import { useSignUp } from "@clerk/nextjs";
+import { useRouter } from 'next/navigation';
+
+export default function Page() {
+  const { isLoaded, signUp, setActive } = useSignUp();
+  const [verifying, setVerifying] = React.useState(false)
+  const [phone, setPhone] = React.useState("")
+  const [code, setCode] = React.useState("")
+  const router = useRouter()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!isLoaded && !signUp) return null
+
+    try {
+      // Start the Sign Up process using the phone number method
+      await signUp.create({
+        phoneNumber: phone,
+      });
+
+      // Start the verification - a SMS message will be sent to the 
+      // number with a one-time code
+      await signUp.preparePhoneNumberVerification();
+
+      // Set 'verifying' true to display second form and capture the OTP code
+      setVerifying(true)
+    }
+    catch (err) {
+      // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
+      console.error('Error:', JSON.stringify(err, null, 2))
+    }
+  }
+
+  async function handleVerification(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!isLoaded && !signUp) return null
+
+    try {
+      // Use the code provided by the user and attempt verification
+      const completeSignUp = await signUp.attemptPhoneNumberVerification({
+        code,
+      });
+
+      // This mainly for debuggin while developing.
+      // Once your Instance is setup this should not be required.
+      if (completeSignUp.status !== 'complete') {
+        console.error(JSON.stringify(completeSignUp, null, 2))
+      }
+
+      // If verification was completed, create a session for the user
+      if (completeSignUp.status === 'complete') {
+        await setActive({ session: completeSignUp.createdSessionId });
+
+        // redirect user 
+        router.push("/")
+      }
+    }
+    catch (err) {
+      // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
+      console.error('Error:', JSON.stringify(err, null, 2))
+    }
+  }
+
+  if (verifying) {
+    return (
+      <form onSubmit={handleVerification}>
+        <label id="code">Code</label>
+        <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
+        <button type="submit">Verify</button>
+      </form>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label id="phone">Phone</label>
+      <input value={phone} id="phone" name="phone" type="tel" onChange={(e) => setPhone(e.target.value)} />
+      <button type="submit">Send Code</button>
+    </form>
+  );
+}
+````
+
 ```jsx filename="SignUpPage.jsx"
 import { useSignUp } from "@clerk/clerk-react";
 
@@ -132,7 +221,109 @@ So, in essence, when you want to authenticate users in your application, you nee
 
 Let's see the above in action. If you want to learn more about sign-ins, check out our documentation on Clerk's [sign-in flow](/docs/custom-flows/overview#sign-in-flow).
 
-<CodeBlockTabs options={["React", "JavaScript"]}>
+<CodeBlockTabs options={["Next App Router", "React", "JavaScript"]}>
+```tsx filename="app/sign-in/page.tsx"
+'use client'
+
+import * as React from 'react'
+import { useSignIn } from "@clerk/nextjs";
+import { useRouter } from 'next/navigation';
+
+export default function Page() {
+  const { isLoaded, signIn, setActive } = useSignIn()
+  const [verifying, setVerifying] = React.useState(false)
+  const [phone, setPhone] = React.useState("")
+  const [code, setCode] = React.useState("")
+  const router = useRouter()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!isLoaded && !signIn) return null
+
+    try {
+      // Start the Sign Up process using the phone number method
+      const { supportedFirstFactors } = await signIn.create({
+        identifier: phone,
+      });
+
+      // Filter the returned array to find the 'phone_code' entry
+      const phoneCodeFactor = supportedFirstFactors.find(factor => {
+        return factor.strategy === 'phone_code'
+      })
+
+      if (phoneCodeFactor) {
+        // Grab the phoneNumberId
+        const { phoneNumberId } = phoneCodeFactor
+
+        // Send the OTP code to the user
+        await signIn.prepareFirstFactor({
+          strategy: 'phone_code',
+          phoneNumberId
+        })
+
+        // Set 'verifying' true to display second form and capture the OTP code
+        setVerifying(true)
+      }
+    }
+    catch (err) {
+      // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
+      console.error('Error:', JSON.stringify(err, null, 2))
+    }
+  }
+
+  async function handleVerification(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!isLoaded && !signIn) return null
+
+    try {
+      // Use the code provided by the user and attempt verification
+      const completeSignIn = await signIn.attemptFirstFactor({
+        strategy: 'phone_code',
+        code
+      })
+
+      // This mainly for debuggin while developing.
+      // Once your Instance is setup this should not be required.
+      if (completeSignIn.status !== 'complete') {
+        console.error(JSON.stringify(completeSignIn, null, 2))
+      }
+
+      // If verification was completed, create a session for the user
+      if (completeSignIn.status === 'complete') {
+        await setActive({ session: completeSignIn.createdSessionId });
+
+        // Redirect user 
+        router.push("/")
+      }
+    }
+    catch (err) {
+      // See https://clerk.com/docs/custom-flows/error-handling for more on error handling
+      console.error('Error:', JSON.stringify(err, null, 2))
+    }
+  }
+
+  if (verifying) {
+    return (
+      <form onSubmit={handleVerification}>
+        <label id="code">Code</label>
+        <input value={code} id="code" name="code" onChange={(e) => setCode(e.target.value)} />
+        <button type="submit">Verify</button>
+      </form>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label id="phone">Phone</label>
+      <input value={phone} id="phone" name="phone" type="tel" onChange={(e) => setPhone(e.target.value)} />
+      <button type="submit">Send Code</button>
+    </form>
+  );
+}
+```
+
 ```jsx filename="SignInPage.jsx"
 import { useSignIn } from "@clerk/clerk-react";
 


### PR DESCRIPTION
@alexisintech -- before I do a final edit/revision do you want the examples to be labelled as 'Next App Router'?. The file path/name, the `'use client'` and the use of 'next/navigation' are minor but specific to App Router. Or just call it Next.js?