### PR TITLE
Accept organization invitations custom flow: clarify collection of additional fields

### DIFF
--- a/docs/guides/development/custom-flows/organizations/accept-organization-invitations.mdx
+++ b/docs/guides/development/custom-flows/organizations/accept-organization-invitations.mdx
@@ -31,7 +31,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
 
 1. It extracts the token from the URL.
 1. It passes the token to either [`signUp.create()`](/docs/reference/javascript/sign-up#create) or [`signIn.create()`](/docs/reference/javascript/sign-in#create), depending on the `__clerk_status`.
-1. It demonstrates how to collect additional fields during sign-up, such as first and last names. You can modify or remove these fields as needed for your application. **If you do not have **First and last name** enabled for your instance in the Clerk Dashboard, remove these fields or `signUp.create()` will throw an error.**
+1. It demonstrates how to collect additional fields during sign-up, such as first and last names. You can modify or remove these fields as needed for your application. If you do not have **First and last name** enabled for your instance [in the Clerk Dashboard](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=user-profile), remove these fields or `signUp.create()` will throw an error.
 
 <Tabs items={["Next.js"]}>
   <Tab>


### PR DESCRIPTION
A user received an error when they copy and pasted this code into their app. We still want to demonstrate how to collect additional fields, so instead of removing this from the example, I've added necessary context.

https://clerk.com/docs/pr/aa-docs-11060/guides/development/custom-flows/organizations/accept-organization-invitations

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
