### PR TITLE
DOCS-488 clarify on where to place middleware.ts

### DIFF
--- a/docs/advanced-usage/satellite-domains.mdx
+++ b/docs/advanced-usage/satellite-domains.mdx
@@ -83,7 +83,7 @@ The `URL` mentioned above is the request url for server side usage or the curren
 
 <Tabs items={['Next.js', 'Remix']}>
   <Tab>
-    You can embed the `<SignIn />` component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The `<SignIn />` component should be mounted on a public page.
+    You can embed the [`<SignIn />`][signin] component using the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes). This allows you to redirect the user inside your application. The [`<SignIn />`][signin] component should be mounted on a public page.
 
     <CodeBlockTabs options={["<ClerkProvider />", "Middleware"]}>
     ```jsx filename="_app.tsx"
@@ -172,3 +172,5 @@ You can repeat this process and create as many satellite applications as you nee
 You can also check out the [example repository](https://github.com/clerkinc/clerk-nextjs-multi-domain-example) with a primary and a satellite Next.js application.
 
 If you have any questions about satellite domains, or you're having any trouble setting this up, please contact support@clerk.com
+
+[signin]: /docs/components/authentication/sign-in

--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -95,7 +95,7 @@ export default MyApp;
 
 ### Protect your application
 
-Now that Clerk is installed and mounted in your application, it’s time to decide which pages are public and which need to hide behind authentication. We do this by creating a `middleware.ts` file at the root folder (or inside `src/` if that is how you set up your app).
+Now that Clerk is installed and mounted in your application, it’s time to decide which pages are public and which need to hide behind authentication. Create a `middleware.ts` file. If your application uses the `src/` directory, your `middleware.ts` file should be placed inside the `src/` folder. If you are not using a `src/` directory, place the `middleware.ts` file in your root directory.
 
 ```tsx filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";
@@ -117,7 +117,7 @@ With this Middleware, your entire application is protected. If you try to access
 
 At this point, your application is fully protected by Clerk and uses Clerk's [Account Portal](/docs/account-portal/overview) pages that are available out of the box. You can start your Next.js application via `npm run dev`, visit `http://localhost:3000`, and sign up to get access to your application. 
 
-Clerk also offers a set of [prebuilt components](/docs/components/overview) and [custom flows](/docs/custom-flows/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components by utilizing the Next.js optional catch-all route.
+Clerk also offers a set of [prebuilt components](/docs/components/overview) and [custom flows](/docs/custom-flows/overview) that you can use instead to embed sign in, sign up, and other user management functions into your Next.js application. We are going to use the [`<SignIn />`](/docs/components/authentication/sign-in) and [`<SignUp />`](/docs/components/authentication/sign-up) components by utilizing the [Next.js optional catch-all route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-routes).
 
 #### Build your sign-up page
 

--- a/docs/references/nextjs/auth-middleware.mdx
+++ b/docs/references/nextjs/auth-middleware.mdx
@@ -9,7 +9,7 @@ The `authMiddleware()` helper integrates Clerk authentication into your Next.js 
 
 ## Usage
 
-Create the `middleware.ts` file in the root folder of your application, or inside the `src/` if that is how your app is set up.
+Create a `middleware.ts` file. If your application uses the `src/` directory, your `middleware.ts` file should be placed inside the `src/` folder. If you are not using a `src/` directory, place the `middleware.ts` file in your root directory.
 
 <Callout type="info">
   For more information about middleware in Next.js, see the [Next.js documentation](https://nextjs.org/docs/pages/building-your-application/routing/middleware).

--- a/docs/references/nextjs/trpc.mdx
+++ b/docs/references/nextjs/trpc.mdx
@@ -48,7 +48,7 @@ CLERK_SECRET_KEY={{secret}}
 
 ### Configure middleware
 
-[Middleware](/docs/references/nextjs/auth-middleware) needs to be placed at the root of your project. This allows you to use Clerk server-side APIs.
+[Middleware](/docs/references/nextjs/auth-middleware) allows you to use Clerk server-side APIs. Create a `middleware.ts` file. If your application uses the `src/` directory, your `middleware.ts` file should be placed inside the `src/` folder. If you are not using a `src/` directory, place the `middleware.ts` file in your root directory.
 
 ```ts filename="middleware.ts"
 import { authMiddleware } from "@clerk/nextjs";


### PR DESCRIPTION
Support continues getting tickets of users struggling with configuring their middleware, specifically where to place their middleware file.

This PR expands on the copy that explains where to place the middleware.ts file