### PR TITLE
Improve 'clerk as idp' content clarity

### DIFF
--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -5,18 +5,18 @@ description: Learn how to implement single sign-on with OAuth & OpenID Connect i
 
 You've likely seen buttons like "Sign in with Google" or "Sign in with GitHub" countless times. Clerk supports both sides of this experience:
 
-1. **Sign in with [Other App]** – Let users sign in to your Clerk app using their existing credentials from social providers like Google, Facebook, or GitHub.
-1. **Sign in with [Your App]** – Let users sign in to *other* apps using their Clerk credentials from your app. In this case, *your app* becomes the identity provider.
+1. **Sign in with \[Other App]** – Let users sign in to your Clerk app using their existing credentials from social providers like Google, Facebook, or GitHub.
+1. **Sign in with \[Your App]** – Let users sign in to _other_ apps using their Clerk credentials from your app. In this case, _your app_ becomes the identity provider.
 
 These features help you streamline authentication for your users, whether they're signing into your Clerk-powered app or accessing external apps with their Clerk credentials. This guide covers both options in detail and provides links to additional resources where applicable.
 
-## Option 1: Sign in with [Other App]
+## Option 1: Sign in with \[Other App]
 
 This feature allows users to sign up or sign in to your Clerk app using their existing credentials from popular social providers (also known as Identity Providers, or IdPs) like Google, Facebook, or GitHub. For example, if you enable GitHub as a social provider, then a user can sign in to your Clerk app by selecting GitHub as an option and authenticating with their GitHub account credentials.
 
 Refer to the appropriate provider's [guide](/docs/guides/configure/auth-strategies/social-connections/overview) for implementation details.
 
-## Option 2: Sign in with [Your App]
+## Option 2: Sign in with \[Your App]
 
 Clerk can be configured as an OAuth 2.0 and OpenID Connect (OIDC) Identity Provider (IdP) to enable Single Sign-On (SSO) with other [clients](!oauth-client) that support these protocols. This allows users to authenticate to third-party applications using their Clerk credentials, enabling user information sharing between your Clerk app and OAuth clients.
 
@@ -27,7 +27,7 @@ It's the reverse of Option 1: instead of using an external provider to authentic
 With Clerk as an IdP, you can:
 
 - **Integrate with third-party tools** – Let users authenticate into platforms like Notion, Retool, or custom internal tools using their credentials from your app.
-- **Build a developer ecosystem** – Enable partners or third-party developers to offer "Sign in with [Your App]" in their applications.
+- **Build a developer ecosystem** – Enable partners or third-party developers to offer "Sign in with \[Your App]" in their applications.
 - **Support AI agents and automation** – Allow [MCP servers](/docs/guides/development/mcp/overview) or AI tools to authenticate users through your app.
 - **Implement enterprise SSO** – Provide B2B customers with centralized identity management using OpenID Connect.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/jeclarify-clerk-as-idps/guides/configure/auth-strategies/oauth/single-sign-on

### What does this solve?

Clerk as an OAuth/OIDC IdP has always been a bit confusing of a feature. This change attempts to add a bit more clarity through framing that aims to be more understandable to developers who are not experts in OAuth and its associated terminology.
