### PR TITLE
feat: Add note about public .well-known endpoints

### DIFF
--- a/docs/mcp/build-mcp-server.mdx
+++ b/docs/mcp/build-mcp-server.mdx
@@ -286,52 +286,49 @@ sdk: nextjs, expressjs
     1. Inside the `oauth-protected-resource` directory, create a `mcp` subdirectory.
     1. In the `mcp` subdirectory, create a `route.ts` file with the following code for that specific route.
     1. In the `oauth-authorization-server` directory, create a `route.ts` file with the following code for that specific route.
-    1. **Important**: Ensure that your `.well-known` endpoints are not protected by Clerk middleware. These endpoints must be publicly accessible for MCP clients to discover OAuth metadata. If you're using `clerkMiddleware()` globally, you'll need to exclude these paths.
 
-    If you have a global `middleware.ts` file, make sure to exclude the `.well-known` paths using `createRouteMatcher()`:
+       <CodeBlockTabs options={["oauth-authorization-server", "oauth-protected-resource"]}>
+         ```ts {{ filename: 'app/.well-known/oauth-authorization-server/route.ts' }}
+         import {
+           authServerMetadataHandlerClerk,
+           metadataCorsOptionsRequestHandler,
+         } from '@clerk/mcp-tools/next'
 
-    ```ts {{ filename: 'middleware.ts' }}
-    import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+         const handler = authServerMetadataHandlerClerk()
+         const corsHandler = metadataCorsOptionsRequestHandler()
 
-    const isPublicRoute = createRouteMatcher([
-      '/.well-known/oauth-authorization-server(.*)',
-      '/.well-known/oauth-protected-resource(.*)',
-    ])
+         export { handler as GET, corsHandler as OPTIONS }
+         ```
 
-    export default clerkMiddleware(async (auth, req) => {
-      if (isPublicRoute(req)) return // Allow public access to .well-known endpoints
-      await auth.protect() // Protect all other routes
-    })
-    ```
+         ```ts {{ filename: 'app/.well-known/oauth-protected-resource/mcp/route.ts' }}
+         import {
+           metadataCorsOptionsRequestHandler,
+           protectedResourceHandlerClerk,
+         } from '@clerk/mcp-tools/next'
 
-    <CodeBlockTabs options={["oauth-authorization-server", "oauth-protected-resource"]}>
-      ```ts {{ filename: 'app/.well-known/oauth-authorization-server/route.ts' }}
-      import {
-        authServerMetadataHandlerClerk,
-        metadataCorsOptionsRequestHandler,
-      } from '@clerk/mcp-tools/next'
+         const handler = protectedResourceHandlerClerk({
+           // Specify which OAuth scopes this protected resource supports
+           scopes_supported: ['profile', 'email'],
+         })
+         const corsHandler = metadataCorsOptionsRequestHandler()
 
-      const handler = authServerMetadataHandlerClerk()
-      const corsHandler = metadataCorsOptionsRequestHandler()
+         export { handler as GET, corsHandler as OPTIONS }
+         ```
+       </CodeBlockTabs>
+    1. Your `.well-known` endpoints must be **publicly accessible** for MCP clients to discover OAuth metadata. When protecting routes, consider these paths and ensure they are not protected. For example, if you're using [`clerkMiddleware()` to protect all routes](/docs/references/nextjs/clerk-middleware#protect-all-routes), you can exclude the `.well-known` endpoints like this:
+       ```ts {{ filename: 'middleware.ts' }}
+       import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-      export { handler as GET, corsHandler as OPTIONS }
-      ```
+       const isPublicRoute = createRouteMatcher([
+         '/.well-known/oauth-authorization-server(.*)',
+         '/.well-known/oauth-protected-resource(.*)',
+       ])
 
-      ```ts {{ filename: 'app/.well-known/oauth-protected-resource/mcp/route.ts' }}
-      import {
-        metadataCorsOptionsRequestHandler,
-        protectedResourceHandlerClerk,
-      } from '@clerk/mcp-tools/next'
-
-      const handler = protectedResourceHandlerClerk({
-        // Specify which OAuth scopes this protected resource supports
-        scopes_supported: ['profile', 'email'],
-      })
-      const corsHandler = metadataCorsOptionsRequestHandler()
-
-      export { handler as GET, corsHandler as OPTIONS }
-      ```
-    </CodeBlockTabs>
+       export default clerkMiddleware(async (auth, req) => {
+         if (isPublicRoute(req)) return // Allow public access to .well-known endpoints
+         await auth.protect() // Protect all other routes
+       })
+       ```
   </If>
 
   <If sdk="expressjs">
@@ -349,8 +346,6 @@ sdk: nextjs, expressjs
     > [!NOTE]
     > For a more in-depth explanation of these helpers, see the [MCP Express reference](https://github.com/clerk/mcp-tools/tree/main/express).
 
-    **Important**: Ensure that your `.well-known` endpoints are not protected by Clerk middleware. These endpoints must be publicly accessible for MCP clients to discover OAuth metadata.
-
     To secure your endpoints and expose your MCP server to a client, add the following code to your file:
 
     ```ts {{ filename: 'index.ts', mark: [[3, 4]] }}
@@ -367,6 +362,9 @@ sdk: nextjs, expressjs
 
     app.listen(3000)
     ```
+
+    > [!WARNING]
+    > Your `.well-known` endpoints must be **publicly accessible** for MCP clients to discover OAuth metadata. When protecting routes, consider these paths and ensure they are not protected.
   </If>
 
   ## Finished 🎉


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/feat-mcp-protected-well-known/nextjs/mcp/build-mcp-server#expose-mcp-metadata-endpoints

### What does this solve?

When setting up an MCP server in a clerk app, it was not clear that the `.well-known` endpoints need to be public. This leads to difficult to debug issues when connecting to the server through tools like Cursor or Warp

### What changed?

Adding a note about ensuring the `.well-known` endpoints are publicly available

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
