### PR TITLE
Fix node-fetch@2 install command on firebase migration docs

### DIFF
--- a/docs/deployments/migrate-from-firebase.mdx
+++ b/docs/deployments/migrate-from-firebase.mdx
@@ -84,7 +84,7 @@ npm init -y
 #### Install dependencies
 
 ```bash filename="terminal"
-node-fetch@2
+npm i node-fetch@2
 ```
 
 #### Create a script


### PR DESCRIPTION
The current command does not include the `npm install` / `npm i`.