### PR TITLE
Fix URL for `currentUser`

### DIFF
--- a/docs/references/nextjs/read-session-data.mdx
+++ b/docs/references/nextjs/read-session-data.mdx
@@ -11,7 +11,7 @@ Clerk provides a set of [hooks and helpers](/docs/references/nextjs/overview#cli
 
 ### App Router
 
-[`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](currentuser-ref) are App Router-specific helpers that you can use inside of your Route Handlers, Middleware, Server Components, and Server Actions.
+[`auth()`](/docs/references/nextjs/auth) and [`currentUser()`](/docs/references/nextjs/current-user) are App Router-specific helpers that you can use inside of your Route Handlers, Middleware, Server Components, and Server Actions.
 
 The `auth()` helper will return the [`Authentication`](/docs/references/nextjs/authentication-object) object of the currently active user. Now that request data is available in the global scope through Next.js's `headers()` and `cookies()` methods, passing the request object to Clerk is no longer required.
 


### PR DESCRIPTION
This broken link was reported on the #broken-links-alerts Slack channel and can be found on [this page](https://clerk.com/docs/references/nextjs/read-session-data) as `currentUser()`.