### PR TITLE
Fix absence of SDKs icons on the Getting Started overview 

### DIFF
--- a/docs/getting-started/quickstart/overview.mdx
+++ b/docs/getting-started/quickstart/overview.mdx
@@ -38,7 +38,7 @@ description: See the getting started guides and tutorials.
 
   - [TanStack React Start (beta)](/docs/tanstack-react-start/getting-started/quickstart)
   - Easily add secure and SSR-friendly authentication to your TanStack React Start application with Clerk.
-  - <Icon name="tanstack-start" />
+  - <Icon name="tanstack" />
 </Cards>
 
 ## Frontend
@@ -52,7 +52,7 @@ description: See the getting started guides and tutorials.
 
   - [Chrome Extension](/docs/chrome-extension/getting-started/quickstart)
   - Use the Chrome Extension SDK to authenticate users in your Chrome extension.
-  - <Icon name="chrome-extension" />
+  - <Icon name="chrome" />
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-fix-ios-icon/getting-started/quickstart/overview

### What does this solve?

Noticed three SDKs cards were missing their icons on the Getting Starter overview page. This PR fixes that. 

### What changed?

**Before:**


<img width="345" height="240" alt="Screenshot 2025-10-21 at 12 14 05 pm" src="https://github.com/user-attachments/assets/57e67d93-381c-491a-8db6-f9694240a237" />
<img width="326" height="198" alt="Screenshot 2025-10-21 at 3 31 35 pm" src="https://github.com/user-attachments/assets/2240467f-4c8d-4d83-be99-6ff4e1ae90e6" />
<img width="327" height="198" alt="Screenshot 2025-10-21 at 3 31 25 pm" src="https://github.com/user-attachments/assets/39e68281-df1b-49d1-bd81-553f394b6ee1" />

**After:**

<img width="330" height="217" alt="Screenshot 2025-10-21 at 3 31 19 pm" src="https://github.com/user-attachments/assets/b0304807-fc37-4acf-bec9-8173628f8aa4" />
<img width="335" height="210" alt="Screenshot 2025-10-21 at 3 31 16 pm" src="https://github.com/user-attachments/assets/c7e05b6d-fe1b-4465-877b-aa82151dc322" />
<img width="338" height="214" alt="Screenshot 2025-10-21 at 3 31 13 pm" src="https://github.com/user-attachments/assets/d2980ddf-a42c-44fe-bca4-6bb410055253" />

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
