### PR TITLE
Add note about the `sts` claim to manual JWT verification docs

### DIFF
--- a/docs/guides/sessions/manual-jwt-verification.mdx
+++ b/docs/guides/sessions/manual-jwt-verification.mdx
@@ -39,7 +39,7 @@ The following example uses the `authenticateRequest()` method to verify the sess
   1. Validate that the `azp` (authorized parties) claim equals any of your known origins permitted to generate those tokens. For better security, it's highly recommended to explicitly set the `authorizedParties` option when authorizing requests. The value should be a list of domains allowed to make requests to your application. Not setting this value can open your application to [CSRF attacks](https://owasp.org/www-community/attacks/csrf). For example, if you're permitting tokens retrieved from `http://localhost:3000`, then the `azp` claim should equal `http://localhost:3000`. You can also pass an array of strings, such as `['http://localhost:4003', 'https://clerk.dev']`. If the `azp` claim doesn't exist, you can skip this step.
 
   ### Optional: Check for a `sts` claim
-  
+
   If you are using Clerk's [organizations](/docs/guides/organizations/overview) feature and [have not enabled personal accounts](/docs/guides/organizations/overview#allow-personal-accounts), users are _required to be part of an organization before accessing your application_. If the user has completed registration, but is not yet part of an organization, a valid session token will be created, but the token will contain a `sts` (status) claim set to `pending`. You may want to reject requests to your backend with pending statuses to ensure that users are not able to work around the organization requirement.
 
   ### Finished


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/jeadd-sts-note-to-manual-verification-docs/guides/sessions/manual-jwt-verification#optional-check-for-a-sts-claim

### What changed?

Since we introduced the force org session task, there is another consideration when manually verifying JWTs. This is handled automatically (requests are rejected) by Clerk's SDK functions like `auth()`, but would need to be handled manually if doing token verification manually.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
