### PR TITLE
DOCS-483 clarify on how to import localizations

### DIFF
--- a/docs/components/customization/localization.mdx
+++ b/docs/components/customization/localization.mdx
@@ -37,6 +37,8 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
 
 ### Usage
 
+To get started, you need to install the `@clerk/localizations` package.
+
 <CodeBlockTabs options={["npm", "yarn", "pnpm"]}>
   ```bash filename="terminal"
   npm install @clerk/localizations
@@ -51,13 +53,17 @@ The `@clerk/localizations` package contains predefined localizations for the Cle
   ```
 </CodeBlockTabs>
 
+Once the `@clerk/localizations` package is installed, you can import the localizations you need by removing the "-" from the locale. In this example, the fr-FR locale is imported as `frFR`. The imported localization is then passed to the `localization` prop on the [`<ClerkProvider />`](/docs/components/clerk-provider).
+
 ```tsx filename="_app.tsx"
 import { ClerkProvider } from "@clerk/nextjs";
+// fr-FR locale is imported as frFR
 import { frFR } from "@clerk/localizations";
 import type { AppProps } from "next/app";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
+    // Add the localization prop to the ClerkProvider
     <ClerkProvider localization={frFR} {...pageProps}>
       <Component {...pageProps} />
     </ClerkProvider>


### PR DESCRIPTION
[DOCS-483](https://linear.app/clerk/issue/DOCS-483/feedback-for-componentscustomizationlocalization) includes feedback from a user who got a syntax error when trying to import a localization. Their import looked like: `import { zh-CN } from '@clerk/localizations'`

This PR adds copy and code comments to clarify how to import locales.