### PR TITLE
Ensure consistency for reverification requirements

### DIFF
--- a/docs/_partials/reverification-callout.mdx
+++ b/docs/_partials/reverification-callout.mdx
@@ -1,0 +1,3 @@
+> [!WARNING]
+>
+> Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.12.7` or later, `@clerk/clerk-react@5.25.1` or later, `@clerk/clerk-js@5.57.1` or later and `@clerk/clerk-sdk-ruby@3.3.0` or later.

--- a/docs/guides/reverification.mdx
+++ b/docs/guides/reverification.mdx
@@ -3,9 +3,7 @@ title: Add reverification for sensitive actions
 description: Learn how to implement Clerk's reverification feature to protect sensitive actions in your application.
 ---
 
-> [!WARNING]
->
-> Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.12.7` or later, `@clerk/clerk-sdk-ruby@3.3.0` or later, and `@clerk/clerk-js@5.57.1` or later.
+<Include src="_partials/reverification-callout" />
 
 Reverification allows you to prompt a user to verify their credentials before performing sensitive actions, even if they're already authenticated. For example, in a banking application, transferring money is considered a "sensitive action." Reverification can be used to confirm the user's identity.
 

--- a/docs/hooks/use-reverification.mdx
+++ b/docs/hooks/use-reverification.mdx
@@ -3,9 +3,7 @@ title: useReverification()
 description: Clerk's useReverification() hook enhances a fetcher function to handle a session's reverification flow.
 ---
 
-> [!WARNING]
->
-> Depending on the SDK you're using, this feature requires `@clerk/nextjs@6.12.7` or later, `@clerk/clerk-react@5.25.1` or later, and `@clerk/clerk-js@5.57.1` or later.
+<Include src="_partials/reverification-callout" />
 
 Reverification allows you to prompt a user to verify their credentials before performing sensitive actions, even if they're already authenticated. For example, in a banking application, transferring money is considered a "sensitive action." Reverification can be used to confirm the user's identity.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10503/guides/reverification
- https://clerk.com/docs/pr/ss-docs-10503/hooks/use-reverification

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-10503/missing-minimum-clerkclerk-react-version-requirement-for

This PR improves consistency in the reverification docs by adding missing requirement of `@clerk/clerk-react` version for the `useReverification()` hook and reverification process in general. 

### What changed?

- Turned the warning callout into a partial that can be used across reverification docs.
- Added the required `@clerk/clerk-react` version for the the `useReverification()` hook and reverification process in general. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
