### PR TITLE
Update KB abbreviation in user and org metadata to be correct

### DIFF
--- a/docs/organizations/metadata.mdx
+++ b/docs/organizations/metadata.mdx
@@ -35,4 +35,4 @@ There are two ways to set organization metadata:
 To ease the flow of setting metadata, Clerk provides the `updateOrganizationMetadata()` and `updateOrganizationMembershipMetadata()` methods from the [Backend SDK](/docs/references/backend/overview), which is a wrapper around the [Backend API](/docs/reference/backend-api){{ target: '_blank' }}.
 
 > [!WARNING]
-> Metadata is limited to **8kb** maximum.
+> Metadata is limited to **8KB** maximum.

--- a/docs/users/metadata.mdx
+++ b/docs/users/metadata.mdx
@@ -12,7 +12,7 @@ Metadata allows for custom data to be saved on the [`User` object](/docs/users/o
 | Unsafe | Read & write access | Read & write access |
 
 > [!WARNING]
-> Metadata is limited to **8kb** maximum.
+> Metadata is limited to **8KB** maximum.
 
 ## Private metadata
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/2283/organizations/metadata.mdx
- https://clerk.com/docs/pr/2283/users/metadata.mdx

### What does this solve?

This correct the abbreviation for data size in user and organization metadata documentation from kb to KB to accurately represent kilobytes instead of kilobits, ensuring clarity and precision in the documentation.

Linear: https://linear.app/clerk/issue/DOCS-9990/update-abbreviations-to-be-correct

### What changed?

Updated all instances of kb to KB in the user metadata and organization metadata docs.

**NOTE:** Noticed kb is used in [this page](https://clerk.com/docs/backend-requests/custom-session-token) and in one of the partials. Do we want to change it there too? 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
