### PR TITLE
feat: add PHP v0.4.0 to available versions supporting api version 2025-11-10

### DIFF
--- a/docs/_partials/available-versions.mdx
+++ b/docs/_partials/available-versions.mdx
@@ -16,6 +16,7 @@ The following SDKs are compatible with this version:
 | JavaScript Backend | @clerk/backend v2.21.0 or higher |
 | Java | com.clerk:backend-api v4.0.0 or higher |
 | Nuxt.js | @clerk/nuxt v1.12.0 or higher |
+| PHP | clerkinc/backend-php v0.4.0 or higher |
 | Python | clerk\_backend\_api v4.0.0 or higher |
 | React Router | @clerk/react-router v2.2.0 or higher |
 | Remix | @clerk/remix v4.13.15 or higher |


### PR DESCRIPTION
### What does this solve?

Needed to add the new PHP version v.0.4.0. to docs to communicate to users that this version and higher is needed to use api version 2025-11-10.

### What changed?

Added the new PHP version to the existing array of SDKs that support api version 2025-11-10.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
