### PR TITLE
fix: Next.js 16 and Error: Clerk: auth() was called but... can't detect clerkMiddleware()

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -120,8 +120,8 @@ sdk: nextjs
     children: React.ReactNode
   }>) {
     return (
-      <ClerkProvider>
-        <html lang="en">
+      <html lang="en">
+        <ClerkProvider>
           <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
             <header className="flex justify-end items-center p-4 gap-4 h-16">
               <SignedOut>
@@ -138,8 +138,8 @@ sdk: nextjs
             </header>
             {children}
           </body>
-        </html>
-      </ClerkProvider>
+        </ClerkProvider>
+      </html>
     )
   }
   ```
@@ -150,7 +150,7 @@ sdk: nextjs
 
   ## It's time to build!
 
-  You've added Clerk to your Next.js app 🎉. From here, you can continue developing your application.
+  You've added Clerk to your Next.js app 🎉. From here, you can continue developing your application. For a more detailed example, check out our [Next.js Auth Starter Template](https://github.com/clerk/nextjs-auth-starter-template).
 
   To make configuration changes to your Clerk development instance, claim the Clerk keys that were generated for you by selecting **Claim your application** in the bottom right of your app. This will associate the application with your Clerk account.
 </Steps>


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

The example provided in the current documentation produces the following error with Next.js 16:

```shall
 ⨯ Error: Clerk: auth() was called but Clerk can't detect usage of clerkMiddleware(). Please ensure the following:
- Your Middleware exists at ./src/middleware.(ts|js)
- clerkMiddleware() is used in your Next.js Middleware.
- Your Middleware matcher is configured to match this route or page.
- If you are using the src directory, make sure the Middleware file is inside of it.

For more details, see https://clerk.com/err/auth-middleware

    at az (.next/server/chunks/ssr/[root-of-the-server]__8b119579._.js:22:188)
    at <unknown> (.next/server/chunks/ssr/[root-of-the-server]__8b119579._.js:24:4432)
    at async a5 (.next/server/chunks/ssr/[root-of-the-server]__8b119579._.js:24:4073)
    at async a7 (.next/server/chunks/ssr/[root-of-the-server]__8b119579._.js:24:5921) {
  digest: '686683912'
}
```

### What changed?

1) Order of the `<html>` and `<ClerkProvider>`, the source ov this change/solution is: <https://github.com/clerk/nextjs-auth-starter-template/blob/main/app/layout.tsx>

2) Added a link to the [Next.js Auth Starter Template](https://github.com/clerk/nextjs-auth-starter-template/blob/main/app/layout.tsx) at the end of the doc page.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
