### PR TITLE
chore: Reference the `verifyWebhook()` helper

### DIFF
--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -114,8 +114,8 @@ You can find a guide on how to use webhooks to sync your data to your database [
 
 ## Protect your webhooks from abuse
 
-To ensure that the API route receiving the webhook can only be hit by your app, there are a few protections you can put in place:
+To ensure that the API route receiving the webhook can only be hit by your app, there are a few protections you should put in place:
 
-- **Verify the request signature**: Svix webhook requests are [signed](https://www.wikiwand.com/en/Digital_signature) and can be verified to ensure the request is not malicious. To learn more, see Svix's guide on [how to verify webhooks with the svix libraries](https://docs.svix.com/receiving/verifying-payloads/how) or [how to verify webhooks manually](https://docs.svix.com/receiving/verifying-payloads/how-manual).
+- **Verify the request signature**: Svix webhook requests are [signed](https://www.wikiwand.com/en/Digital_signature) and can be verified to ensure the request is not malicious. To verify the signature, use Clerk's [`verifyWebhook`](https://clerk.com/docs/references/backend/verify-webhook) helper. To learn more, see Svix's guide on [how to verify webhooks with the svix libraries](https://docs.svix.com/receiving/verifying-payloads/how) or [how to verify webhooks manually](https://docs.svix.com/receiving/verifying-payloads/how-manual).
 
 - **Only accept requests coming from [Svix's webhook IPs](https://docs.svix.com/webhook-ips.json)**:  To further prevent attackers from flooding your servers or wasting your compute, you can ensure that your webhook-receiving api routes only accept requests coming from [Svix's webhook IPs](https://docs.svix.com/webhook-ips.json), rejecting all other requests.


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
- No reference to `verifyWebhook` on the webhook overview page

### What changed?

- <!--- How does this PR solve the problem? -->
- Adds reference to the helper

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
