### PR TITLE
chore(how-clerk-works): mention JWT

### DIFF
--- a/docs/guides/how-clerk-works/overview.mdx
+++ b/docs/guides/how-clerk-works/overview.mdx
@@ -133,7 +133,7 @@ The stateless authentication flow operates as follows. This example assumes that
 While more complex to implement, this stateless model offers significant advantages. Because verifying the JWT doesn't require interacting with a database, the latency overhead and scaling challenges caused by database lookups are eliminated, leading to faster request processing.
 
 > [!QUIZ]
-> How exactly does stateless authenticate mitigate database scaling challenges?
+> How exactly does stateless authentication mitigate database scaling challenges?
 >
 > ---
 >


### PR DESCRIPTION
This adds an explicitly mention of "JWT"... so that the following usage of the "JWT" acronym in the paragraph after the 4 numbered list items is less abrupt.
