### PR TITLE
Docs build script - dist folder improvements

### DIFF
--- a/scripts/lib/dev.ts
+++ b/scripts/lib/dev.ts
@@ -7,6 +7,7 @@ import type { build } from '../build-docs'
 import type { BuildConfig } from './config'
 import { invalidateFile, type Store } from './store'
 import chokidar from 'chokidar'
+import fs from 'node:fs/promises'
 
 export const watchAndRebuild = (store: Store, config: BuildConfig, buildFunc: typeof build) => {
   const invalidate = invalidateFile(store, config)
@@ -40,6 +41,8 @@ export const watchAndRebuild = (store: Store, config: BuildConfig, buildFunc: ty
     }
   }
 
+  let lastTempDistPath: string = config.distTempPath
+
   const handleFilesChanged = async (paths: string[]) => {
     if (abortController !== null) {
       console.log('aborting current build')
@@ -60,6 +63,9 @@ export const watchAndRebuild = (store: Store, config: BuildConfig, buildFunc: ty
 
       const output = await buildFunc(newConfig, store, abortController.signal)
 
+      await fs.rm(lastTempDistPath, { recursive: true }) // clean up the old temp dist folder
+
+      lastTempDistPath = newConfig.distTempPath
       abortController = null
 
       if (config.flags.controlled) {


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

- Was getting flaky errors when updating files in the docs

### What changed?

- During dev mode, symblink the temp dist folder to the `./dist` folder
- Add clean up in dev mode to delete older temp dist folders
- Add retries when deleting folders to reduce chance of flaky issues

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
