### PR TITLE
migrate page from sanity to mdx; add copy about being deprecated

### DIFF
--- a/docs/references/react/use-organizations.mdx
+++ b/docs/references/react/use-organizations.mdx
@@ -1,3 +1,169 @@
 ---
-sanity_slug: /docs/reference/clerk-react/useorganizations
+title: useOrganizations()
+description: The useOrganizations() hook has been deprecated in favor of useOrganization().
 ---
+
+# `useOrganizations()`
+
+<Callout type="danger">
+  This hook has been deprecated in favor of [`useOrganization()`](/docs/references/react/use-organization) and [`useOrganizationList()`](/docs/references/react/use-organization-list).
+</Callout>
+
+The `useOrganizations()` hook gives you access to the [`Organization`](/docs/references/javascript/organization/organization) object and related object methods.
+
+For now the available methods are: `createOrganization()`, `getOrganizationMemberships()` and `getOrganization()`.
+
+## Usage
+
+<Callout type="warning">
+  Make sure you've followed the installation guide for [Clerk React](/docs/references/react/overview) before running the snippets below.
+</Callout>
+
+The examples below illustrates simple usage of the methods available. 
+
+<Callout type="info">
+  Note that your component must be a descendant of the [`<SignedIn />`](/docs/components/control/signed-in) component, which in turn needs to be wrapped inside the [`<ClerkProvider />`](/docs/components/clerk-provider).
+</Callout>
+
+<CodeBlockTabs options={["createOrganization", "getMemberships", "getOrganization"]}>
+```jsx
+import { useState } from "react";
+import { SignedIn, useOrganizations } from "@clerk/clerk-react";
+
+function App() {
+  return (
+    <SignedIn>
+      <NewOrganization />
+    </SignedIn>
+  );
+}
+
+// Form to create a new organization. The current user
+// will become the organization administrator.
+function NewOrganization() {
+  const [name, setName] = useState("");
+  const router = useRouter();
+
+  const { createOrganization } = useOrganizations();
+
+  async function submit(e) {
+    e.preventDefault();
+    try {
+      // Create a new organization.
+      await createOrganization({ name });
+      setName("");
+      // Do anything after the action is complete
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div>
+      <h2>Create an organization</h2>
+      <form onSubmit={submit}>
+        <div>
+          <label>Name</label>
+          <br />
+          <input
+            name="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <button>Create organization</button>
+      </form>
+    </div>
+  );
+}
+```
+
+```jsx
+// Retrieve OrganizationMemberships of the current user.
+import { SignedIn, useOrganizations } from "@clerk/clerk-react";
+
+function App() {
+  return (
+    <SignedIn>
+      <OrganizationMemberships />
+    </SignedIn>
+  );
+}
+
+function OrganizationMemberships() {
+  const [organizationMemberships, setOrganizationMemberships] = useState([]);
+
+  const { getOrganizationMemberships } = useOrganizations();
+
+  useEffect(() => {
+    async function fetchOrganizationMemberships() {
+      try {
+        const orgs = await getOrganizationMemberships();
+        setOrganizationMemberships(orgs);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    fetchOrganizationMemberships();
+  }, []);
+
+  return (
+    <div>
+      <h2>Your organizations</h2>
+      <ul>
+        {organizationMemberships.map(({ organization }) => (
+            <p
+              key={organization.id}
+            >
+              {organization.name}
+            </p>
+          ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+```jsx
+import { useState } from "react";
+import { SignedIn, useOrganizations } from "@clerk/clerk-react";
+
+function App() {
+  return (
+    <SignedIn>
+      <GetOrganization orgId={'org_123'} />
+    </SignedIn>
+  );
+}
+
+function GetOrganization({ orgId }){
+  const [organization, setOrganization] = useState(null);
+
+  const { getOrganization } = useOrganizations();
+
+  useEffect(() => {
+    async function fetchOrganization() {
+      try {
+        const org = await getOrganization(orgId);
+        setOrganization(orgs);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    fetchOrganization();
+  }, [orgId]);
+  
+  if(!organization){
+    return null;
+  }
+  
+  return (
+    <div>
+      <h2>Organization {organization.name} with id: {organization.id}</h2>
+    </div>
+  );
+}
+````
+</CodeBlockTabs>


### PR DESCRIPTION
This PR migrates the useOrganizations page to MDX, and adds copy to mention that it's been deprecated in favor of useOrganization and useOrganizationList.