### PR TITLE
Remove "optional" mention for algorithm verification

### DIFF
--- a/docs/guides/sessions/manual-jwt-verification.mdx
+++ b/docs/guides/sessions/manual-jwt-verification.mdx
@@ -34,7 +34,7 @@ The following example uses the `authenticateRequest()` method to verify the sess
 
   To verify the token signature:
 
-  1. Verifiy that the token's algorithm has the expected value.
+  1. Verify that the token's algorithm has the expected value.
   1. Use your instance's public key to verify the token's signature.
   1. Validate that the token isn't expired by checking the `exp` ([expiration time](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4)) and `nbf` ([not before](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5)) claims.
   1. Validate that the `azp` (authorized parties) claim equals any of your known origins permitted to generate those tokens. For better security, it's highly recommended to explicitly set the `authorizedParties` option when authorizing requests. The value should be a list of domains allowed to make requests to your application. Not setting this value can open your application to [CSRF attacks](https://owasp.org/www-community/attacks/csrf). For example, if you're permitting tokens retrieved from `http://localhost:3000`, then the `azp` claim should equal `http://localhost:3000`. You can also pass an array of strings, such as `['http://localhost:4003', 'https://clerk.dev']`. If the `azp` claim doesn't exist, you can skip this step.


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Related to DOCS-11100

Verifying the algorithm shouldn't just be a optional. Some modern libraries (go-jose/v4 comes to mind) will require it anyway and others are quite smart about guessing the correct one (node's jsonwebtoken) but we should have this recommendation to ensure secure JWT validation.

### What changed?

- Removes mention of optional in the code sample
- Explicitly mentions verification of algorithm

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
