### PR TITLE
Include the page title and description on sdk redirect pages

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1365,7 +1365,8 @@ This document is available for React and Next.js.`,
     // Verify landing page content
     expect(await readFile(pathJoin('./dist/sdk-document.mdx'))).toBe(
       `---
-title: SDK Document
+metadata:
+  title: SDK Document
 description: This document is available for React and Next.js.
 template: wide
 redirectPage: "true"
@@ -7003,7 +7004,8 @@ Documentation specific to React.js
 `)
 
     expect(await readFile('./dist/api-doc.mdx')).toBe(`---
-title: API Documentation
+metadata:
+  title: API Documentation
 description: x
 template: wide
 redirectPage: "true"
@@ -7103,7 +7105,8 @@ Documentation specific to React
 `)
 
     expect(await readFile('./dist/test.mdx')).toBe(`---
-title: Documentation
+metadata:
+  title: Documentation
 template: wide
 redirectPage: "true"
 availableSdks: react,nextjs

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -965,7 +965,7 @@ export async function build(config: BuildConfig, store: Store = createBlankStore
             doc.file.filePathInDocsFolder,
             `---
 ${yaml.stringify({
-  title: doc.frontmatter.title,
+  metadata: { title: doc.frontmatter.title },
   description: doc.frontmatter.description,
   template: 'wide',
   redirectPage: 'true',


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/nick-redirect-pages-metadata/reference/components/authentication/sign-in

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- Currently the `<SDKDocRedirectPage />` pages don't have page titles

example:
[<img width="433" height="112" alt="Screenshot 2025-12-17 at 2 14 03 PM" src="https://github.com/user-attachments/assets/a9af746f-df32-4aba-a32e-5fdce90f6bb9" />](https://clerk.com/docs/reference/components/authentication/sign-in)

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- This embeds the page titles in to the markdown for the site to use

example:
[<img width="433" height="98" alt="image" src="https://github.com/user-attachments/assets/a9ac127f-c550-405d-ae4e-f48e60b4453f" />](https://clerk.com/docs/pr/nick-redirect-pages-metadata/reference/components/authentication/sign-in)

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
