### PR TITLE
Clarify where verifyWebhook is imported from 

### DIFF
--- a/docs/references/backend/verify-webhook.mdx
+++ b/docs/references/backend/verify-webhook.mdx
@@ -40,6 +40,8 @@ function verifyWebhook(request: Request, options?: VerifyWebhookOptions): Promis
 See the [guide on syncing data](/docs/webhooks/sync-data) for more comprehensive and framework-specific examples that you can copy and paste into your app.
 
 ```ts
+import { verifyWebhook } from '@clerk/backend/webhooks'
+
 try {
   const evt = await verifyWebhook(request)
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10696/references/backend/verify-webhook

### What does this solve?

Users reported confusion about how to access `verifyWebhook`. The code snippet doesn't have a clear import at the top to show where `verifyWebhook` is coming from.

### What changed?

This PR adds the import within the code snippet from `@clerk/backend`, given the framework specific examples are mentioned right above the code snippet. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
