### PR TITLE
fix: cURL command in OAuth IDP docs

### DIFF
--- a/docs/advanced-usage/clerk-idp.mdx
+++ b/docs/advanced-usage/clerk-idp.mdx
@@ -33,7 +33,7 @@ curl
  -X POST https://api.clerk.com/v1/oauth_applications \
  -H "Authorization: Bearer <CLERK_SECRET_KEY>"  \
  -H "Content-Type: application/json" \
- -D {"callback_url":"https://oauth-client.com/oauth2/callback", "name": "oauth_app_1"}
+ -d {"callback_url":"https://oauth-client.com/oauth2/callback", "name": "oauth_app_1"}
 ```
 
 To create an OAuth Application that uses the authorization code flow with proof of key exchange (PKCE), set `public` to `true` in the POST request body.


### PR DESCRIPTION
`-D` is the shorthand of the `--dump-header` option, while here we want the `-d` (shorthand for `--data`).