### PR TITLE
Fixes broken TanStack links

### DIFF
--- a/docs/getting-started/quickstart.tanstack-react-start.mdx
+++ b/docs/getting-started/quickstart.tanstack-react-start.mdx
@@ -175,10 +175,10 @@ sdk: tanstack-react-start
 
   ### Server-side
 
-  To protect your routes, create a [server function](https://tanstack.com/router/latest/docs/framework/react/start/server-functions) that checks the user's authentication state via the [`getAuth()`](/docs/reference/tanstack-react-start/get-auth) method. If the user is not authenticated, they are redirected to a sign-in page. If authenticated, the user's `userId` is passed to the route, allowing access to the `<Home />` component, which welcomes the user and displays their `userId`. The [`beforeLoad()`](https://tanstack.com/router/latest/docs/framework/react/api/router/RouteOptionsType#beforeload-method) method ensures authentication is checked before loading the page, and the [`loader()`](https://tanstack.com/router/latest/docs/framework/react/api/router/RouteOptionsType#loader-method) method returns the user data for use in the component.
+  To protect your routes, create a [server function](https://tanstack.com/start/latest/docs/framework/react/guide/server-functions) that checks the user's authentication state via the [`getAuth()`](/docs/reference/tanstack-react-start/get-auth) method. If the user is not authenticated, they are redirected to a sign-in page. If authenticated, the user's `userId` is passed to the route, allowing access to the `<Home />` component, which welcomes the user and displays their `userId`. The [`beforeLoad()`](https://tanstack.com/router/latest/docs/framework/react/api/router/RouteOptionsType#beforeload-method) method ensures authentication is checked before loading the page, and the [`loader()`](https://tanstack.com/router/latest/docs/framework/react/api/router/RouteOptionsType#loader-method) method returns the user data for use in the component.
 
   > [!TIP]
-  > Ensure that your app has the [TanStack Start server handler](https://tanstack.com/start/latest/docs/framework/react/server-routes#handling-server-route-requests) configured in order for your server routes to work.
+  > Ensure that your app has the [TanStack Start server handler](https://tanstack.com/start/latest/docs/framework/react/guide/server-routes#handling-server-route-requests) configured in order for your server routes to work.
 
   ```tsx {{ filename: 'src/routes/index.tsx' }}
   import { createFileRoute, redirect } from '@tanstack/react-router'


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-docs-11070-fix-tanstack-broken-links/tanstack-react-start/getting-started/quickstart#server-side

### What does this solve?

Fixes broken TanStack links reported by Oh Dear.

|Status code                                                                   |Crawled URL|Found on URL|Link text|
|------------------------------------------------------------------------------|-----------|------------|---------|
|404                                                                           |https://tanstack.com/router/latest/docs/framework/react/start/server-functions|https://clerk.com/docs/tanstack-react-start/getting-started/quickstart|server function⁠|
|404                                                                           |https://tanstack.com/start/latest/docs/framework/react/server-routes|https://clerk.com/docs/tanstack-react-start/getting-started/quickstart|TanStack Start server handler⁠|

### What changed?

- Updated links

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
