### PR TITLE
feat: Add do not merge workflow

### DIFF
--- a/.github/workflows/check-do-not-merge.yml
+++ b/.github/workflows/check-do-not-merge.yml
@@ -1,0 +1,20 @@
+name: Check for 'do not merge' label
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  allow-merge:
+    name: Allow Merge
+    runs-on: ubuntu-latest
+    env:
+      should_block: ${{ contains(github.event.*.labels.*.name, 'do not merge') }}
+    steps:
+      - name: Check for label
+        run: |
+          if [[ "$should_block" = "true" ]]; then
+            exit 1
+          else
+            exit 0
+          fi


### PR DESCRIPTION
### 🔎 Previews:

Saw this workflow in the clerk_go repo and thought it'd be handy here to. I want to mark a PR as ready for review but don't want to merge it, so we typically have to update the title with DO NOT MERGE. But imo, the label `do not merge` is a nice way to handle this flow.

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

-

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

-

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
