### PR TITLE
DOCS-453 add copy and code comment to clarify on the sign out process

### DIFF
--- a/docs/custom-flows/sign-out.mdx
+++ b/docs/custom-flows/sign-out.mdx
@@ -76,6 +76,8 @@ const Header = () => {
 
 If the pre-built [`<UserButton />`][user-button] doesn't cover your needs, you can use the [`signOut()`](/docs/references/javascript/clerk/clerk#sign-out) function to build a custom solution.
 
+In this example, the [`useClerk()`](/docs/references/react/use-clerk) hook is used to access the [`signOut()`](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out) function. We then use the [`useRouter()`](https://nextjs.org/docs/pages/api-reference/functions/use-router) hook from Next.js to redirect the user to the home page (`/`) after they sign out.
+
 <CodeBlockTabs options={["React", "JavaScript"]}>
 ```jsx
 import { useClerk } from "@clerk/clerk-react";
@@ -86,6 +88,7 @@ const SignOutButton = () => {
   const router = useRouter()
 
   return (
+    // Clicking on this button will sign out a user and reroute them to the "/" (home) page.
     <button onClick={() => signOut(() => router.push("/"))}>
       Sign out
     </button>


### PR DESCRIPTION
[DOCS-453](https://linear.app/clerk/issue/DOCS-453/%F0%9F%98%A2-feedback-for-custom-flowssign-out) expresses that the docs aren't clear on how to perform a sign out and redirect to a page after the sign out.

This PR adds copy and a code comment to clarify how the signOut method is used to sign out a user, and the NextJS router is used to redirect a user to a page after sign out is complete.