### PR TITLE
Adds list item punctuation section to styleguide

### DIFF
--- a/styleguides/STYLEGUIDE.md
+++ b/styleguides/STYLEGUIDE.md
@@ -206,12 +206,12 @@ When list items are full sentences, end with a period.
 
 > ❌
 >
-> - Click _Save_
+> - Click **Save**
 > - The system sends you a confirmation email
 
 > ✅
 >
-> - Click _Save_.
+> - Click **Save**.
 > - The system sends you a confirmation email.
 
 When list items aren't full sentences, don't use a period.


### PR DESCRIPTION
### 🔎 Previews:

- https://github.com/clerk/clerk-docs/blob/79721ec78e60619730701eae85fc30be13c96c9c/styleguides/STYLEGUIDE.md#list-item-punctuation

### What does this solve?

- Adds missing styleguide section on list punctuation.

### What changed?

- Documents [team discussion](https://clerkinc.slack.com/archives/C084WHCNHCZ/p1761926461658779) on list punctuation.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
