### PR TITLE
add video callout to custom-signup-signin-pages

### DIFF
--- a/docs/references/nextjs/custom-signup-signin-pages.mdx
+++ b/docs/references/nextjs/custom-signup-signin-pages.mdx
@@ -9,6 +9,9 @@ This guide shows you how to use the [`<SignIn />`](/docs/components/authenticati
 
 If Clerk's prebuilt components don't meet your specific needs or if you require more control over the logic, you can rebuild the existing Clerk flows using the Clerk API. For more information, check out the [custom flows](/docs/custom-flows/overview) guides.
 
+> [!NOTE]
+> Watch the video version of this guide on the Clerk YouTube channel  → [YouTube (4 minutes)](https://youtu.be/fsuHLafTYyg).
+
 <Callout>
   Just getting started with Clerk and Next.js? Check out the [quickstart tutorial](/docs/quickstarts/nextjs)!
 </Callout>


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
> 
> - https://clerk.com/docs/pr/1237/references/nextjs/custom-signup-signin-pages#build-your-own-sign-in-and-sign-up-pages-for-your-next-js-app-with-clerk

Inspired by the [Next documentation](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations), I recorded a video version of the custom-signup-signin-pages guide to embed on the same page.

The goal is to increase the time on page and strengthen/increase our ranking in Google for the page.

Intuitively, I know some developers prefer to watch video sometimes, so I hope this improves their experience with Clerk.


### This PR:

Adds a callout with a link to the video on YouTube. 
