### PR TITLE
chore: Updates BAPI rate limits

### DIFF
--- a/docs/backend-requests/resources/rate-limits.mdx
+++ b/docs/backend-requests/resources/rate-limits.mdx
@@ -46,16 +46,16 @@ Frontend API requests are rate-limited per user and identified by their IP addre
 ## Backend API requests
 
 Backend API requests are rate-limited per application instance which is identified by the Secret Key that is provided when making Backend API requests.
+These limits differ based on whether you're using a development or production instance.
 
 <Properties>
-  - Create users
-  - `POST /v1/users`
+  - Production instances
 
-  20 requests per 10 seconds
+  1000 requests per 10 seconds
 
   ---
 
-  - All other endpoints
+  - Development instances
 
   100 requests per 10 seconds
 
@@ -68,4 +68,4 @@ Backend API requests are rate-limited per application instance which is identifi
 </Properties>
 
 > [!NOTE]
-> The `currentUser()` helper uses the `GET /v1/users/me` endpoint, so it is subject to the 100 requests per 10 seconds rate limit.
+> The `currentUser()` helper uses the `GET /v1/users/me` endpoint, so it is subject to the respective rate limits.


### PR DESCRIPTION
### 🔎 Previews:

https://clerk.com/docs/pr/bapi-rate-limits/backend-requests/resources/rate-limits#backend-api-requests

### What does this solve?

BAPI rate limits for production instances have always been on the conservative side, causing quite a few issues to our customers.

### What changed?

We recently bumped the BAPI rate limits.
These limits now depend on the type of instance we have.
* Development: 100req/10sec
* Production: 1000req/10sec

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
