### PR TITLE
Add that webhook handlers can access user private metadata

### DIFF
--- a/docs/guides/users/extending.mdx
+++ b/docs/guides/users/extending.mdx
@@ -124,7 +124,7 @@ On the backend, it's available on the [Backend `User`](/docs/reference/backend/t
 
 ### Private metadata
 
-Private metadata is only accessible by the backend, which makes this useful for storing sensitive data that you don't want to expose to the frontend. For example, you could store a user's Stripe customer ID.
+Private metadata is only accessible by the backend and webhook handlers, which makes this useful for storing sensitive data that you don't want to expose to the frontend. For example, you could store a user's Stripe customer ID.
 
 #### Set private metadata
 


### PR DESCRIPTION
Clarified that private metadata is accessible by webhook handlers.

### What does this solve?

- It wasn't clear to me whether this should be true until I saw [this example](https://clerk.com/docs/guides/development/webhooks/overview#:~:text=%22private_metadata%22%3A%20%7B%7D%2C)

Related to USER-2719

### What changed?

- Made it explicit that webhooks can receive private metadata

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
