### PR TITLE
workflows(revalidate): output paths to summary

### DIFF
--- a/.github/workflows/revalidate.yml
+++ b/.github/workflows/revalidate.yml
@@ -4,6 +4,7 @@ env:
   CLERK_COM_BASE_URL: https://clerk.com
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -31,8 +32,12 @@ jobs:
         run: |
           paths_to_revalidate=$(echo ${{ contains(steps.changed-files.outputs.all_changed_files, 'docs/manifest.json') && '\\\"*\\\"' || toJSON(steps.changed-files.outputs.all_changed_files) }} | sed 's/.mdx//g' | sed 's/\/index//g')
           echo "paths=$paths_to_revalidate" >> "$GITHUB_OUTPUT"
+          echo "### Paths to revalidate" >> $GITHUB_STEP_SUMMARY
+          echo ""                        >> $GITHUB_STEP_SUMMARY
+          echo "$paths_to_revalidate"    >> $GITHUB_STEP_SUMMARY
 
       - name: Trigger revalidate
+        if: github.ref_name == 'main'
         run: |
           curl -X POST ${{ env.CLERK_COM_BASE_URL }}/api/revalidate-docs \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
# Description

This adds a `workflow_dispatch` trigger to the revalidate workflow

This outputs changed paths to GITHUB_STEP_SUMMARY

This updates the workflow trigger to only revalidate if the `ref_name` is `main`