### PR TITLE
DOCS-420 add reference link to custom flows for oauth

### DIFF
--- a/docs/authentication/social-connections/oauth.mdx
+++ b/docs/authentication/social-connections/oauth.mdx
@@ -69,13 +69,13 @@ Using these tokens, you can query the respective OAuth providers for additional 
   Clerk ensures that the OAuth Access Token will be always fresh so that you don't have to worry about OAuth Refresh Tokens anymore.
 </Callout>
 
-## Add Social Connection after Sign Up
+## Add Social Connection after sign-up
 
 For each OAuth provider, you can choose whether it will be available during sign-up and sign-in, or if the connection should be made later.
 
 This is especially useful for applications that prefer to connect third-parties after the fact. For example, a Github connection can be made after sign-up if an application wants to read repository data.
 
-After sign-up, connections can be made through our [`<UserProfile/>`](/docs/components/user/user-profile) component, or with a custom flow.
+After sign-up, connections can be made through our [`<UserProfile/>`](/docs/components/user/user-profile) component, or with a [custom flow](https://clerk.com/docs/custom-flows/oauth-connections).
 
 <Images
   width={3024}
@@ -84,11 +84,11 @@ After sign-up, connections can be made through our [`<UserProfile/>`](/docs/comp
   alt="The 'Google' social connection settings modal with a red box surrounding the 'Enable for sign-up and sign-in' section."
 />
 
-## Connecting to OAuth providers while signed in
+## Connecting to OAuth providers while signed-in
 
-When signed in, a user can connect to further OAuth providers as well. There is no need to perform another sign-up.
+When signed-in, a user can connect to further OAuth providers as well. There is no need to perform another sign-up.
 
-When using Clerk's [Account Portal](/docs/account-portal/overview) pages, users can see which providers they have already connected to and which ones they can still connect to on thier [User Profile](/docs/account-portal/user-profile-org-profile#user-profile) page.
+When using Clerk's [Account Portal](/docs/account-portal/overview) pages, users can see which providers they have already connected to and which ones they can still connect to on their [User Profile](/docs/account-portal/user-profile-org-profile#user-profile) page.
 
 <Images
   width={3024}

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -11,7 +11,7 @@ Learn how to use Clerk to quickly and easily add secure authentication and user 
 
 ### Install `@clerk/nextjs`
 
-Once you have a Next.js application ready, you need to install Clerk's Next.js SDK. This gives you access to prebuilt components and hooks, as well as [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and middleware.
+Once you have a Next.js application ready, you need to install Clerk's Next.js SDK. This gives you access to prebuilt components and hooks, as well as [helpers](/docs/references/nextjs/overview) for Next.js API routes, server-side rendering, and Middleware.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
   ```bash filename="terminal"
@@ -111,7 +111,7 @@ export const config = {
 
 ```
 
-With this middleware, your entire application is protected. If you try to access it, the middleware will redirect you to your Sign Up page. If you want to make other routes public, check out the [authMiddleware reference page](/docs/references/nextjs/auth-middleware).
+With this middleware, your entire application is protected. If you try to access it, the Middleware will redirect you to your Sign Up page. If you want to make other routes public, check out the [authMiddleware reference page](/docs/references/nextjs/auth-middleware).
 
 
 
@@ -344,7 +344,7 @@ export default async function handler(
 
     #### **`auth()`**
 
-    Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the same [`Authentication` Object](/docs/references/nextjs/authentication-object) as [`getAuth(req)`](/docs/references/nextjs/get-auth) in middleware, getServerSideProps, and API routes.
+    Clerk has introduced a new [`auth()`](/docs/references/nextjs/auth) helper that returns the same [`Authentication` Object](/docs/references/nextjs/authentication-object) as [`getAuth(req)`](/docs/references/nextjs/get-auth) in Middleware, getServerSideProps, and API routes.
 
     Since request data like `headers()` and `cookies()` is now available in the global scope for Next.js, you no longer need to explicitly pass a `Request` object to Clerk.
 

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -9,7 +9,7 @@ The `authMiddleware()` helper integrates Clerk authentication into your Next.js 
 
 ## Usage
 
-Create the `middleware.ts` file in the root folder of your application, or inside the src/ if that is how your app is set up.
+Create the `middleware.ts` file in the root folder of your application, or inside the `src/` if that is how your app is set up.
 
 <Callout type="info">
   For more information about middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
@@ -21,7 +21,7 @@ import { authMiddleware } from "@clerk/nextjs";
 export default authMiddleware();
 
 export const config = {
-      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
+  matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 ```
 
@@ -75,7 +75,7 @@ export default authMiddleware({
 });
 
 export const config = {
-      matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
+  matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)'],
 };
 ```
 

--- a/docs/references/nextjs/current-user.mdx
+++ b/docs/references/nextjs/current-user.mdx
@@ -5,16 +5,16 @@ description: Access the User object inside of your server components, actions an
 
 # `currentUser()`
 
-The `currentUser` helper returns the `User` object of the currently active user. This is the same `User` object that is returned by the [`useUser`](/docs/references/react/use-user) hook. However, it can be used in server components, route handlers, and server actions.
+The `currentUser` helper returns the `User` object of the currently active user. This is the same `User` object that is returned by the [`useUser`](/docs/references/react/use-user) hook. However, it can be used in Server Components, Route Handlers, and Server Actions.
 
 ```tsx filename="app/page.[jsx/tsx]"
 import { currentUser } from '@clerk/nextjs';
 
 export default async function Page() {
-const user = await currentUser();
+  const user = await currentUser();
 
-if (!user) return <div>Not logged in</div>;
+  if (!user) return <div>Not logged in</div>;
 
-return <div>Hello {user?.firstName}</div>;
+  return <div>Hello {user?.firstName}</div>;
 }
 ```


### PR DESCRIPTION
[Feedback on this page](https://linear.app/clerk/issue/DOCS-420/%F0%9F%98%A2-feedback-for-authenticationsocial-connectionsoauthadd-social) asks "What about programmatically doing this?"

This PR
- adds a link to creating a custom flow for oauth connections
- fixes syntax where necessary
- uses Middleware (capitalized) when referring to Next.js Middleware