### PR TITLE
Remove broken m2m dashboard image

### DIFF
--- a/docs/guides/development/machine-auth/overview.mdx
+++ b/docs/guides/development/machine-auth/overview.mdx
@@ -21,8 +21,6 @@ If you are looking for support for the OAuth [client credentials flow](https://d
 
 If your goal is to authenticate requests made between several different services within your own infrastructure, this is the intended use case for Clerk's M2M tokens feature. With this feature, you can create machines, dictate which machines are allowed to communicate with each other, and create tokens that can be used to authenticate requests between these machines.
 
-![Clerk dashboard screenshot showing machine configuration for M2M authentication](/docs/images/machine-auth/dashboard-machines.jpg)
-
 To learn more about machine authentication with M2M tokens, see the [M2M tokens](/docs/guides/development/machine-auth/m2m-tokens) guide.
 
 ## API keys


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Context here: https://clerkinc.slack.com/archives/C084WHCNHCZ/p1763631855218999. @NWylynko reported a broken image on the M2M overview page. However, this is a screenshot of a dashboard setup and we usually don't want those in our docs, as they might become outdated. Also, the image didn't bring much purpose to the section, so this PR removes it entirely. 

### What changed?

Removes the image 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
