### PR TITLE
(references/nextjs/clerk-middleware) add return back to intlMiddleware

### DIFF
--- a/docs/references/nextjs/clerk-middleware.mdx
+++ b/docs/references/nextjs/clerk-middleware.mdx
@@ -276,7 +276,7 @@ const isProtectedRoute = createRouteMatcher(['dashboard/(.*)'])
 export default clerkMiddleware((auth, req) => {
   if (isProtectedRoute(req)) auth().protect()
 
-  intlMiddleware(req)
+  return intlMiddleware(req)
 })
 
 export const config = {


### PR DESCRIPTION
<!--- Add the "deploy-preview" label and add your page previews here -->

> [!IMPORTANT]
> 🔎 Previews:
>
> - https://clerk.com/docs/pr/1635/references/nextjs/clerk-middleware

<!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

### Explanation:

<!--- How does this PR solve the problem? -->

### This PR:

- reverts the return 
- made a new PR to keep the corrected syntax highlighting 
