### PR TITLE
fix: Remove wrap: false from API Keys link

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3279,7 +3279,6 @@
                         {
                           "title": "`<AuthenticateWithRedirectCallback />`",
                           "wrap": false,
-                          "tag": "(Beta)",
                           "href": "/docs/reference/components/control/authenticate-with-redirect-callback"
                         },
                         {


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/alexcarpenter-remove-api-keys-wrap/chrome-extension/reference/components/api-keys

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- Removes wrap: false from API Keys link in the nav

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

-

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
