### PR TITLE
Scope the native apps callout + reframe text to highlight Expo too 

### DIFF
--- a/docs/guides/configure/auth-strategies/social-connections/apple.mdx
+++ b/docs/guides/configure/auth-strategies/social-connections/apple.mdx
@@ -5,17 +5,17 @@ description: Learn how to allow users to sign up and sign in to your Clerk app w
 
 <TutorialHero
   beforeYouStart={[
-  {
-    title: "A Clerk application is required.",
-    link: "/docs/getting-started/quickstart/setup-clerk",
-    icon: "clerk",
-  },
-  {
-    title: "An Apple Developer account is required.",
-    link: "https://developer.apple.com/programs/enroll/",
-    icon: "user-circle",
-  }
-]}
+    {
+      title: "A Clerk application is required.",
+      link: "/docs/getting-started/quickstart/setup-clerk",
+      icon: "clerk",
+    },
+    {
+      title: "An Apple Developer account is required.",
+      link: "https://developer.apple.com/programs/enroll/",
+      icon: "user-circle",
+    }
+  ]}
 />
 
 Enabling OAuth via [Sign in with Apple](https://developer.apple.com/sign-in-with-apple/) allows your users to sign in and sign up to your Clerk app with their Apple ID.


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-11133/guides/configure/auth-strategies/social-connections/apple
 
### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-11133/feedback-for-guidesconfigureauth-strategiessocial-connectionsapple

A user reported reading this [guide](https://clerk.com/docs/guides/configure/auth-strategies/social-connections/apple), and not being sure which steps to take if working on expo /RN. There was a callout already mentioning a dedicated guide for native apps, but it specifically mentioned iOS, and no mention of expo. This PR makes sure expo is mentioned and scopes the callout to iOS and expo SDKs. 

### Checklist

- [ ] I have clicked on "Files changed" and performed a thorough self-review
- [ ] All existing checks pass
