### PR TITLE
Tailwind v4 - Clarify `@layer` css is in addition to `@import`

### DIFF
--- a/docs/_partials/nextjs/update-globals-css.mdx
+++ b/docs/_partials/nextjs/update-globals-css.mdx
@@ -1,4 +1,4 @@
-In the previous step, the `cssLayerName` property is set on the `<ClerkProvider>` component. Now, you need to add the following line to the top of your `globals.css` file in order to include the layer you named in the `cssLayerName` property. The example names the layer `clerk` but you can name it anything you want. These steps are necessary for v4 of Tailwind as it ensures that Tailwind's utility styles are applied after Clerk's styles.
+In the previous step, the `cssLayerName` property is set on the `<ClerkProvider>` component. Now, you need to **add the following line to the top of your `globals.css` file** in order to include the layer you named in the `cssLayerName` property. The example names the layer `clerk` but you can name it anything you want. These steps are necessary for v4 of Tailwind as it ensures that Tailwind's utility styles are applied after Clerk's styles.
 
 ```css {{ filename: 'globals.css' }}
 + @layer theme, base, clerk, components, utilities;


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/nick-tailwind-v4-clarify/quickstarts/nextjs

### What does this solve?

- While it does say in the text that this is in addition, I don't read I just look at code examples, it wasn't clear to me that the example code doesn't just replace the `@import 'tailwindcss';`

### What changed?

- Used the `+` to make it clear this is an addition not a replacement.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
