### PR TITLE
DOCS-419 clarify on where the middleware options can be used

### DIFF
--- a/docs/backend-requests/handling/nodejs.mdx
+++ b/docs/backend-requests/handling/nodejs.mdx
@@ -159,6 +159,7 @@ app.listen(port, () => {
 </CodeBlockTabs>
 
 ### Express Error Handlers
+
 Express comes with a default error handler for errors encountered in the middleware chain.
 
 Developers can also implement their own custom error handlers as detailed in the [Express error handling guide](https://expressjs.com/en/guide/error-handling.html). An example error handler can be found above.
@@ -166,6 +167,8 @@ Developers can also implement their own custom error handlers as detailed in the
 If you are using the strict middleware variant, the `err` passed to your error handler will contain enough context for you to respond as you deem fit.
 
 ## Middleware options
+
+These options can be used with both [`ClerkExpressWithAuth`](#clerk-express-with-auth) and [`ClerkExpressRequireAuth`](#clerk-express-require-auth).
 
 | Name        | Type        | Description    |
 | ----------- | ----------- | -------------- |


### PR DESCRIPTION
In [DOCS-419](https://linear.app/clerk/issue/DOCS-419/%F0%9F%98%A2-feedback-for-backend-requestshandlingnodejs), the user asked "What are the options for ClerkExpressWithAuth()"

This PR adds copy to clarify that the middleware options listed at the bottom of the page can be used with any of the middleware addressed on the page.