### PR TITLE
Add section on handling missing requirements during custom SSO sign-up

### DIFF
--- a/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
@@ -39,7 +39,7 @@ You must configure your application instance through the Clerk Dashboard for the
             .authenticateWithRedirect({
               strategy,
               redirectUrl: '/sign-in/sso-callback',
-              redirectUrlComplete: '/',
+              redirectUrlComplete: '/sign-in/tasks', // Learn more about session tasks at https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
             })
             .then((res) => {
               console.log(res)
@@ -68,7 +68,6 @@ You must configure your application instance through the Clerk Dashboard for the
       export default function Page() {
         // Handle the redirect flow by calling the Clerk.handleRedirectCallback() method
         // or rendering the prebuilt <AuthenticateWithRedirectCallback/> component.
-        // This is the final step in the custom OAuth flow.
         return
         ;<>
           <AuthenticateWithRedirectCallback />
@@ -99,10 +98,10 @@ You must configure your application instance through the Clerk Dashboard for the
     import { useSSO } from '@clerk/clerk-expo'
     import { View, Button, Platform } from 'react-native'
 
+    // Preloads the browser for Android devices to reduce authentication load time
+    // See: https://docs.expo.dev/guides/authentication/#improving-user-experience
     export const useWarmUpBrowser = () => {
       useEffect(() => {
-        // Preloads the browser for Android devices to reduce authentication load time
-        // See: https://docs.expo.dev/guides/authentication/#improving-user-experience
         if (Platform.OS !== 'android') return
         void WebBrowser.warmUpAsync()
         return () => {
@@ -136,11 +135,12 @@ You must configure your application instance through the Clerk Dashboard for the
           if (createdSessionId) {
             setActive!({
               session: createdSessionId,
+              // Check for session tasks and navigate to custom UI to help users resolve them
+              // See https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
               navigate: async ({ session }) => {
                 if (session?.currentTask) {
-                  // Check for tasks and navigate to custom UI to help users resolve them
-                  // See https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
                   console.log(session?.currentTask)
+                  router.push('/sign-in/tasks')
                   return
                 }
 
@@ -150,8 +150,7 @@ You must configure your application instance through the Clerk Dashboard for the
           } else {
             // If there is no `createdSessionId`,
             // there are missing requirements, such as MFA
-            // Use the `signIn` or `signUp` returned from `startSSOFlow`
-            // to handle next steps
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/oauth-connections#handle-missing-requirements
           }
         } catch (err) {
           // See https://clerk.com/docs/guides/development/custom-flows/error-handling
@@ -360,14 +359,20 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
 
       import { useState } from 'react'
       import { useSignUp } from '@clerk/nextjs'
+      import { useRouter } from 'next/navigation'
 
       export default function Page() {
+        const router = useRouter()
         // Use `useSignUp()` hook to access the `SignUp` object
         // `missing_requirements` and `missingFields` are only available on the `SignUp` object
         const { isLoaded, signUp, setActive } = useSignUp()
         const [formData, setFormData] = useState<Record<string, string>>({})
 
         if (!isLoaded) return <div>Loading…</div>
+
+        // Protect the page from users who are not in the sign-up flow
+        // such as users who visited this route directly
+        if (!signUp.id) router.push('/sign-in')
 
         const status = signUp?.status
         const missingFields = signUp?.missingFields ?? []
@@ -384,8 +389,20 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
             // E.g. if your app requires a phone number, you will need to collect and verify it here
             const res = await signUp?.update(formData)
             if (res?.status === 'complete') {
-              await setActive({ session: res.createdSessionId })
-              window.location.href = '/'
+              await setActive({
+                session: res.createdSessionId,
+                navigate: async ({ session }) => {
+                  if (session?.currentTask) {
+                    // Check for tasks and navigate to custom UI to help users resolve them
+                    // See https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
+                    console.log(session?.currentTask)
+                    router.push('/sign-in/tasks')
+                    return
+                  }
+
+                  router.push('/')
+                },
+              })
             }
           } catch (err) {
             // See https://clerk.com/docs/guides/development/custom-flows/error-handling
@@ -428,7 +445,13 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
         }
 
         // Handle other statuses if needed
-        return null
+        return (
+          <>
+            {/* Required for sign-up flows
+            Clerk's bot sign-up protection is enabled by default */}
+            <div id="clerk-captcha" />
+          </>
+        )
       }
       ```
 

--- a/docs/guides/development/custom-flows/overview.mdx
+++ b/docs/guides/development/custom-flows/overview.mdx
@@ -92,7 +92,7 @@ The following steps outline the sign-in process:
 
 Session tasks require users to complete specific actions after authentication, such as selecting an organization. These tasks ensure that users meet all requirements before gaining full access to your application.
 
-For detailed information about configuring and implementing session tasks, see the [session tasks overview](/docs/guides/configure/session-tasks).
+For detailed information about configuring and implementing session tasks, see the [dedicated guide](/docs/guides/configure/session-tasks).
 
 #### Steps to handle session tasks
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Linear ticket: https://linear.app/clerk/issue/SUP-496/custom-flow-guide-how-to-handle-missing-requirements

### What changed?

- Added a new "Handle missing requirements during sign-up" section to the custom OAuth flow guide. An alternative would be to scope it under "Next.js" tab in "Create the sign-up and sign-in flow", but I assume that missing requirements are quite generic, and people using other frameworks could use it as a base, too. Also, I think, eventually, we'll add other tabs as well ("Expo", "iOS", "Android"). 
- Included a Next.js example of a continue page and updated SSO callback with `continueSignUpUrl`.
- Added notes on why this only applies to SignUp, and comments in code on handling different field types.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
