### PR TITLE
Update shadcn-cli docs to use namespace

### DIFF
--- a/docs/guides/development/shadcn-cli.mdx
+++ b/docs/guides/development/shadcn-cli.mdx
@@ -36,7 +36,7 @@ npx shadcn@latest add @clerk/nextjs-sign-in-page
 
 The sign-up page is a dedicated page that allows users to sign up for a new account which includes a two column layout with a list of selling points and a form to sign up.
 
- ```npm {{ filename: 'terminal' }}
+```npm {{ filename: 'terminal' }}
 npx shadcn@latest add @clerk/nextjs-sign-up-page
 ```
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/alexcarpenter-registry-commands/guides/development/shadcn-cli

### What does this solve?

- Now that `@clerk` is a trusted registry, we can simplify docs to just use the namespace installs

### What changed?

- <!--- How does this PR solve the problem? -->

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
