### PR TITLE
Fix frontmatter search keywords for session tasks guide

### DIFF
--- a/docs/guides/configure/session-tasks.mdx
+++ b/docs/guides/configure/session-tasks.mdx
@@ -2,7 +2,8 @@
 title: Tasks after sign-up/sign-in
 description: Learn how to configure your application to require users to complete specific tasks after signing up or signing in.
 search:
-  keywords: session tasks
+  keywords:
+    - session tasks
 ---
 
 **Session tasks** are pending requirements that users must complete after authentication, such as choosing an Organization. When enabled in the Clerk Dashboard, these tasks are handled automatically within the `<SignIn />` and `<SignUp />` components.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/nick-fix-session-tasks-frontmatter/guides/configure/session-tasks

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- The yaml doesn't match the sites zod schema so the page 500s

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- changed the yaml to conform to the zod schema

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
