### PR TITLE
(session-tasks) use isAuthenticated for auth checks

### DIFF
--- a/docs/authentication/configuration/session-tasks.mdx
+++ b/docs/authentication/configuration/session-tasks.mdx
@@ -153,7 +153,7 @@ export const config = {
 }
 ```
 
-For `auth().userId`, it would return `null` if the user has a `pending` session. Pending users will be redirected to the sign-in page, where the `<SignIn />` component will prompt them to fulfill the session tasks. Once finished, their session will move from `pending` to a `signed-in` state.
+For `auth().isAuthenticated`, it would return `false` if the user has a `pending` session. Pending users will be redirected to the sign-in page, where the `<SignIn />` component will prompt them to fulfill the session tasks. Once finished, their session will move from `pending` to a `signed-in` state.
 
 ```tsx {{ filename: 'app/middleware.ts', mark: [[6, 12]] }}
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
@@ -161,11 +161,11 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
 
 export default clerkMiddleware(async (auth, req) => {
-  const { userId, redirectToSignIn } = await auth()
+  const { isAuthenticated, redirectToSignIn } = await auth()
 
-  // pending users will not have a `userId`
-  // and will be redirected to the sign-in page
-  if (!userId && isProtectedRoute(req)) {
+  // `isAuthenticated` will be `false` for pending users
+  // and they will be redirected to the sign-in page
+  if (!isAuthenticated && isProtectedRoute(req)) {
     return redirectToSignIn()
   }
 })
@@ -310,7 +310,7 @@ export default function Dashboard() {
 ```
 
 <If sdk="nextjs">
-  For `auth().userId`, `isAuthenticated` would return `false` and `userId` and `orgId` would return `null` if the user has a `pending` session.
+  For `auth()`, `isAuthenticated` would return `false` and `userId` and `orgId` would return `null` if the user has a `pending` session.
 
   ```tsx {{ filename: 'app/page.tsx' }}
   import { auth } from '@clerk/nextjs/server'


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/aa-fix-session-tasks

we want to recommend the practice of using `isSignedIn` and `isAuthenticated` for authentication checks.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
