### PR TITLE
chore: Add redirect for Vercel social connection docs

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4035,6 +4035,11 @@
     "permanent": true
   },
   {
+    "source": "/docs/authentication/social-connections/vercel",
+    "destination": "/docs/guides/configure/auth-strategies/social-connections/vercel",
+    "permanent": true
+  },
+  {
     "source": "/docs/authentication/social-connections/x-twitter-v2",
     "destination": "/docs/guides/configure/auth-strategies/social-connections/x-twitter",
     "permanent": true


### PR DESCRIPTION
Adds the redirect for the SDK's `docsUrl` to work correctly:

```
/docs/authentication/social-connections/vercel → /docs/guides/configure/auth-strategies/social-connections/vercel
```

This matches the pattern used by all other social connection providers.