### PR TITLE
fix: update broken link on fauna integration page

### DIFF
--- a/docs/integrations/databases/fauna.mdx
+++ b/docs/integrations/databases/fauna.mdx
@@ -46,7 +46,7 @@ You can find this URL in the [API keys](https://dashboard.clerk.com/last-active?
   alt="The API Keys page in the Clerk Dashboard. A red box outlines the 'Advanced' drop down button. A red arrow is pointing to the copy button next to 'JWKS URL' in the 'JWT public key' section."
 />
 
-The last part is to select a role that will be assigned to authenticated users. The [Role](https://docs.fauna.com/fauna/current/cookbook/security/user-roles) defines the access privileges and domain-specific security rules. You can specify multiple roles if necessary.
+The last part is to select a role that will be assigned to authenticated users. The [Role](https://docs.fauna.com/fauna/current/cookbook/advanced/security/user-roles) defines the access privileges and domain-specific security rules. You can specify multiple roles if necessary.
 
 The completed provider form should resemble the following:
 


### PR DESCRIPTION
Fauna changed the URL to their user-roles page and the old one is 404ing.

Broken Link
https://docs.fauna.com/fauna/current/cookbook/security/user-roles

Working Link
https://docs.fauna.com/fauna/current/cookbook/advanced/security/user-roles