### PR TITLE
remove return from middleware and fix syntax highlighting

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -233,7 +233,7 @@ export const config = {
 
 If you are having issues getting your Middleware dialed in, or are trying to narrow down auth-related issues, you can use the debugging feature in `clerkMiddleware()`. Add `{ debug: true }` to `clerkMiddleware()` and you will get debug logs in your terminal.
 
-```tsx {{ filename: 'middleware.ts', mark: [7] }}
+```tsx {{ filename: 'middleware.ts', mark: [[4, 7]] }}
 import { clerkMiddleware } from '@clerk/nextjs/server'
 
 export default clerkMiddleware(
@@ -276,7 +276,7 @@ const isProtectedRoute = createRouteMatcher(['dashboard/(.*)'])
 export default clerkMiddleware((auth, req) => {
   if (isProtectedRoute(req)) auth().protect()
 
-  return intlMiddleware(req)
+  intlMiddleware(req)
 })
 
 export const config = {


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1566

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- removes `return` from middleware
- fixes syntax highlighting
