### PR TITLE
Custom OAuth IdP: Removed PKCE limitation

### DIFF
--- a/docs/guides/configure/auth-strategies/social-connections/custom-provider.mdx
+++ b/docs/guides/configure/auth-strategies/social-connections/custom-provider.mdx
@@ -99,10 +99,6 @@ The proxy receives the request from Clerk (which contains an `Authorization` hea
 
 1. Map the returned claim format of the proxy to the respective attributes in the **Attribute mapping** section
 
-## Proof Key for Code Exchange (PKCE)
-
-Currently, Clerk doesn't support custom SSO providers with Proof Key for Code Exchange (PKCE).
-
 ## References
 
 - [OpenID Connect Specification](https://openid.net/specs/openid-connect-core-1_0.html)


### PR DESCRIPTION
I tested against our own Public/PKCE provider and it worked fine. We have a toggle under SSO Connections to enable PKCE for the provider.

UPDATE: This [just shipped last week](https://clerk.com/changelog/2025-11-12-pkce-support-custom-oauth)! 🙌 

<img width="1602" height="1010" alt="Screenshot of toggle to enable PKCE on custom SSO provider" src="https://github.com/user-attachments/assets/d85010c9-9e04-40ca-a39a-ba36cf03a432" />
