### PR TITLE
Add option for local-clerk-typedoc folder to override typedoc folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn.lock
 /docs/docs
 /docs/docs/
 public/manifest.proposal.json
+/local-clerk-typedoc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 data/api_errors.json
 clerk-typedoc/
+local-clerk-typedoc/

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -114,6 +114,7 @@ async function main() {
     partialsPath: '../docs/_partials',
     distPath: '../dist',
     typedocPath: '../clerk-typedoc',
+    localTypedocOverridePath: '../local-clerk-typedoc',
     publicPath: '../public',
     redirects: {
       static: {

--- a/scripts/link-typedoc.ts
+++ b/scripts/link-typedoc.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import symlinkDir from 'symlink-dir'
 
-const TYPEDOC_DIR = './clerk-typedoc'
+const TYPEDOC_DIR = './local-clerk-typedoc'
 
 const main = async () => {
   const typedocFolderLocation = process.argv[2]


### PR DESCRIPTION
### What does this solve?

- The git status gets a bit unhappy when working on typedoc changes locally, as running `npm run typedoc:link` will override the known good copy of typedocs files.

### What changed?

- This links the local typedocs files from the javascript repo to `./local-clerk-typedoc` instead of `./clerk-typedoc`.
- The build script will look for the local version first, falling back to the standard version otherwise.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
