### PR TITLE
Adds a check to the `validateLinks` plugin

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -4305,6 +4305,39 @@ sdk: react, nextjs
       `<SDKLink href="/docs/:sdk:/guide-2" sdks={["react","nextjs"]} code={true}>\\<Guide 2></SDKLink>`,
     )
   })
+
+  test('Should prevent doc links not starting with a slash', async () => {
+    const title = 'Docs link missing starting slash'
+    const href = '/docs/missing-starting-slash'
+    const badDocLink = 'docs/link-to-something'
+    const { tempDir } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [[{ title, href }]],
+        }),
+      },
+      {
+        path: `.${href}.mdx`,
+        content: `---
+title: ${title}
+description: Page description
+---
+
+[Doc Link](${badDocLink})`,
+      },
+    ])
+
+    const output = await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+      }),
+    )
+
+    expect(output).toContain(`Doc link must start with a slash (/docs/...). Fix url: ${badDocLink}`)
+  })
 })
 
 describe('Path and File Handling', () => {

--- a/scripts/lib/error-messages.ts
+++ b/scripts/lib/error-messages.ts
@@ -69,7 +69,7 @@ export const errorMessages = {
     `Matching file not found for path: ${url}. Expected file to exist at ${file}`,
   'link-hash-not-found': (hash: string, url: string): string => `Hash "${hash}" not found in ${url}`,
   'doc-link-must-start-with-a-slash': (url: string): string =>
-    `Doc link much start with a slash (/docs/...). Fix url: ${url}`,
+    `Doc link must start with a slash (/docs/...). Fix url: ${url}`,
 
   // File reading errors
   'file-read-error': (filePath: string): string => `Failed to read in ${filePath}`,

--- a/scripts/lib/plugins/validateLinks.ts
+++ b/scripts/lib/plugins/validateLinks.ts
@@ -28,6 +28,10 @@ export const validateLinks =
       if (node.type !== 'link') return node
       if (!('url' in node)) return node
       if (typeof node.url !== 'string') return node
+
+      // we are overwriting the url with the mdx suffix removed
+      node.url = removeMdxSuffix(node.url)
+
       if (node.url.startsWith('docs/')) {
         safeMessage(
           config,
@@ -41,9 +45,6 @@ export const validateLinks =
       }
       if (!node.url.startsWith(config.baseDocsLink) && (!node.url.startsWith('#') || href === undefined)) return node
       if (!('children' in node)) return node
-
-      // we are overwriting the url with the mdx suffix removed
-      node.url = removeMdxSuffix(node.url)
 
       let [url, hash] = (node.url as string).split('#')
 


### PR DESCRIPTION
### What does this solve?

Prevents bad/broken docs links. Example → https://github.com/clerk/clerk-docs/pull/2749

### What changed?

Adds a check to the `validateLinks` plugin for links starting with `docs/` (which will fail) instead of `/docs/`.

Running on this PR before merging the fixes already in `main`:

<img width="2666" height="1926" alt="CleanShot 2025-10-28 at 13 13 01@2x" src="https://github.com/user-attachments/assets/d2565023-da29-44c4-b455-64d5ffbecb79" />

After brining in the changes from `main`: ✅ 

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
