### PR TITLE
Update authenticateWithPopup reference doc

### DIFF
--- a/docs/reference/javascript/_partials/authenticate-with-popup-params.mdx
+++ b/docs/reference/javascript/_partials/authenticate-with-popup-params.mdx
@@ -1,11 +1,3 @@
-Opens a popup window to allow a user to sign up via a Single Sign On (SSO) connection, such as OAuth or SAML, where an external account is used for verifying the user's identity.
-
-```typescript
-function authenticateWithPopup(params: AuthenticateWithPopupParams): Promise<void>
-```
-
-#### `AuthenticateWithPopupParams`
-
 <Properties>
   - `redirectUrl`
   - `string`
@@ -72,14 +64,3 @@ function authenticateWithPopup(params: AuthenticateWithPopupParams): Promise<voi
 
   Metadata that can be read and set from the frontend. Once the sign-up is complete, the value of this field will be automatically copied to the newly created user's unsafe metadata. One common use case for this attribute is to use it to implement custom fields that can be collected during sign-up and will automatically be attached to the created `User` object.
 </Properties>
-
-#### Example
-
-```js
-await clerk.signUp.authenticateWithPopup({
-  popup: window.open('https://example.com', '_blank'),
-  strategy: 'oauth_google',
-  redirectUrl: '/sso-callback',
-  redirectUrlComplete: '/home',
-})
-```

--- a/docs/reference/javascript/sign-in.mdx
+++ b/docs/reference/javascript/sign-in.mdx
@@ -344,7 +344,26 @@ For enterprise connections, see the [custom flow for enterprise connections](/do
 
 ### `authenticateWithPopup()`
 
-<Include src="./_partials/authenticate-with-popup" />
+Opens a popup window to allow a user to sign in via a Single Sign On (SSO) connection, such as OAuth or SAML, where an external account is used for verifying the user's identity.
+
+```typescript
+function authenticateWithPopup(params: AuthenticateWithPopupParams): Promise<void>
+```
+
+#### `AuthenticateWithPopupParams`
+
+<Include src="./_partials/authenticate-with-popup-params" />
+
+#### Example
+
+```js
+await clerk.signIn.authenticateWithPopup({
+  popup: window.open('https://example.com', '_blank'),
+  strategy: 'oauth_google',
+  redirectUrl: '/sso-callback',
+  redirectUrlComplete: '/home',
+})
+```
 
 ### `authenticateWithWeb3()`
 

--- a/docs/reference/javascript/sign-up.mdx
+++ b/docs/reference/javascript/sign-up.mdx
@@ -390,7 +390,26 @@ For enterprise connections, see the [custom flow for enterprise connections](/do
 
 ### `authenticateWithPopup()`
 
-<Include src="./_partials/authenticate-with-popup" />
+Opens a popup window to allow a user to sign up via a Single Sign On (SSO) connection, such as OAuth or SAML, where an external account is used for verifying the user's identity.
+
+```typescript
+function authenticateWithPopup(params: AuthenticateWithPopupParams): Promise<void>
+```
+
+#### `AuthenticateWithPopupParams`
+
+<Include src="./_partials/authenticate-with-popup-params" />
+
+#### Example
+
+```js
+await clerk.signUp.authenticateWithPopup({
+  popup: window.open('https://example.com', '_blank'),
+  strategy: 'oauth_google',
+  redirectUrl: '/sso-callback',
+  redirectUrlComplete: '/home',
+})
+```
 
 ### `authenticateWithWeb3()`
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

[A user reported](https://linear.app/clerk/issue/DOCS-11102/feedback-for-guidesdevelopmentcustom-flowsauthenticationoauth) that there was no example usage for `authenticateWithPopup()` in the [OAuth Connections custom flow guide](https://clerk.com/docs/guides/development/custom-flows/authentication/oauth-connections). During triage, we investigated and noticed an incorrect "Example" section under `authenticateWithPopUp()` which was misleading users to the oauth-connections guide.

<img width="1512" height="911" alt="Screenshot 2025-10-30 at 15 32 24" src="https://github.com/user-attachments/assets/7318e79e-dab3-4db9-872d-1e9d87cde6a6" />

### What changed?

- Adds the correct example
- Uses a partial for `authenticateWithPopup()` as its used in both the [`/sign-in`](https://github.com/clerk/clerk-docs/pull/2757/files#diff-fff3bf3b85e3cf49068472c53ffce99878c716eae0c3c1d0bd043b508e3023e2) and [`sign-up`](https://github.com/clerk/clerk-docs/pull/2757/files#diff-9e0c1fb70257bf8b762f971276f2e1c2bd10e18d826402fa03fcfbecbe2d21b6) javascript references

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
