### PR TITLE
feat: Clarify that Clerk costs the same as Stripe directly

### DIFF
--- a/docs/_partials/billing/enable-billing.mdx
+++ b/docs/_partials/billing/enable-billing.mdx
@@ -2,7 +2,7 @@
 
 To enable billing for your application, navigate to the [**Billing Settings**](https://dashboard.clerk.com/~/billing/settings) page in the Clerk Dashboard. This page will guide you through enabling billing for your application.
 
-Clerk billing costs just 0.7% per transaction, plus Stripe's transaction fees which are paid directly to Stripe. Clerk Billing is **not** the same as Stripe Billing. Plans and pricing are managed directly through the Clerk Dashboard and won't sync with your existing Stripe products or plans. Clerk uses Stripe **only** for payment processing, so you don't need to set up Stripe Billing.
+Clerk billing costs the same as using Stripe directly, just 0.7% per transaction, plus transaction fees which are paid directly to Stripe. Clerk Billing is **not** the same as Stripe Billing. Plans and pricing are managed directly through the Clerk Dashboard and won't sync with your existing Stripe products or plans. Clerk uses Stripe **only** for payment processing, so you don't need to set up Stripe Billing.
 
 ### Payment gateway
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/guilherme-clarify-pricing-as-stripe/react/guides/billing/for-b2c

### What does this solve?

 <!--- Describe your changes in detail. Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

A user reached out confirming Clerk costs the same as Stripe [[plain ticket](https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01KA95FV9S616KRZQJZ1HVH1KF/?q=confirm%20price%20stripe)]. clerk.com/billing is pretty clear but I think this line in the docs can be read as 0.7% more expensive than stripe directly.

More context here: https://clerkinc.slack.com/archives/C08QHV76VA8/p1763392792750519

### What changed?

- <!--- How does this PR solve the problem? -->

The goal is to make this copy pretty solid and accessible to understand that final price is the same as using Stripe directly.

### Checklist

- [x] I have clicked on "Files changed" and performed a thorough self-review
- [x] All existing checks pass
