### PR TITLE
Updates API reference sidebar links to be relative

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3264,11 +3264,13 @@
                   },
                   {
                     "title": "Frontend API",
-                    "href": "/docs/reference/frontend-api"
+                    "href": "/docs/reference/frontend-api",
+                    "target": "_blank"
                   },
                   {
                     "title": "Backend API",
-                    "href": "/docs/reference/backend-api"
+                    "href": "/docs/reference/backend-api",
+                    "target": "_blank"
                   }
                 ]
               ]


### PR DESCRIPTION
### 🔎 Previews:

- 

### What does this solve?

Noticed this when testing https://github.com/clerk/clerk/pull/1710. Local dev and preview urls don't carry over to API references.

### What changed?

Updates API reference links to carryover host.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
