### PR TITLE
DOCS-427 pass correct variable to verifyClient() in nodejs code example

### DIFF
--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -142,11 +142,13 @@ If you would like to customize the behavior of the SDK, you can instantiate a `c
 
 The example below shows how to create a `clerkClient` instance and pass a Clerk secret key instead of setting a `CLERK_SECRET_KEY` environment variable.
 
+<InjectKeys>
+
 <CodeBlockTabs options={["ESM", "CJS"]}>
 ```js
 import Clerk from '@clerk/clerk-sdk-node/esm/instance';
 
-const clerkClient = Client({ secretKey: 'secret_key' });
+const clerkClient = Clerk({ secretKey: '{{secret}}' });
 
 const clientList = await clerkClient.clients.getClientList();
 ```
@@ -154,7 +156,7 @@ const clientList = await clerkClient.clients.getClientList();
 ```js
 const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default;
 
-const clerkClient = Clerk({ secretKey: 'secret_key' });
+const clerkClient = Clerk({ secretKey: '{{secret}}' });
 
 clerkClient.smsMessages
   .createSMSMessage({ message, phoneNumberId })
@@ -162,6 +164,8 @@ clerkClient.smsMessages
   .catch((error) => console.error(error));
 ```
 </CodeBlockTabs>
+
+</InjectKeys>
 
 ## Multi-session applications
 
@@ -199,6 +203,7 @@ Using the last active session is appropriate when determining the user after a n
 
 ```js
 import { clients, sessions } from '@clerk/clerk-sdk-node';
+import Cookies from 'cookies';
 
 // Note: Clerk stores the clientToken in a cookie 
 // named "__session" for Firebase compatibility

--- a/docs/references/nodejs/overview.mdx
+++ b/docs/references/nodejs/overview.mdx
@@ -205,7 +205,7 @@ import { clients, sessions } from '@clerk/clerk-sdk-node';
 const cookies = new Cookies(req, res);
 const clientToken = cookies.get('__session');  
 
-const client = await clients.verifyClient(sessionToken);
+const client = await clients.verifyClient(clientToken);
 const sessionId = client.lastActiveSessionId;
 
 const session = await sessions.verifySession(sessionId, clientToken);


### PR DESCRIPTION
[DOCS-427](https://linear.app/clerk/issue/DOCS-427/feedback-for-referencesnodejsoverview) points out that a variable is passed to the verifyClient() method but the variable is never declared.
This PR passes the correct variable to the method and also adds a necessary import.
This PR also adds <InjectKeys /> for where the Clerk secret key can be injected.