### PR TITLE
docs(expo): Remove publishable key instruction

### DIFF
--- a/docs/quickstarts/expo.mdx
+++ b/docs/quickstarts/expo.mdx
@@ -80,8 +80,6 @@ description: Add authentication and user management to your Expo app with Clerk.
 
   <Include src="_partials/clerk-provider/explanation" />
 
-  You must pass your Publishable Key as a prop to the `<ClerkProvider>` component.
-
   Add the component to your root layout as shown in the following example:
 
   ```tsx {{ filename: 'app/_layout.tsx' }}


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2131/quickstarts/expo#add-clerk-provider-to-your-root-layout

### What does this solve?

- We are still instructing to put `publishableKey` in the `<ClerkProvider>`. This is okay, but we do read it in the env var already. A follow up to https://github.com/clerk/clerk-docs/pull/2127 w/c I missed [🫣](https://emojipedia.org/face-with-peeking-eye)

### What changed?

- Removes the instruction in the expo quickstart to add PK in the `<ClerkProvider>`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
