### PR TITLE
Strip out sdk scoping for sdk-development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1054,7 +1054,6 @@ Available values for the `sdk` prop:
 | Ruby / Rails / Sinatra | "ruby"                 |
 | Python                 | "python"               |
 | JS Backend SDK         | "js-backend"           |
-| SDK Development        | "sdk-development"      |
 | Community SDKs         | "community-sdk"        |
 
 To update the value, or `key`, for an SDK, see the [section on updating the key of an SDK](#update-the-key-of-an-sdk).

--- a/docs/guides/development/sdk-development/backend-only.mdx
+++ b/docs/guides/development/sdk-development/backend-only.mdx
@@ -1,7 +1,6 @@
 ---
 title: Backend-only SDK
 description: A reference for implementing a backend-only Clerk SDK
-sdk: sdk-development
 ---
 
 When creating a backend-only SDK, you have two options for implementing the [BAPI](/docs/guides/development/sdk-development/terminology) endpoints: either [develop a backend SDK that encompasses all BAPI endpoints](#implementation-bapi) or [create an SDK tailored for an existing backend framework](#implementation-node-js-backend-framework).

--- a/docs/guides/development/sdk-development/conventions.mdx
+++ b/docs/guides/development/sdk-development/conventions.mdx
@@ -1,7 +1,6 @@
 ---
 title: Conventions
 description: A set of agreed standards for building Clerk SDKs.
-sdk: sdk-development
 ---
 
 Ideally, when a user switches from one Clerk SDK to another, the general concepts, feature set, names, and exports should be consistent. By following certain conventions, you can develop an SDK that achieves this ideal state, making it easier for users to quickly start a new project.

--- a/docs/guides/development/sdk-development/frontend-only.mdx
+++ b/docs/guides/development/sdk-development/frontend-only.mdx
@@ -1,7 +1,6 @@
 ---
 title: Frontend-only SDK
 description: A reference for implementing a frontend-only Clerk SDK
-sdk: sdk-development
 ---
 
 While [ClerkJS](/docs/reference/javascript/overview) can be used in any browser context and framework, realistically users expect to consume its features through the conventions and syntax of their framework of choice. For example, `@clerk/clerk-react` turns ClerkJS into React components, `@clerk/astro` into Astro components, and so on.

--- a/docs/guides/development/sdk-development/fullstack.mdx
+++ b/docs/guides/development/sdk-development/fullstack.mdx
@@ -1,7 +1,6 @@
 ---
 title: Fullstack SDK
 description: A reference for implementing a fullstack Clerk SDK
-sdk: sdk-development
 ---
 
 A fullstack SDK combines the [frontend-only SDK](/docs/guides/development/sdk-development/frontend-only) and [backend-only SDK](/docs/guides/development/sdk-development/backend-only) into one. A fullstack SDK is necessary for frameworks that support multiple rendering strategies (SSR, SSG, etc.), middleware, data fetching, and more. Examples of such frameworks would be Next.js or Rails.

--- a/docs/guides/development/sdk-development/overview.mdx
+++ b/docs/guides/development/sdk-development/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: SDK development
 description: A reference for implementing a new Clerk SDK from scratch.
-sdk: sdk-development
 ---
 
 Clerk believes that truly optimal developer experience can only be achieved by building SDKs independently for each framework. Each framework differentiates itself with nuanced patterns, and it's important to lean into those patterns to avoid feeling like a square peg in a round hole.

--- a/docs/guides/development/sdk-development/philosophy.mdx
+++ b/docs/guides/development/sdk-development/philosophy.mdx
@@ -1,7 +1,6 @@
 ---
 title: Philosophy
 description: The guiding principle for building a Clerk SDK.
-sdk: sdk-development
 ---
 
 Clerk believes that truly optimal developer experience can only be achieved by building SDKs independently for each framework. Each framework has nuanced patterns that should be embraced to avoid mismatched implementations.

--- a/docs/guides/development/sdk-development/terminology.mdx
+++ b/docs/guides/development/sdk-development/terminology.mdx
@@ -1,7 +1,6 @@
 ---
 title: Terminology
 description: A list of common terms and their explanations used inside Clerk's SDKs.
-sdk: sdk-development
 ---
 
 A consistent terminology should be used across all user interactions with Clerk's services (e.g., SDKs, documentation, dashboard, error messages, support). The following list includes the most common terms and their explanations. Use these terms in your SDKs, documentation, and support materials.

--- a/docs/guides/development/sdk-development/types.mdx
+++ b/docs/guides/development/sdk-development/types.mdx
@@ -1,7 +1,6 @@
 ---
 title: SDK types
 description: "Learn about the three different types of SDKs: frontend-only, backend-only, and fullstack."
-sdk: sdk-development
 ---
 
 Clerk categorizes its SDKs into three different types:

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -183,8 +183,7 @@
         "nuxt",
         "vue",
         "ruby",
-        "js-backend",
-        "sdk-development"
+        "js-backend"
       ]
     }
   }

--- a/scripts/lib/schemas.ts
+++ b/scripts/lib/schemas.ts
@@ -22,7 +22,6 @@ export const VALID_SDKS = [
   'vue',
   'ruby',
   'js-backend',
-  'sdk-development',
 ] as const
 
 export type SDK = (typeof VALID_SDKS)[number]

--- a/scripts/migrate-sdk-scoping.ts
+++ b/scripts/migrate-sdk-scoping.ts
@@ -20,7 +20,6 @@ type SDK =
   | 'vue'
   | 'ruby'
   | 'js-backend'
-  | 'sdk-development'
 
 interface ManifestItem {
   title: string


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/nick-remove-sdk-development/guides/development/sdk-development/overview

### What does this solve?

- We are deprecating the SDK Development option from the sdk selector

### What changed?

- Removes all uses of `sdk-development`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
