### PR TITLE
Update Android SDK package names in documentation for clarity

### DIFF
--- a/docs/reference/views/overview.mdx
+++ b/docs/reference/views/overview.mdx
@@ -27,7 +27,7 @@ Clerk offers a comprehensive suite of views designed to seamlessly integrate aut
       // Only if you're using the Clerk API without the Clerk UI components
       implementation("com.clerk:clerk-android-api:<latest-version>")
       
-      implementation("com.clerk:clerk-androidui:<latest-version>")
+      implementation("com.clerk:clerk-android-ui:<latest-version>")
   }
   ```
 


### PR DESCRIPTION
This pull request updates the documentation to reflect new package names for the Clerk Android SDK. The changes clarify which packages should be used for integrating Clerk's core functionality and UI components.

Documentation updates for Clerk Android SDK packages:

* Updated references from `com.clerk:clerk-api` and `com.clerk:clerk-ui` to `com.clerk:clerk-android-api` and `com.clerk:clerk-android-ui` throughout the documentation to match the new package naming conventions.
* Corrected the Gradle dependency example to use the new package names, ensuring developers add the appropriate dependencies in their projects.