### PR TITLE
Fixes Nuxt middleware route link.

### DIFF
--- a/docs/guides/secure/protect-pages.mdx
+++ b/docs/guides/secure/protect-pages.mdx
@@ -19,7 +19,7 @@ The `useAuth()` composable provides access to the current user's authentication 
 
 The `createRouteMatcher()` is a Clerk helper function that allows you to protect multiple routes in your Nuxt application. It accepts an array of route patterns and checks if the route the user is trying to visit matches one of the patterns passed to it.
 
-The `createRouteMatcher()` helper returns a function that, when called with the `to` route object from Nuxt's [`defineNuxtRouteMiddleware()`](https://nuxt.com/docs/api/utils/define-nuxt-route-middleware), will return `true` if the user is trying to access a route that matches one of the patterns provided.
+The `createRouteMatcher()` helper returns a function that, when called with the `to` route object from Nuxt's [`defineNuxtRouteMiddleware()`](https://nuxt.com/docs/4.x/api/utils/define-nuxt-route-middleware), will return `true` if the user is trying to access a route that matches one of the patterns provided.
 
 ### Example
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/fix-nuxt-middleware-link/guides/secure/protect-pages#protect-multiple-pages

### What does this solve?

- Previous url was 404ing (according to Oh Dear)

### What changed?

- Adds a better, direct link

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
