### PR TITLE
DOCS-487 add copy that guides users to our component customization docs

### DIFF
--- a/docs/components/authentication/sign-in.mdx
+++ b/docs/components/authentication/sign-in.mdx
@@ -108,6 +108,10 @@ All props below are optional.
 | `afterSignUpUrl` | `string` | The full URL or path to navigate after a successful sign up. |
 | `initialValues` | [`SignInInitialValues`](/docs/references/javascript/types/sign-in-initial-values) | The values used to prefill the sign-in fields with. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
 

--- a/docs/components/authentication/sign-up.mdx
+++ b/docs/components/authentication/sign-up.mdx
@@ -110,5 +110,9 @@ All props below are optional.
 | `unsafeMetadata` | `object` | An object with the key and value for unsafeMetadata that will be saved to the user after sign up.<br />E.g. `{ "company": "companyID1234" }` |
 | `initialValues` | [`SignUpInitialValues`](/docs/references/javascript/types/sign-up-initial-values) | The values used to prefill the sign-up fields with. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview

--- a/docs/components/organization/create-organization.mdx
+++ b/docs/components/organization/create-organization.mdx
@@ -71,5 +71,9 @@ All props below are optional.
 | `path` | `string` | The path where the component is mounted when path-based routing is used. -e.g. /create-org. This prop is ignored in hash and virtual based routing. |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components][components-ref] and not [Account Portal][ap-ref] pages. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview

--- a/docs/components/organization/organization-list.mdx
+++ b/docs/components/organization/organization-list.mdx
@@ -101,6 +101,10 @@ All props below are optional.
 | `afterSelectOrganizationUrl` | <code>((org: [Organization][org-ref]) => string)</code> \| `string` | Full URL or path to navigate after selecting an organization.<br />Defaults to `undefined`. |
 | `afterSelectPersonalUrl` | <code>((org: [Organization][org-ref]) => string)</code> \| `string` | Full URL or path to navigate after selecting the personal account.<br />Defaults to `undefined`. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [org-ref]: /docs/references/javascript/organization/organization
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview

--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -75,5 +75,9 @@ All props below are optional.
 | `path` | `string` | The path where the component is mounted when path-based routing is used. -e.g. /create-org. This prop is ignored in hash and virtual based routing. |
 | `appearance` | <code>[Appearance](/docs/components/customization/overview) \| undefined</code> | Optional object to style your components. Will only affect [Clerk Components][components-ref] and not [Account Portal][ap-ref] pages. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview

--- a/docs/components/organization/organization-switcher.mdx
+++ b/docs/components/organization/organization-switcher.mdx
@@ -93,6 +93,10 @@ All props below are optional.
 | `defaultOpen` | `boolean` | Controls the default state of the [`<OrganizationSwitcher />`][orgswitcher-ref] component. |
 | `organizationProfileProps` | `object` | Specify options for the underlying [`<OrganizationProfile />`][orgprofile-ref] component.<br />e.g. `{appearance: {...}}` |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
 [orgswitcher-ref]: /docs/components/organization/organization-switcher

--- a/docs/components/user/user-button.mdx
+++ b/docs/components/user/user-button.mdx
@@ -210,6 +210,10 @@ All props below are optional.
 | `defaultOpen` | `boolean` | Controls whether the `<UserButton />` should open by default during the first render. |
 | `userProfileProps` | `object` | Specify options for the underlying [`<UserProfile />`][userprofile-ref] component. e.g. `{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}`. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
 [userprofile-ref]: /docs/components/user/user-profile

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -79,5 +79,9 @@ All props below are optional.
 | `path` | `string` | The path where the component is mounted on when path-based routing is used e.g. /sign-in. |
 | `additionalOAuthScopes` | `object` | Specify additional scopes per OAuth provider that your users would like to provide if not already approved. <br />e.g. `{google: ['foo', 'bar'], github: ['qux']}`. |
 
+## Customization
+
+To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview


### PR DESCRIPTION
[DOCS-463](https://linear.app/clerk/issue/DOCS-463/%F0%9F%98%A2-feedback-for-componentsuseruser-button) and [DOCS-479](https://linear.app/clerk/issue/DOCS-479/%F0%9F%98%A2-feedback-for-referencesjavascriptclerkuser-buttonuser-button) are feedback tickets from users that express confusion on how to customize Clerk components.

This PR adds a section titled `Customization` to each of the customizable Clerk component pages. This section guides users to our customization docs.