### PR TITLE
fix: Update `@latest` to `@5`

### DIFF
--- a/docs/quickstarts/javascript.mdx
+++ b/docs/quickstarts/javascript.mdx
@@ -275,7 +275,7 @@ Use the following tabs to choose your preferred method.
         async
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
-        src="https://{{fapi_url}}/npm/@clerk/clerk-js@latest/dist/clerk.browser.js"
+        src="https://{{fapi_url}}/npm/@clerk/clerk-js@5/dist/clerk.browser.js"
         type="text/javascript"
       ></script>
 


### PR DESCRIPTION
### 🔎 Previews:

### What does this solve?

It was reported in the JS repo that `@latest` was resolving to v4. This, however, is correct.

It appears that one of the two instances on this page didn't get updated to `@5` from `@latest`.

### What changed?

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
