### PR TITLE
Clarify the UserProfile customization docs 

### DIFF
--- a/docs/guides/customizing-clerk/adding-items/user-profile.mdx
+++ b/docs/guides/customizing-clerk/adding-items/user-profile.mdx
@@ -3,7 +3,10 @@ title: Add custom pages and links to the `<UserProfile />` component
 description: Learn how to add custom pages and include external links within the navigation sidenav of the <UserProfile /> component.
 ---
 
-The [`<UserProfile />`](/docs/reference/components/user/user-profile) component supports the addition of custom pages and external links to the component's sidenav. It only accepts `<UserButton.UserProfilePage />`/`<UserProfile.Page />` and `<UserProfile.Link />` as children; any other components will be ignored.
+The [`<UserProfile />`](/docs/reference/components/user/user-profile) component supports the addition of custom pages and external links to the component's sidenav. It only accepts the following components as children:
+
+- `<UserButton.UserProfilePage />` or `<UserProfile.Page />` to add a [custom page](#add-a-custom-page).
+- `<UserButton.UserProfileLink />` or `<UserProfile.Link />` to add a [custom link](#add-a-custom-link).
 
 ## Before you start
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-11144/feedback-for-guidescustomizing-clerkadding-itemsuser-button

Following user feedback, this PR aims at clarifying that the <UserProfile /> component can only accept certain components. 

### What changed?

Added clarification 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
