### PR TITLE
Include "Require organization membership" option and update "Allow personal account" copy

### DIFF
--- a/docs/_partials/clerk-middleware-options.mdx
+++ b/docs/_partials/clerk-middleware-options.mdx
@@ -46,7 +46,7 @@ The `clerkMiddleware()` function accepts an optional object. The following optio
   - `organizationSyncOptions?`
   - <code>[OrganizationSyncOptions](#organization-sync-options) | undefined</code>
 
-  Used to activate a specific [Organization](/docs/guides/organizations/overview) or [Personal Account](/docs/guides/dashboard/overview) based on URL path parameters. If there's a mismatch between the [Active Organization](!active-organization) in the session (e.g., as reported by [`auth()`](/docs/reference/nextjs/app-router/auth)) and the Organization indicated by the URL, the middleware will attempt to activate the Organization specified in the URL.
+  Used to activate a specific [Organization](/docs/guides/organizations/overview) or [Personal Account](!personal-account) based on URL path parameters. If there's a mismatch between the [Active Organization](!active-organization) in the session (e.g., as reported by [`auth()`](/docs/reference/nextjs/app-router/auth)) and the Organization indicated by the URL, the middleware will attempt to activate the Organization specified in the URL.
 
   ---
 

--- a/docs/_partials/organization-sync-options.mdx
+++ b/docs/_partials/organization-sync-options.mdx
@@ -25,7 +25,7 @@ object has the type `OrganizationSyncOptions`, which has the following propertie
   - `personalAccountPatterns`
   - <code>[Pattern](#pattern)\[]</code>
 
-  URL patterns for resources that exist within the context of a user's [Personal Account](/docs/guides/organizations/configure#personal-accounts).
+  URL patterns for resources that exist within the context of a user's [Personal Account](!personal-account).
 
   If the route also matches the `organizationPattern` prop, the `organizationPattern` prop takes precedence.
 

--- a/docs/_tooltips/personal-account.mdx
+++ b/docs/_tooltips/personal-account.mdx
@@ -1,0 +1,1 @@
+**Personal Accounts** are individual workspaces that allow users to operate independently without belonging to an Organization. Learn more about [Personal Accounts](/docs/guides/organizations/configure#personal-accounts).

--- a/docs/guides/configure/session-tasks.mdx
+++ b/docs/guides/configure/session-tasks.mdx
@@ -16,7 +16,7 @@ The following table lists the available tasks and their corresponding keys.
 
 | Setting | Key | Description |
 | - | - | - |
-| [Allow Personal Accounts](https://dashboard.clerk.com/~/organizations-settings) | `choose-organization` | Disabled by default when enabling Organizations. When disabled, users are required to choose an Organization after authenticating. When enabled, users can choose a Personal Account instead of an Organization. |
+| [Allow Personal Accounts](https://dashboard.clerk.com/~/organizations-settings) | `choose-organization` | Disabled by default when enabling Organizations. When disabled, users are required to choose an Organization after authenticating. When enabled, users can choose a [Personal Account](!personal-account) instead of an Organization. |
 
 ## Session states
 
@@ -36,10 +36,10 @@ The following table lists the available tasks and their corresponding components
 
 | Name | Component |
 | - | - |
-| [Personal accounts disabled (default)](/docs/guides/organizations/configure#enable-organizations) | [`<TaskChooseOrganization />`](/docs/reference/components/authentication/task-choose-organization) |
+| [Personal Accounts disabled (default)](/docs/guides/organizations/configure#enable-organizations) | [`<TaskChooseOrganization />`](/docs/reference/components/authentication/task-choose-organization) |
 
 > [!IMPORTANT]
-> Personal accounts being disabled by default was released on 08-22-2025. Applications created before this date will not be able to see the **Allow Personal Accounts** setting, because Personal Accounts were enabled by default.
+> [Personal Accounts](!personal-account) being disabled by default was released on 08-22-2025. Applications created before this date will not be able to see the **Allow Personal Accounts** setting, because Personal Accounts were enabled by default.
 
 If the prebuilt components don't meet your specific needs or if you require more control over the logic, you can also build your own UI using the `Session.currentTask` property to check if the user has pending session tasks. To access the `Session.currentTask` property, you can use either the `useSession()` hook for React-based applications or `window.Clerk` for other frameworks.
 
@@ -273,7 +273,7 @@ By default, `pending` sessions are treated as signed-out across Clerk's authenti
 
 The `useAuth()` hook and helpers that access the [`Auth` object](/docs/reference/backend/types/auth-object), such as `getAuth()` or `request.auth`, will return `null` if the user has a `pending` session. Most utilities accept a `treatPendingAsSignedOut` option that defaults to `true`. You can pass `false` to treat `pending` sessions as signed-in.
 
-#### Example: Personal accounts disabled
+#### Example: Personal Accounts disabled
 
 When Organizations are enabled, [Personal Accounts are disabled by default](/docs/guides/organizations/configure#personal-accounts) and your users will be required to select or create an Organization after authenticating. Until completed, their session remains `pending`. Pages that are protected using Clerk's protection utilities will treat the user's session as signed-out.
 

--- a/docs/guides/how-clerk-works/multi-tenant-architecture.mdx
+++ b/docs/guides/how-clerk-works/multi-tenant-architecture.mdx
@@ -32,7 +32,7 @@ B2B companies sell to other businesses. Some examples include: GitHub, Vercel, S
 
 In the B2B model, multi-tenant SaaS applications generally leverage organizations (sometimes called teams or workspaces) to manage users and their memberships. This approach allows for control over what resources users have access to across different organizations based on their Roles.
 
-Oftentimes such applications will also allow users to create Personal Accounts that are separate from other organizations. For example, GitHub allows users to create repositories under their own Personal Account or an organization they are part of.
+Oftentimes such applications will also allow users to create [Personal Accounts](!personal-account) that are separate from other organizations. For example, GitHub allows users to create repositories under their own Personal Account or an organization they are part of.
 
 The user pool for multi-tenant, SaaS applications will generally fall into one of two categories:
 

--- a/docs/guides/organizations/configure.mdx
+++ b/docs/guides/organizations/configure.mdx
@@ -16,9 +16,9 @@ Organizations are disabled by default. When you enable Organizations, Clerk offe
   > [!IMPORTANT]
   > This is the default setting since on August 22, 2025. Applications created before this date will not see the **Membership required** setting, because organization membership was optional.
 
-- **Membership optional**: Users can operate in their own individual workspace or join Organizations. They start in their Personal Account and can switch to Organizations using the [`<OrganizationSwitcher />`](/docs/reference/components/organization/organization-switcher) component. This setting is common for B2C applications moving to B2B.
+- **Membership optional**: Users can operate in their own individual workspace or join Organizations. They start in their [Personal Account](#personal-accounts) and can switch to Organizations using the [`<OrganizationSwitcher />`](/docs/reference/components/organization/organization-switcher) component. This setting is common for B2C applications moving to B2B.
 
-We recommend most B2B and multi-tenant applications require organization membership. This ensures proper data isolation and team structure from the start. You should only make membership optional if your app serves both individual users and teams (like a tool that works for solo users but also has team features).
+For most B2B and multi-tenant applications, requiring organization membership is recommended to ensure proper data isolation and team structure from the start. Making membership optional is only recommended if the application serves both individual users and teams (such as tools that work for solo users but also provide team features).
 
 To enable Organizations:
 
@@ -54,9 +54,9 @@ To change the membership limit for a specific Organization:
 
 ### Personal Accounts
 
-When enabling the Organizations feature, you were prompted to choose whether to allow Personal Accounts. This setting is disabled by default.
+When enabling the Organizations feature, you were prompted to choose whether to make membership required (the default) or optional. If you chose to make membership optional, this enabled the Personal Accounts feature.
 
-Personal Accounts are individual workspaces that allow users to operate independently without belonging to an Organization. When Personal Accounts are enabled, users start in their Personal Account by default and can switch between their Personal Account and any Organizations they belong.
+Personal Accounts are individual workspaces that allow users to operate independently without belonging to an Organization. When Personal Accounts are enabled, users start in their Personal Account by default and can switch between their Personal Account and any Organizations they belong to.
 
 **When to enable Personal Accounts:**
 
@@ -69,9 +69,9 @@ Enable Personal Accounts if your application serves both individual users and te
 
 Most B2B and multi-tenant applications should leave Personal Accounts disabled. This ensures:
 
-- Proper data isolation from the start
-- Clear team structure requirements
-- All users are part of an Organization, which is essential for proper access control and billing
+- Proper data isolation from the start.
+- Clear team structure requirements.
+- All users are part of an Organization, which is essential for proper access control and billing.
 
 **Changing this setting:**
 

--- a/docs/guides/organizations/create-and-manage.mdx
+++ b/docs/guides/organizations/create-and-manage.mdx
@@ -49,7 +49,7 @@ Users who belong to multiple Organizations can switch between them at any time. 
 
 The [`<OrganizationSwitcher />`](/docs/reference/components/organization/organization-switcher) component provides the easiest way for users to switch between Organizations. If you need more control over the switching logic, you can use the `setActive()` method from the [`useOrganizationList()`](/docs/reference/hooks/use-organization-list) hook, or access it directly from the [`Clerk`](/docs/reference/javascript/clerk#set-active) object.
 
-If [Personal Accounts are enabled](/docs/guides/organizations/configure#personal-accounts), users can switch to their Personal Account using the `<OrganizationSwitcher />` component.
+If [Personal Accounts are enabled](!personal-account), users can switch to their Personal Account using the `<OrganizationSwitcher />` component.
 
 ## Next steps
 

--- a/docs/guides/organizations/getting-started.astro.mdx
+++ b/docs/guides/organizations/getting-started.astro.mdx
@@ -143,13 +143,13 @@ Organizations let you group users with Roles and Permissions, enabling you to bu
 
   ### Enable Organizations
 
-  When prompted, select **Enable Organizations**.
+  When prompted, select **Enable Organizations**. Choose to make membership required.
 
   ### Create first user and Organization
 
   You must sign in to use Organizations. When prompted, select **Sign in to continue**. Then, authenticate to create your first user.
 
-  Since you selected disabled personal accounts when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
+  Since you chose to make membership required when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
 
   ## Create and switch Organizations
 

--- a/docs/guides/organizations/getting-started.mdx
+++ b/docs/guides/organizations/getting-started.mdx
@@ -174,13 +174,13 @@ Organizations let you group users with Roles and Permissions, enabling you to bu
 
   ### Enable Organizations
 
-  When prompted, select **Enable Organizations**.
+  When prompted, select **Enable Organizations**. Choose to make membership required.
 
   ### Create first user and Organization
 
   You must sign in to use Organizations. When prompted, select **Sign in to continue**. Then, authenticate to create your first user.
 
-  Since you selected disabled Personal Accounts when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
+  Since you chose to make membership required when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
 
   ## Create and switch Organizations
 

--- a/docs/guides/organizations/getting-started.nuxt.mdx
+++ b/docs/guides/organizations/getting-started.nuxt.mdx
@@ -119,13 +119,13 @@ Organizations let you group users with Roles and Permissions, enabling you to bu
 
   ### Enable organizations
 
-  When prompted, select **Enable Organizations**.
+  When prompted, select **Enable Organizations**. Choose to make membership required.
 
   ### Create first user and Organization
 
   You must sign in to use Organizations. When prompted, select **Sign in to continue**. Then, authenticate to create your first user.
 
-  Since you selected disabled Personal Accounts when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
+  Since you chose to make membership required when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
 
   ## Create and switch Organizations
 

--- a/docs/guides/organizations/getting-started.react-router.mdx
+++ b/docs/guides/organizations/getting-started.react-router.mdx
@@ -252,13 +252,13 @@ Organizations let you group users with Roles and Permissions, enabling you to bu
 
   ### Enable Organizations
 
-  When prompted, select **Enable Organizations**.
+  When prompted, select **Enable Organizations**. Choose to make membership required.
 
   ### Create first user and Organization
 
   You must sign in to use Organizations. When prompted, select **Sign in to continue**. Then, authenticate to create your first user.
 
-  Since you selected disabled personal accounts when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
+  Since you chose to make membership required when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
 
   ## Create and switch Organizations
 

--- a/docs/guides/organizations/getting-started.react.mdx
+++ b/docs/guides/organizations/getting-started.react.mdx
@@ -121,13 +121,13 @@ Organizations let you group users with roles and permissions, enabling you to bu
 
   ### Enable Organizations
 
-  When prompted, select **Enable Organizations**.
+  When prompted, select **Enable Organizations**. Choose to make membership required.
 
   ### Create first user and Organization
 
   You must sign in to use Organizations. When prompted, select **Sign in to continue**. Then, authenticate to create your first user.
 
-  Since you selected disabled Personal Accounts when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
+  Since you chose to make membership required when you enabled Organizations, every user must be in at least one Organization. [Clerk will prompt you](!choose-organization) to create an Organization for your user.
 
   ## Create and switch Organizations
 

--- a/docs/guides/sessions/manual-jwt-verification.mdx
+++ b/docs/guides/sessions/manual-jwt-verification.mdx
@@ -43,7 +43,7 @@ The following example uses the `authenticateRequest()` method to verify the sess
 
   ### Optional: Check for a `sts` claim
 
-  If you are using Clerk's [Organizations](/docs/guides/organizations/overview) feature and [have not enabled Personal Accounts](/docs/guides/organizations/configure#personal-accounts), users are _required to be part of an Organization before accessing your application_. If the user has completed registration, but is not yet part of an Organization, a valid session token will be created, but the token will contain a `sts` (status) claim set to `pending`. You may want to reject requests to your backend with pending statuses to ensure that users are not able to work around the Organization requirement.
+  If you are using Clerk's [Organizations](/docs/guides/organizations/overview) feature and [have not enabled Personal Accounts](!personal-account), users are _required to be part of an Organization before accessing your application_. If the user has completed registration, but is not yet part of an Organization, a valid session token will be created, but the token will contain a `sts` (status) claim set to `pending`. You may want to reject requests to your backend with pending statuses to ensure that users are not able to work around the Organization requirement.
 
   ### Finished
 

--- a/docs/reference/components/billing/checkout-button.mdx
+++ b/docs/reference/components/billing/checkout-button.mdx
@@ -6,7 +6,7 @@ sdk: react, nextjs, vue
 
 ![The \<CheckoutButton /> component renders a button that opens the checkout drawer.](/docs/images/ui-components/checkout-button.png)
 
-The `<CheckoutButton />` component renders a button that opens the checkout drawer when selected, allowing users to subscribe to a Plan for either their Personal Account or an Organization. It must be wrapped inside a [`<SignedIn />`](/docs/reference/components/control/signed-in) component to ensure the user is authenticated.
+The `<CheckoutButton />` component renders a button that opens the checkout drawer when selected, allowing users to subscribe to a Plan for either their [Personal Account](!personal-account) or an Organization. It must be wrapped inside a [`<SignedIn />`](/docs/reference/components/control/signed-in) component to ensure the user is authenticated.
 
 <Include src="_partials/billing/billing-experimental" />
 

--- a/docs/reference/components/billing/subscription-details-button.mdx
+++ b/docs/reference/components/billing/subscription-details-button.mdx
@@ -6,7 +6,7 @@ sdk: react, nextjs, vue
 
 ![The \<SubscriptionDetailsButton /> component renders a button that opens the subscription details drawer.](/docs/images/ui-components/subscription.png)
 
-The `<SubscriptionDetailsButton />` component renders a button that opens the subscription details drawer when selected, allowing users to view and manage their subscription details, whether for their Personal Account or Organization. It must be wrapped inside a [`<SignedIn />`](/docs/reference/components/control/signed-in) component to ensure the user is authenticated.
+The `<SubscriptionDetailsButton />` component renders a button that opens the subscription details drawer when selected, allowing users to view and manage their subscription details, whether for their [Personal Account](!personal-account) or Organization. It must be wrapped inside a [`<SignedIn />`](/docs/reference/components/control/signed-in) component to ensure the user is authenticated.
 
 <Include src="_partials/billing/billing-experimental" />
 

--- a/docs/reference/components/organization/organization-list.mdx
+++ b/docs/reference/components/organization/organization-list.mdx
@@ -287,7 +287,7 @@ The `<OrganizationList />` component accepts the following properties, all of wh
   - `afterSelectPersonalUrl`
   - <code>((org: [Organization][org-ref]) => string) | string</code>
 
-  The full URL or path to navigate to after selecting the [Personal Account](/docs/guides/organizations/configure#personal-accounts). Defaults to `undefined`.
+  The full URL or path to navigate to after selecting the [Personal Account](!personal-account). Defaults to `undefined`.
 
   ---
 
@@ -308,7 +308,7 @@ The `<OrganizationList />` component accepts the following properties, all of wh
   - `hidePersonal`
   - `boolean`
 
-  A boolean that controls whether `<OrganizationList />` will include the user's [Personal Account](/docs/guides/organizations/configure#personal-accounts) in the Organization list. Setting this to `true` will hide the Personal Account option, and users will only be able to switch between Organizations. Defaults to `false`.
+  A boolean that controls whether `<OrganizationList />` will include the user's [Personal Account](!personal-account) in the Organization list. Setting this to `true` will hide the Personal Account option, and users will only be able to switch between Organizations. Defaults to `false`.
 
   ---
 

--- a/docs/reference/components/organization/organization-switcher.mdx
+++ b/docs/reference/components/organization/organization-switcher.mdx
@@ -6,7 +6,7 @@ sdk: astro, chrome-extension, expo, nextjs, nuxt, react, react-router, remix, ta
 
 ![The \<OrganizationSwitcher /> component allows a user to switch between their account types - their Personal Account and their joined Organizations.](/docs/images/ui-components/organization-switcher.png){{ style: { maxWidth: '436px' } }}
 
-The `<OrganizationSwitcher />` component allows a user to switch between their joined Organizations. If [Personal Accounts are enabled](/docs/guides/organizations/configure#personal-accounts), users can also switch to their Personal Account. This component is useful for applications that have a multi-tenant architecture, where users can be part of multiple Organizations. It handles all Organization-related flows, including full Organization management for admins. Learn more about [Organizations](/docs/guides/organizations/overview).
+The `<OrganizationSwitcher />` component allows a user to switch between their joined Organizations. If [Personal Accounts are enabled](!personal-account), users can also switch to their Personal Account. This component is useful for applications that have a multi-tenant architecture, where users can be part of multiple Organizations. It handles all Organization-related flows, including full Organization management for admins. Learn more about [Organizations](/docs/guides/organizations/overview).
 
 <If
   sdk={["astro", "chrome-extension", "expo", "nextjs", "nuxt", "react", "react-router", "remix", "tanstack-react-start", "vue"]}
@@ -287,7 +287,7 @@ The `<OrganizationSwitcher />` component accepts the following properties, all o
   - `hidePersonal`
   - `boolean`
 
-  A boolean that controls whether `<OrganizationSwitcher />` will include the user's [Personal Account](/docs/guides/organizations/configure#personal-accounts) in the Organization list. Setting this to `true` will hide the Personal Account option, and users will only be able to switch between Organizations. Defaults to `false`.
+  A boolean that controls whether `<OrganizationSwitcher />` will include the user's [Personal Account](!personal-account) in the Organization list. Setting this to `true` will hide the Personal Account option, and users will only be able to switch between Organizations. Defaults to `false`.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/laura-update-allow-personal-accounts-section/guides/organizations/configure#personal-accounts

### What does this solve?

Resolves ORGS-1121

The Dashboard UI + enable orgs SDK modal is going to be updated to contain a radio group with two options: 
- Membership required
- Membership optional 

Dashboard preview: https://dashboard-aagv0tv39.clerkstage.dev/ + [PR](https://github.com/clerk/dashboard/pull/7802)


### What changed?

- Update mentions of "toggle allow personal account" to account for new radio group UI
- Clarify what are personal accounts are so users can get more context when linking from the Dashboard

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
