### PR TITLE
ios - filter out UI components homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,7 +7,7 @@ template: wide
 Find all the guides and resources you need to develop with Clerk.
 
 <If
-  sdk={["nextjs", "react", "astro", "chrome-extension", "expo", "android", "js-frontend", "nuxt", "react-router", "remix", "tanstack-react-start", "vue", "js-backend", "expressjs", "go", "fastify", "python", "ruby"]}
+  sdk={["nextjs", "react", "astro", "chrome-extension", "expo", "android", "js-frontend", "nuxt", "react-router", "remix", "tanstack-react-start", "vue", "js-backend", "expressjs", "go", "fastify", "ruby"]}
 >
   <Cards cols={4} level={2}>
     - [Quickstarts & Tutorials](/docs/getting-started/quickstart/overview)


### PR DESCRIPTION
on top of https://github.com/clerk/clerk-docs/pull/2773

### 🔎 Previews:

- https://clerk-git-nick-navigation-sdk-scoping.clerkstage.dev/docs/pr/nick-filter-out-ui-components-homepage

### What does this solve?

- https://github.com/clerk/clerk/pull/1800#issuecomment-3505086099
- Replace the "UI Components" card on the homepage with a "Views" card when ios is the active sdk

### What changed?

- used the `<If />` component to swap out the contents of the page based on the sdk

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
