### PR TITLE
Add client-side example for authorization checks

### DIFF
--- a/docs/guides/secure/authorization-checks.mdx
+++ b/docs/guides/secure/authorization-checks.mdx
@@ -55,28 +55,49 @@ The [`has()`](/docs/reference/backend/types/auth-object#has) helper returns `fal
 
 <Tabs items={["Protect a page", "Protect a route handler", "Protect a Server Action"]}>
   <Tab>
-    The following example demonstrates how to perform authorization checks in a page in order to protect the content from unauthorized access. It uses `has()` to check if the user has the `org:team_settings:manage` Permission. If they aren't authorized, `null` is returned and the page isn't rendered.
+    The following example demonstrates how to perform authorization checks in a page in order to protect the content from unauthorized access. It uses `has()` to check if the user has the `org:team_settings:manage` Permission.
 
     This example is written for Next.js App Router, but can be adapted to other frameworks by using [the appropriate method for accessing the `Auth` object](/docs/reference/backend/types/auth-object#how-to-access-the-auth-object).
 
-    ```tsx {{ filename: 'app/page.tsx' }}
-    import { auth } from '@clerk/nextjs/server'
+    <CodeBlockTabs options={["Server-side", "Client-side"]}>
+      ```tsx {{ filename: 'app/page.tsx' }}
+      import { auth } from '@clerk/nextjs/server'
 
-    export default async function Page() {
-      // Use `auth()` to access the `has()` helper
-      // For other frameworks, use the appropriate method for accessing the `Auth` object
-      const { has } = await auth()
+      export default async function Page() {
+        // Use `auth()` to access the `has()` helper
+        // For other frameworks, use the appropriate method for accessing the `Auth` object
+        const { has } = await auth()
 
-      // Check if the user is authorized
-      const canManage = has({ permission: 'org:team_settings:manage' })
+        // Check if the user is authorized
+        const canManage = has({ permission: 'org:team_settings:manage' })
 
-      // If has() returns false, the user does not have the correct permissions
-      // You can choose how your app responds. This example returns null.
-      if (!canManage) return null
+        // If has() returns false, the user does not have the correct permissions
+        // You can choose how your app responds. This example returns null.
+        if (!canManage) return null
 
-      return <h1>Team Settings</h1>
-    }
-    ```
+        return <h1>Team Settings</h1>
+      }
+      ```
+
+      ```tsx {{ filename: 'app/protected/page.tsx' }}
+      'use client'
+      import { useAuth } from '@clerk/nextjs'
+
+      export default function Page() {
+        // The `useAuth()` hook gives you access to the `has()` helper
+        const { has } = useAuth()
+
+        // Check if the user is authorized
+        const canManage = has({ permission: 'org:team_settings:manage' })
+
+        // If has() returns false, the user does not have the correct permissions
+        // You can choose how your app responds. This example returns the following:
+        if (!canManage) return <h1>You do not have the permissions to manage team settings.</h1>
+
+        return <h1>Team Settings</h1>
+      }
+      ```
+    </CodeBlockTabs>
   </Tab>
 
   <Tab>

--- a/docs/reference/hooks/use-auth.mdx
+++ b/docs/reference/hooks/use-auth.mdx
@@ -4,7 +4,7 @@ description: Access and manage authentication state in your application with Cle
 sdk: astro, chrome-extension, expo, nextjs, react, react-router, tanstack-react-start
 ---
 
-The `useAuth()` hook provides access to the current user's authentication state and methods to manage the active session.
+The `useAuth()` hook provides access to the current user's authentication state and methods to manage the active session. You can use this hook to get the user's authentication and organization information, like their ID, session ID, session token, organization ID, and organization role, and to check if the user is authenticated or [authorized to access a specific resource](!authorization-check).
 
 > [!NOTE]
 > To access auth data server-side, see the [`Auth` object reference doc](/docs/reference/backend/types/auth-object).


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-update-auth-checks/guides/secure/authorization-checks
- https://clerk.com/docs/pr/aa-update-auth-checks/nextjs/reference/hooks/use-auth

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- The docs didn't previously demonstrate that you can use `has()` on the client-side to perform authorization checks.

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Adds an example to the authorization checks guide
- Adds a reference to authorization checks in the `useAuth()` reference

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
