### PR TITLE
Fix SignUp object reference on JS SDK 

### DIFF
--- a/docs/reference/javascript/sign-up.mdx
+++ b/docs/reference/javascript/sign-up.mdx
@@ -73,8 +73,8 @@ The following steps outline the sign-up process:
   - `string | null`
 
   The [username](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#username) supplied to the current sign-up. Only supported if username is enabled in the instance settings.
-  \`
-  --
+
+  ---
 
   - `emailAddress`
   - `string | null`


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Noticed some issue with the formatting of `username` for the SignUp object on JS SDK. 

**Before**

<img width="725" height="292" alt="Screenshot 2025-10-14 at 9 59 26 am" src="https://github.com/user-attachments/assets/0c8f4ee9-5bdc-45eb-a506-a54e6e826530" />

**After**

<img width="601" height="102" alt="Screenshot 2025-10-14 at 10 05 32 am" src="https://github.com/user-attachments/assets/0a514cf0-1d85-4d83-ad14-8e04b2183e05" />

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
