### PR TITLE
feat: Add subdomain verbiage to Restrictions/Blocklist

### DIFF
--- a/docs/guides/secure/restricting-access.mdx
+++ b/docs/guides/secure/restricting-access.mdx
@@ -86,9 +86,9 @@ To enable this feature:
 
 <Include src="_partials/feature-not-free-callout" />
 
-By adding specific identifiers to the blocklist, you block users with those identifiers from signing up. This helps prevent attacks, like when multiple spam accounts register. For example, adding `clerk.dev` to the blocked email domains list prevents anyone with a @clerk.dev email address from signing up.
+By adding specific identifiers to the blocklist, you can prevent users with those identifiers from signing up. This helps protect your application from attacks, such as scripts creating multiple spam accounts. For example, adding `clerk.dev` to the blocked email domains list prevents anyone with an email address ending in `@clerk.dev` from signing up.
 
-You can also block email addresses from all subdomains using `*@*.clerk.dev`. This means anyone with an email address with a `@subdomain.clerk.dev` or `@subdomain2.clerk.dev` cannot sign up. It also blocks addresses from further subdomains, such as `@subdomain.subdomain2.clerk.dev`.
+You can also block email addresses from all subdomains by using `*@*.clerk.dev`. This prevents sign-ups from email addresses such as `@subdomain.clerk.dev` or `@subdomain2.clerk.dev`, and deeper subdomains like `@subdomain.subdomain2.clerk.dev`.
 
 To enable this feature:
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/tom-restricting-access-blocklist/guides/secure/restricting-access#blocklist

### What does this solve?

- Adds additional verbiage to Restrictions#Blocklist around blocked subdomains.
- Removes "sign-ins" as the forced-default is now "sign-ups" only.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
