### PR TITLE
Add note on Apple Sign In email issues depending on user base locale

### DIFF
--- a/docs/authentication/social-connections/apple.mdx
+++ b/docs/authentication/social-connections/apple.mdx
@@ -99,7 +99,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
   ### Configure Email Source for Apple Private Relay
 
   > [!NOTE]
-  > In some regions (such as China and India), Apple IDs may not include an email address at all, and instead are tied only to a phone number. If your instance requires all users to have an email, Sign in with Apple may fail for these users. Depending on your user base, you may want to navigate to the [**User & authentication**](https://dashboard.clerk.com/last-active?path=user-authentication/user-and-authentication) page in the Clerk Dashboard and disable the **Require email during sign-up** setting.
+  > In some regions (such as China and India), Apple IDs may not include an email address at all, and instead are tied only to a phone number. If your instance requires all users to have an email, Sign in with Apple may fail for these users. Depending on your user base, you may want to navigate to the [**User & authentication**](https://dashboard.clerk.com/last-active?path=user-authentication/user-and-authentication) page in the Clerk Dashboard and disable the **Sign-up with email** setting.
   >
   > If you'd like to know more about this, see the [Apple documentation](https://support.apple.com/en-au/105034).
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-10642/authentication/social-connections/apple

### What does this solve?

Developers using Sign in with Apple may encounter issues for users in regions such as China and India, where Apple IDs can be tied only to a phone number with no email address. If Clerk instances enforce the requirement for an email during sign-up, these users will be unable to sign in with Apple. 

This update clarifies the limitation and provides guidance on how to configure instance settings depending on the developer’s user base.

### What changed?

Added a note to the Sign in with Apple docs warning developers that some Apple IDs may not include an email address + added note on how to disable this requirement in the Clerk Dashboard when supporting user bases from affected regions.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
