### PR TITLE
Small typo in fastify quickstart

### DIFF
--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -52,7 +52,7 @@ CLERK_SECRET_KEY={{secret}}
 
 </InjectKeys>
 
-This examples uses `dontenv` to load the environment variables. You can use any other library or method, if you so wish.
+This examples uses `dotenv` to load the environment variables. You can use any other library or method, if you so wish.
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
   ```bash filename="terminal"

--- a/docs/quickstarts/fastify.mdx
+++ b/docs/quickstarts/fastify.mdx
@@ -56,18 +56,18 @@ This examples uses `dotenv` to load the environment variables. You can use any o
 
 <CodeBlockTabs options={['npm', 'yarn', 'pnpm']}>
   ```bash filename="terminal"
-  npm install @dotenv
-  npm install -D types/dotenv
+  npm install dotenv
+  npm install -D @types/dotenv
   ```
 
   ```bash filename="terminal"
-  yarn add @clerk/fastify
-  yarn add -D types/dotenv
+  yarn add dotenv
+  yarn add -D @types/dotenv
   ```
 
   ```bash filename="terminal"
-  pnpm add @clerk/fastify
-  pnpm add -D types/dotenv
+  pnpm add dotenv
+  pnpm add -D @types/dotenv
   ```
 </CodeBlockTabs>
 


### PR DESCRIPTION
Just fixed a small typo in `/docs/quickstarts/fastify.mdx`

dotenv was spelled `dontenv`