### PR TITLE
fix: Update React Router documentation

### DIFF
--- a/docs/getting-started/quickstart.react-router.mdx
+++ b/docs/getting-started/quickstart.react-router.mdx
@@ -182,7 +182,7 @@ This tutorial assumes that you're using React Router **v7.1.2 or later** in fram
   - [`<UserButton />`](/docs/reference/components/user/user-button): Shows the signed-in user's avatar. Selecting it opens a dropdown menu with account management options.
   - [`<SignInButton />`](/docs/reference/components/unstyled/sign-in-button): An unstyled component that links to the sign-in page. In this example, since no props or [environment variables](/docs/guides/development/clerk-environment-variables) are set for the sign-in URL, this component links to the [Account Portal sign-in page](/docs/guides/customizing-clerk/account-portal#sign-in).
 
-  ```tsx {{ filename: 'app/root.tsx', mark: [44, [46, 58]], fold: [[2, 42], [62, 87]] }}
+  ```tsx {{ filename: 'app/root.tsx', mark: [44, [46, 58], 60], fold: [[2, 42], [62, 87]] }}
   import { ClerkProvider, SignedIn, SignedOut, UserButton, SignInButton } from '@clerk/react-router'
   import { isRouteErrorResponse, Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
   import { clerkMiddleware, rootAuthLoader } from '@clerk/react-router/server'


### PR DESCRIPTION
### 🔎 Previews:

Before: (notice `</ClerkProvider>` is not visible, nor highlighted)

<img width="692" height="763" alt="image" src="https://github.com/user-attachments/assets/edf355c5-7f73-4031-a674-9e78790d58da" />
<img width="705" height="199" alt="image" src="https://github.com/user-attachments/assets/0cfa00f9-2167-4543-9351-45d38597d485" />

After: (notice `<main>` was removed as it is already present in React Router's `welcome.tsx`)

<img width="709" height="722" alt="image" src="https://github.com/user-attachments/assets/c146072b-36ef-4f9b-958a-62369866655d" />

### What does this solve?

- Ensures all added lines are visible and highlighted
- Keeps code in parody with `npx create-react-router@latest` (https://reactrouter.com/start/framework/installation )

### What changed?

- Updates code & marks

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
