### PR TITLE
DOCS-350 / DOCS-191 use clerkClient instead of clerk from node SDK

### DIFF
--- a/docs/references/backend/overview.mdx
+++ b/docs/references/backend/overview.mdx
@@ -35,10 +35,10 @@ import { clerkClient } from "@clerk/fastify";
 </Tab>
 
 <Tab>
-The Backend SDK is accessible via the `clerk` object if you are using Node.
+The Backend SDK is accessible via the `clerkClient` object if you are using Node.
 
 ```js
-import clerk from '@clerk/clerk-sdk-node';
+import clerkClient from '@clerk/clerk-sdk-node';
 ```
 </Tab>
 </Tabs>

--- a/docs/references/backend/user/update-user.mdx
+++ b/docs/references/backend/user/update-user.mdx
@@ -82,7 +82,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 ```
 
 ```js filename="updateUser.js"
-import clerk from '@clerk/clerk-sdk-node';
+import clerkClient from '@clerk/clerk-sdk-node';
 
 app.post('/api/update-user',
   // ClerkExpressRequireAuth returns an error for unauthorized requests
@@ -97,7 +97,7 @@ app.post('/api/update-user',
     // The user attributes to update
     const params = { firstName: "John", lastName: "Wick" }
 
-    const updatedUser = await clerk.users.updateUser(userId, params)
+    const updatedUser = await clerkClient.users.updateUser(userId, params)
 
     res.json({ updatedUser })
   })

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -37,7 +37,7 @@ Below is an example of an `.env.local` file. If you are signed into your Clerk D
 
 <InjectKeys>
 
-```sh filename=".env.local"
+```env filename=".env.local"
 CLERK_SECRET_KEY={{secret}}
 ```
 
@@ -47,11 +47,11 @@ CLERK_SECRET_KEY={{secret}}
 
 ## Resources
 
-All resource operations are mounted as sub-APIs on the `Clerk` class. For more information, check out the [Clerk Backend SDK](/docs/references/backend/overview) documentation.
+All resource operations are mounted as sub-APIs on the `clerkClient` object. For more information, check out the [Clerk Backend SDK](/docs/references/backend/overview) documentation.
 
 ## Customizing resources
 
-The following options are available for you to customize the behaviour of the `Clerk` class.
+The following options are available for you to customize the behaviour of the `clerkClient` object.
 
 <Callout type="info">
   Most options can also be set as environment variables so that you don't need to pass anything to the constructor or set it via the available setters.
@@ -79,9 +79,9 @@ If you are comfortable with setting the `CLERK_SECRET_KEY` environment variable 
 <Tabs items={["ESM", "CJS"]}>
 <Tab>
 ```js
-import clerk from '@clerk/clerk-sdk-node';
+import clerkClient from '@clerk/clerk-sdk-node';
 
-const userList = await clerk.users.getUserList();
+const userList = await clerkClient.users.getUserList();
 ```
 
 Or if you are interested only in a certain resource:
@@ -96,9 +96,9 @@ const sessionList = await sessions.getSessionList();
 <Tab>
 ```js
 const pkg = require('@clerk/clerk-sdk-node');
-const clerk = pkg.default;
+const clerkClient = pkg.default;
 
-clerk.emails
+clerkClient.emails
   .createEmail({ fromEmailName, subject, body, emailAddressId })
   .then((email) => console.log(email))
   .catch((error) => console.error(error));
@@ -120,16 +120,16 @@ clients
 
 #### Setters
 
-The following setters are available for you to change the options even after you've obtained a handle on a `Clerk` or sub-api instance:
+The following setters are available for you to change the options even after you've obtained a handle on a `clerkClient` or sub-api instance:
 
-If you have a `Clerk` handle:
+If you have a `clerkClient` handle:
 
-- `clerk.secretKey = value;`
-- `clerk.serverApiUrl = value;`
-- `clerk.apiVersion = value;`
-- `clerk.httpOptions = value;`
+- `clerkClient.secretKey = value;`
+- `clerkClient.serverApiUrl = value;`
+- `clerkClient.apiVersion = value;`
+- `clerkClient.httpOptions = value;`
 
-If are using a sub-api handle and wish to change options on the (implicit) singleton `Clerk` instance:
+If are using a sub-api handle and wish to change options on the (implicit) singleton `clerkClient` instance:
 
 - `setClerkSecretKey(value)`
 - `setClerkServerApiUrl(value)`
@@ -138,21 +138,25 @@ If are using a sub-api handle and wish to change options on the (implicit) singl
 
 ### Custom instantiation
 
+If you would like to customize the behavior of the SDK, you can instantiate a `clerkClient` instance yourself by passing in [options](#customizing-resources).
+
+The example below shows how to create a `clerkClient` instance and pass a Clerk secret key instead of setting a `CLERK_SECRET_KEY` environment variable.
+
 <CodeBlockTabs options={["ESM", "CJS"]}>
 ```js
 import Clerk from '@clerk/clerk-sdk-node/esm/instance';
 
-const clerk = new Clerk({ secretKey: 'secret_key' });
+const clerkClient = Client({ secretKey: 'secret_key' });
 
-const clientList = await clerk.clients.getClientList();
+const clientList = await clerkClient.clients.getClientList();
 ```
 
 ```js
 const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default;
 
-const clerk = new Clerk({ secretKey: 'secret_key' });
+const clerkClient = Clerk({ secretKey: 'secret_key' });
 
-clerk.smsMessages
+clerkClient.smsMessages
   .createSMSMessage({ message, phoneNumberId })
   .then((smsMessage) => console.log(smsMessage))
   .catch((error) => console.error(error));

--- a/docs/references/nodejs/token-verification.mdx
+++ b/docs/references/nodejs/token-verification.mdx
@@ -24,9 +24,9 @@ withAuth(handler, { jwtKey: 'my_clerk_public_key' });
 Custom instance initialization:
 
 ```js
-import Clerk from '@clerk/clerk-sdk-node/instance';
+import clerkClient from '@clerk/clerk-sdk-node/instance';
 
-const clerk = new Clerk({ jwtKey: 'my_clerk_public_key' });
+const clerk = clerkClient({ jwtKey: 'my_clerk_public_key' });
 ```
 
 ## Validate the Authorized Party of a session token

--- a/docs/users/deleting-users.mdx
+++ b/docs/users/deleting-users.mdx
@@ -51,13 +51,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 ```
 
 ```ts filename="private.ts"
-import { clerk } from "@clerk/clerk-sdk-node";
+import { clerkClient } from "@clerk/clerk-sdk-node";
 
 app.post('/deleteUser', (req, res) => {
   const userId = req.body.userId;
 
   try {
-    await clerk.users.deleteUser(userId);
+    await clerkClient.users.deleteUser(userId);
     return res.status(200).json({ message: 'Success' });
   }
   catch (error) {


### PR DESCRIPTION
Fixes [DOCS-350](https://linear.app/clerk/issue/DOCS-350/change-clerk-to-clerkclient-in-all-node-examples) and [DOCS-191](https://linear.app/clerk/issue/DOCS-191/node-sdk-docs-mention-clerk-as-a-class)

This PR
- updates imports of the `clerk` object from the Node SDK to use `clerkClient` instead. All other SDK's import as `clerkClient` so we can do the same for the Node SDK in the name of consistency.
- fixes the custom instantiation of the Clerk object (was being called as a class, when it is simply a function)

The code examples were tested 👍