### PR TITLE
Remove redirect for /docs/quickstart

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -3540,11 +3540,6 @@
     "permanent": true
   },
   {
-    "source": "/docs/quickstart",
-    "destination": "/docs/getting-started/quickstart",
-    "permanent": true
-  },
-  {
     "source": "/docs/quickstarts/nextjs",
     "destination": "/docs/nextjs/getting-started/quickstart",
     "permanent": true


### PR DESCRIPTION
### What does this solve?

- A redirect with this source shouldn't exist as a route handler at /docs/quickstart already exists

### What changed?

- Removed the redirect

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
