### PR TITLE
Add manifest option "shortcut"

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -98,7 +98,8 @@
                 [
                   {
                     "title": "View all guides",
-                    "href": "#nav_guides"
+                    "href": "/docs/guides/overview",
+                    "shortcut": true
                   }
                 ]
               ]

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -783,6 +783,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
               target: item.target,
               // @ts-expect-error - It exists, up on line 481
               sdk: item.itemSDK ?? sdks,
+              shortcut: item.shortcut,
             }
           }
 
@@ -795,6 +796,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
             icon: item.icon,
             target: item.target,
             sdk: item.sdk,
+            shortcut: item.shortcut,
           }
         },
         // @ts-expect-error - This traverseTree function might just be the death of me

--- a/scripts/lib/manifest.ts
+++ b/scripts/lib/manifest.ts
@@ -44,6 +44,7 @@ export type ManifestItem = {
   icon?: Icon
   target?: '_blank'
   sdk?: SDK[]
+  shortcut?: boolean
 }
 
 export type ManifestGroup = {
@@ -71,6 +72,7 @@ const createManifestSchema = (config: BuildConfig) => {
       icon: icon.optional(),
       target: z.enum(['_blank']).optional(),
       sdk: z.array(sdk).optional(),
+      shortcut: z.boolean().optional(),
     })
     .strict()
 


### PR DESCRIPTION
Sibling pr https://github.com/clerk/clerk/pull/1659

Preview
https://clerk.com/docs/pr/nick-add-shortcut-manifest-option

### What does this solve?

- The "View all Guides" button added in the ia project has a bug that you can't click back on to "Getting Started" after clicking "View all Guides".

### What changed?

- Adds an option to manifest items `"shortcut"` that when set to true tells the site to skip over this item when finding which section of the navigation the sidebar should be filtered to.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
