### PR TITLE
POST IA: Fix redirect old custom-signup-signin-pages paths 

### DIFF
--- a/redirects/dynamic/docs.jsonc
+++ b/redirects/dynamic/docs.jsonc
@@ -50,6 +50,11 @@
     "permanent": true,
   },
   {
+    "source": "/docs/references/:path/custom-signup-signin-pages",
+    "destination": "/docs/guides/development/custom-sign-in-or-up-page",
+    "permanent": true,
+  },
+  {
     "source": "/docs/references/:path*",
     "destination": "/docs/reference/:path*",
     "permanent": true,
@@ -59,9 +64,4 @@
     "destination": "/docs/:sdk/reference/:path*",
     "permanent": true,
   },
-  {
-    "source": "/docs/reference/:path/custom-signup-signin-pages",
-    "destination": "/docs/guides/development/custom-sign-in-or-up-page",
-    "permanent": true,
-  }
 ]


### PR DESCRIPTION
### 🔎 Previews:

### What does this solve?

Context: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1759170151192319?thread_ts=1758895167.659069&cid=C01QFRQNHSN. 

This [PR](https://github.com/clerk/clerk-docs/pull/2637/) removed a key dynamic redirect for the old custom-signup-signin-pages paths. 

<img width="458" height="161" alt="Screenshot 2025-09-29 at 12 56 34 pm" src="https://github.com/user-attachments/assets/565362b2-c40d-4fc8-9310-91ba42f7095c" />

This is causing links which are present in the Dashboard to fail and be 404s. For example:

<img width="692" height="549" alt="Screenshot 2025-09-29 at 12 50 50 pm" src="https://github.com/user-attachments/assets/17500721-1b22-492e-b6bd-24a45bfa18a3" />

### What changed?

- Re-added the removed dynamic redirect - to avoid redirect chains, I placed the redirect rule above this rule:

```
{
    "source": "/docs/references/:path*",
    "destination": "/docs/reference/:path*",
    "permanent": true,
 },
```

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
