### PR TITLE
DOCS-448 add reference link for load() method

### DIFF
--- a/docs/references/javascript/overview.mdx
+++ b/docs/references/javascript/overview.mdx
@@ -31,7 +31,7 @@ There are two ways you can include ClerkJS in your project. You can either [impo
   ```
 </CodeBlockTabs>
 
-Once you have installed the package, you will need to import the ClerkJS object constructor into your code and pass it your Clerk Publishable Key as a parameter.
+Once you have installed the package, you will need to import the ClerkJS object constructor into your code and pass it your Clerk Publishable Key as a parameter. Then, you can call the `load()` method to initialize ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
 
 <InjectKeys>
 
@@ -52,6 +52,10 @@ await clerk.load({
 ClerkJS can be loaded from a `<script />` tag with the source from your **Frontend API URL**. You can find your **Frontend API URL** on the [API Keys](https://dashboard.clerk.com/last-active?path=api-keys) page in the Clerk Dashboard. Click on the **Advanced** dropdown to reveal the **Frontend API URL**.
 
 Add the following script to your site's `<body>` element:
+
+<Callout type="info">
+  Calling the `load()` method initializes ClerkJS. For more information on the `load()` method and what options you can pass to it, check out the [reference documentation](/docs/references/javascript/clerk/clerk#load).
+</Callout>
 
 <InjectKeys>
 


### PR DESCRIPTION
[DOCS-448](https://linear.app/clerk/issue/DOCS-448/feedback-for-referencesjavascriptoverview) expresses confusion about the `load()` method called to instantiate ClerkJS.

This PR adds copy and a reference link to guide users to the `load()` reference docs, which describe the options that can be passed to this method.