### PR TITLE
Fix broken link in machines guide

### DIFF
--- a/docs/guides/development/machine-auth/m2m-tokens.mdx
+++ b/docs/guides/development/machine-auth/m2m-tokens.mdx
@@ -32,7 +32,7 @@ There will also be a feature that allows the use of [JSON Web Tokens (JWTs)](htt
 
 ## Creating machines
 
-Clerk's M2M feature is designed to secure and facilitate communication between different machines within your backend infrastructure. To get started, head to the [**Machines**](https://dashboard.clerk.com/last-active?path=machines) page in the Clerk Dashboard, where you can create machines and configure their allowed communication partners.
+Clerk's M2M feature is designed to secure and facilitate communication between different machines within your backend infrastructure. To get started, head to the [**Machines**](https://dashboard.clerk.com/last-active?path=/machines/configure) page in the Clerk Dashboard, where you can create machines and configure their allowed communication partners.
 
 This example creates two machines, `Machine A` and `Machine B`, and configures them to allow communication with each other.
 


### PR DESCRIPTION
### 🔎 Previews:

https://clerk.com/docs/pr/fix-broken-machines-link/guides/development/machine-auth/m2m-tokens

### What does this solve?

We adjusted the link from just `/machines` -> `/machines/configure`.  Currently this link 404's.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
