### PR TITLE
chore: Update Go token verification examples

### DIFF
--- a/docs/references/go/verifying-sessions.mdx
+++ b/docs/references/go/verifying-sessions.mdx
@@ -17,7 +17,7 @@ package main
 import (
 	"net/http"
 	"strings"
-	
+
 	"github.com/clerkinc/clerk-sdk-go/clerk"
 )
 
@@ -28,7 +28,7 @@ func main() {
 		// get session token from Authorization header
 		sessionToken := r.Header.Get("Authorization")
 		sessionToken = strings.TrimPrefix(sessionToken, "Bearer ")
-		
+
 		// verify the session
 		sessClaims, err := client.VerifyToken(sessionToken)
 		if err != nil {
@@ -63,16 +63,16 @@ package main
 
 import (
 	"net/http"
-	
+
 	"github.com/clerkinc/clerk-sdk-go/clerk"
 )
 
 func main() {
 	client, _ := clerk.NewClient({{secret}})
-	
+
 	mux := http.NewServeMux()
 
-	injectActiveSession := clerk.WithSession(client)
+	injectActiveSession := clerk.WithSessionV2(client)
 	mux.Handle("/hello", injectActiveSession(helloUserHandler(client)))
 
 	http.ListenAndServe(":8080", mux)
@@ -81,8 +81,8 @@ func main() {
 func helloUserHandler(client clerk.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		
-		sessClaims, ok := ctx.Value(clerk.ActiveSessionClaims).(*clerk.SessionClaims)
+
+		sessClaims, ok := clerk.SessionFromContext(ctx)
 		if !ok {
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte("Unauthorized"))


### PR DESCRIPTION
The previous examples were using the old/deprecated middlewares.