### PR TITLE
sdk scoping migration from manifest to frontmatter

### DIFF
--- a/docs/quickstarts/android.mdx
+++ b/docs/quickstarts/android.mdx
@@ -1,6 +1,7 @@
 ---
 title: Android Quickstart (beta)
 description: Add authentication and user management to your Android app with Clerk.
+sdk: android
 ---
 
 > [!WARNING]

--- a/docs/references/android/get-token.mdx
+++ b/docs/references/android/get-token.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`getToken()`'
 description: Use Clerk's Android SDK to retrieve a token for a JWT template that is defined in the Clerk Dashboard.
+sdk: android
 ---
 
 The `getToken()` method retrieves the user's [session token](/docs/backend-requests/resources/session-tokens) or a [custom JWT template](/docs/backend-requests/jwt-templates).

--- a/docs/references/android/overview.mdx
+++ b/docs/references/android/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Clerk Android SDK (beta)
 description: The Clerk Android SDK provides a set of tools and utilities for handling authentication and user management.
+sdk: android
 ---
 
 The Clerk Android SDK provides a set of tools and utilities for handling authentication and user management. Refer to the [quickstart guide](/docs/quickstarts/android) to get started.

--- a/docs/references/android/passkeys.mdx
+++ b/docs/references/android/passkeys.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure passkeys for Android
 description: Learn how to configure passkeys for your Android application.
+sdk: android
 ---
 
 [Passkeys](/docs/authentication/configuration/sign-up-sign-in-options#passkeys) are a secure, passwordless authentication method that use biometrics and a physical device to authenticate users. This guide shows you how to configure passkeys for your Android application.

--- a/docs/references/android/sign-in-with-google.mdx
+++ b/docs/references/android/sign-in-with-google.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sign in with Google
 description: Learn how to use Clerk to natively Sign in with Google.
+sdk: android
 ---
 
 <TutorialHero

--- a/docs/references/nextjs/shadcn.mdx
+++ b/docs/references/nextjs/shadcn.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Install Clerk with shadcn/ui CLI'
 description: Use the shadcn/ui CLI to bootstrap your Next.js app with Clerk.
+sdk: nextjs
 ---
 
 The [shadcn/ui CLI](https://ui.shadcn.com/docs/cli) is a tool that allows you to bootstrap your Next.js app with Clerk. Clerk's shadcn/ui registry enables developers to add pre-built components and configurations to their projects with a single command.

--- a/docs/references/nuxt/integration.mdx
+++ b/docs/references/nuxt/integration.mdx
@@ -1,6 +1,7 @@
 ---
 title: '`@clerk/nuxt` module'
 description: The `@clerk/nuxt` module provides session and user context to Clerk's composables and components.
+sdk: nuxt
 ---
 
 The `@clerk/nuxt` module is required to integrate Clerk into your Nuxt application, providing session and user context to Clerk's composables and components.


### PR DESCRIPTION
### 🔎 Previews:

https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/quickstarts/android
https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/references/android/get-token
https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/references/android/overview
https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/references/android/passkeys
https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/references/android/sign-in-with-google
https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/references/nextjs/shadcn
https://clerk.com/docs/pr/nick-add-sdk-scoping-from-manifest/references/nuxt/integration

### What does this solve?

- Some new docs that are sdk scoped in the manifest, haven't got the sdk scoping in the frontmatter.

### What changed?

- Ran `npm run migrate-sdk-scoping` to move the scoping over.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
