### PR TITLE
DOCS-469 add publicMetadata param and example to createInvitation

### DIFF
--- a/docs/references/backend/invitations/create-invitation.mdx
+++ b/docs/references/backend/invitations/create-invitation.mdx
@@ -13,6 +13,12 @@ Keep in mind that you cannot create an invitation if there is already one for th
 const invitation = await clerkClient.invitations.createInvitation({
   emailAddress: 'invite@example.com',
   redirectUrl: 'https://optionally-redirect-here',
+  publicMetadata: {
+    "example": "metadata",
+    "example_nested": {
+      "nested": "metadata",
+    },
+  }
 });
 ```
 
@@ -22,3 +28,4 @@ const invitation = await clerkClient.invitations.createInvitation({
 | --- | --- | --- |
 | `emailAddress` | `string` | The email address of the user to invite. |
 | `redirectUrl?` | `string` | The URL to redirect the user to after they accept the invitation. |
+| `publicMetadata?` | `Record<string, unknown>` | Metadata saved on the invitation that is visible to both your Frontend and Backend APIs. | 


### PR DESCRIPTION
[DOCS-469](https://linear.app/clerk/issue/DOCS-469/feedback-for-referencesbackendinvitationscreate-invitation) mentions how the docs are missing the possible parameter `publicMetadata`

This PR adds the param to the table of params, and adds example of its usage