### PR TITLE
Add a reference to Custom Pages docs in UserProfile and OrganizationProfile pages

### DIFF
--- a/docs/components/organization/organization-profile.mdx
+++ b/docs/components/organization/organization-profile.mdx
@@ -79,5 +79,8 @@ All props below are optional.
 
 To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
 
+In addition, you also can add custom pages and links. For more information, refer to the [Custom Pages documentation][custom-pages-ref].
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
+[custom-pages-ref]: /docs/components/customization/organization-profile

--- a/docs/components/user/user-profile.mdx
+++ b/docs/components/user/user-profile.mdx
@@ -83,5 +83,8 @@ All props below are optional.
 
 To learn about how to customize Clerk components, see the [customization documentation](/docs/components/customization/overview).
 
+In addition, you also can add custom pages and links. For more information, refer to the [Custom Pages documentation][custom-pages-ref].
+
 [components-ref]: /docs/components/overview
 [ap-ref]: /docs/account-portal/overview
+[custom-pages-ref]: /docs/components/customization/user-profile


### PR DESCRIPTION
This PR adds a small sentence to point to the Custom pages documentation at the bottom of `UserProfile` and `OrganizationProfile` pages.