### PR TITLE
feat: Add SDK versions that support api version 2025-11-10

### DIFF
--- a/docs/_partials/available-versions.mdx
+++ b/docs/_partials/available-versions.mdx
@@ -2,6 +2,26 @@
 
 Brings more consistency and clarity to the Clerk Billing API endpoints. See the [migration guide](/docs/guides/development/upgrading/upgrade-guides/2025-11-10) for more details.
 
+The following SDKs are compatible with this version:
+
+| SDK | Version |
+| - | - |
+| Clerk.js | @clerk/clerk-js v5.107.0 or higher |
+| Next.js | @clerk/nextjs v6.35.0 or higher |
+| Astro | @clerk/astro v2.15.0 or higher |
+| Expo | @clerk/expo v2.19.0 or higher |
+| Express | @clerk/express v1.7.48 or higher |
+| Fastify | @clerk/fastify v2.6.0 or higher |
+| Go | clerk-sdk-go v2.5.0 or higher |
+| JavaScript Backend | @clerk/backend v2.21.0 or higher |
+| Java | com.clerk:backend-api v4.0.0 or higher |
+| Nuxt.js | @clerk/nuxt v1.12.0 or higher |
+| Python | clerk\_backend\_api v4.0.0 or higher |
+| React Router | @clerk/react-router v2.2.0 or higher |
+| Remix | @clerk/remix v4.13.15 or higher |
+| TanStack React Start | @clerk/tanstack-react-start v0.27.0 or higher |
+| C# | Clerk.BackendAPI v0.14.0 or higher |
+
 ### 2025-04-10
 
 Adds support for [version 2 of Clerk session tokens](/docs/guides/sessions/session-tokens).


### PR DESCRIPTION
### 🔎 Previews:

https://clerk.com/docs/pr/api-version-2025-11-10-sdk-versions/guides/development/upgrading/versioning#2025-11-10

### What does this solve?

Adds SDK versions that support API version 2025-11-10

### What changed?

Adds SDK versions that support API version 2025-11-10

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
