### PR TITLE
Add Remix SDK maintenance mode callout

### DIFF
--- a/docs/_partials/remix/maintenance-mode.mdx
+++ b/docs/_partials/remix/maintenance-mode.mdx
@@ -1,0 +1,2 @@
+> [!WARNING]
+> The Remix SDK is in maintenance mode and will only receive security updates. Please migrate to the [React Router SDK](/docs/quickstarts/react-router) for continued development and new features.

--- a/docs/quickstarts/remix.mdx
+++ b/docs/quickstarts/remix.mdx
@@ -4,8 +4,7 @@ description: Learn how to use Clerk to quickly and easily add secure authenticat
 sdk: remix
 ---
 
-> [!WARNING]
-> The Remix SDK is in maintenance mode and will only receive security updates. Please migrate to the [React Router SDK](/docs/quickstarts/react-router) for continued development and new features.
+<Include src="_partials/remix/maintenance-mode" />
 
 <TutorialHero
   exampleRepo={[

--- a/docs/references/remix/clerk-app.mdx
+++ b/docs/references/remix/clerk-app.mdx
@@ -4,6 +4,8 @@ description: Clerk provides a ClerkApp wrapper to provide the authentication sta
 sdk: remix
 ---
 
+<Include src="_partials/remix/maintenance-mode" />
+
 Clerk provides a `ClerkApp` wrapper to provide the authentication state to your React tree. This helper works with Remix SSR out-of-the-box and follows the "higher-order component" paradigm.
 
 ## Usage

--- a/docs/references/remix/custom-sign-in-or-up-page.mdx
+++ b/docs/references/remix/custom-sign-in-or-up-page.mdx
@@ -4,6 +4,8 @@ description: Learn how to add a custom sign-in-or-up page to your Remix app with
 sdk: remix
 ---
 
+<Include src="_partials/remix/maintenance-mode" />
+
 This guide shows you how to use the [`<SignIn />`](/docs/components/authentication/sign-in) component to build a custom page **that allows users to sign in or sign up within a single flow**.
 
 To set up separate sign-in and sign-up pages, follow this guide, and then follow the [custom sign-up page guide](/docs/references/remix/custom-sign-up-page).

--- a/docs/references/remix/custom-sign-up-page.mdx
+++ b/docs/references/remix/custom-sign-up-page.mdx
@@ -4,6 +4,8 @@ description: Learn how to add a custom sign-up page to your Remix app with Clerk
 sdk: remix
 ---
 
+<Include src="_partials/remix/maintenance-mode" />
+
 By default, the [`<SignIn />`](/docs/references/remix/custom-sign-in-or-up-page) component handles signing in and signing up, but if you'd like to have a dedicated sign-up page, this guide shows you how to use the [`<SignUp />`](/docs/components/authentication/sign-up) component to build a custom sign-up page.
 
 To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page guide](/docs/references/remix/custom-sign-in-or-up-page).

--- a/docs/references/remix/overview.mdx
+++ b/docs/references/remix/overview.mdx
@@ -4,6 +4,8 @@ description: The Clerk Remix SDK gives you access to prebuilt components, React 
 sdk: remix
 ---
 
+<Include src="_partials/remix/maintenance-mode" />
+
 The Clerk Remix SDK gives you access to prebuilt components, React hooks, and helpers to make user authentication easier. Refer to the [quickstart guide](/docs/quickstarts/remix) to get started.
 
 ## `ClerkApp`

--- a/docs/references/remix/read-session-data.mdx
+++ b/docs/references/remix/read-session-data.mdx
@@ -4,6 +4,8 @@ description: Learn how to use Clerk's hooks and helpers to access the active ses
 sdk: remix
 ---
 
+<Include src="_partials/remix/maintenance-mode" />
+
 Clerk provides a set of [hooks and helpers](/docs/references/remix/overview) that you can use to access the active session and user data in your Remix application. Here are examples of how to use these helpers in both the client and server-side to get you started.
 
 ## Server-side

--- a/docs/references/remix/root-auth-loader.mdx
+++ b/docs/references/remix/root-auth-loader.mdx
@@ -4,6 +4,8 @@ description: The `rootAuthLoader` function is a helper function that provides th
 sdk: remix
 ---
 
+<Include src="_partials/remix/maintenance-mode" />
+
 The `rootAuthLoader()` function is a helper function that provides the authentication state to your Remix application.
 
 ## Usage

--- a/docs/references/remix/spa-mode.mdx
+++ b/docs/references/remix/spa-mode.mdx
@@ -14,6 +14,8 @@ sdk: remix
   ]}
 />
 
+<Include src="_partials/remix/maintenance-mode" />
+
 This guide explains how to use Clerk with [Remix in SPA mode](https://remix.run/docs/en/main/guides/spa-mode). To use Clerk with Remix in SSR mode, follow the [Remix quickstart](/docs/quickstarts/remix).
 
 <Steps>


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/rob-remix-maintenance-mode/quickstarts/remix

### What does this solve?

- Companion PR to https://github.com/clerk/javascript/pull/6744, which puts the Remix SDK in maintenance mode.

### What changed?

- Added a callout to the quickstart page that the Remix SDK is in maintenance mode and will only receive security updates.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
