### PR TITLE
(/development/webhooks/billing) Adds link to webhooks overview

### DIFF
--- a/docs/guides/development/webhooks/billing.mdx
+++ b/docs/guides/development/webhooks/billing.mdx
@@ -48,4 +48,4 @@ Payment attempt events contain a `type`, which can be either `checkout` or `recu
 | `paymentAttempt.created` | A payment attempt has been created with `pending` status. It can either succeed or fail in the future. |
 | `paymentAttempt.updated` | A payment attempt has been updated to `paid` or `failed` status. |
 
-Looking for other webhook events? To find a list of all the events Clerk supports, navigate to the [**Webhooks**](https://dashboard.clerk.com/~/webhooks) page and select the **Event Catalog** tab.
+Looking for other webhook events? To find a list of all the events Clerk supports, navigate to the [**Webhooks**](https://dashboard.clerk.com/~/webhooks) page in the Clerk Dashboard and select the **Event Catalog** tab.


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/aa-docs-11158/nextjs/guides/development/webhooks/billing

### What does this solve?

[User feedback ](https://linear.app/clerk/issue/DOCS-11158/feedback-for-nextjsguidesdevelopmentwebhooksbilling) said "Just please give some example code". 

They seem to be confused that this guide is a reference - a list of supported webhook events.

### What changed?

Updates the introductory paragraph to be more clear on the purpose of the doc, and link users to the webhook overview for more information.

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
