### PR TITLE
fold non-essential lines in nextjs quickstart codeblock

### DIFF
--- a/docs/quickstarts/nextjs.mdx
+++ b/docs/quickstarts/nextjs.mdx
@@ -84,7 +84,7 @@ sdk: nextjs
   1. Add the [`<ClerkProvider>`](/docs/components/clerk-provider) component to your app's layout. This component provides Clerk's authentication context to your app.
   1. Copy and paste the following file into your `layout.tsx` file. This creates a header with Clerk's [prebuilt components](/docs/components/overview) to allow users to sign in and out.
 
-  ```tsx {{ filename: 'app/layout.tsx', mark: [[2, 9], 34, [37, 45], 49] }}
+  ```tsx {{ filename: 'app/layout.tsx', mark: [[2, 9], 34, [37, 45], 49], fold: [[12, 27]] }}
   import type { Metadata } from 'next'
   import {
     ClerkProvider,


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/alexcarpenter-nextjs-quickstart-fold-lines/quickstarts/nextjs

### What does this solve?

- Folds non-essential code in the nextjs quickstart to reduce the overall height of the ClerkProvider codeblock.

### What changed?

| BEFORE | AFTER |
|--------|--------|
| <img width="2784" height="3054" alt="Screenshot 2025-09-23 at 10 21 03 AM" src="https://github.com/user-attachments/assets/2dc2ee7b-9119-4200-b4e5-b6fcab3522c7" /> | <img width="2784" height="3054" alt="Screenshot 2025-09-23 at 10 21 35 AM" src="https://github.com/user-attachments/assets/eb418bce-84ee-41d4-8264-2975034f98ce" /> | 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
