### PR TITLE
Update quickstart.mdx marks

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -84,7 +84,7 @@ sdk: nextjs
   1. Add the [`<ClerkProvider>`](/docs/reference/components/clerk-provider) component to your app's layout. This component provides Clerk's authentication context to your app.
   1. Copy and paste the following file into your `layout.tsx` file. This creates a header with Clerk's [prebuilt components](/docs/reference/components/overview) to allow users to sign in and out.
 
-  ```tsx {{ filename: 'app/layout.tsx', mark: [[2, 9], 34, [37, 45], 49], fold: [[12, 27]] }}
+  ```tsx {{ filename: 'app/layout.tsx', mark: [[2, 9], 34, [37, 49], 53], fold: [[12, 27]] }}
   import type { Metadata } from 'next'
   import {
     ClerkProvider,


### PR DESCRIPTION
### 🔎 Previews:

Existing (incorrect marks):
<img width="693" height="532" alt="image" src="https://github.com/user-attachments/assets/7681a7a8-bedc-4b76-a701-a107d105ca43" />

Resolved: (not sure why spaces are appearing at line ends on my local build, can confirm file line endings are unchanged)
<img width="687" height="536" alt="image" src="https://github.com/user-attachments/assets/59837012-7926-416f-82e9-b24483afa369" />

### What does this solve?

- All new lines of code are now correctly highlighted for the reader

### What changed?

- Fixed outdated `marks`

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
