### PR TITLE
Removes `docsIAv2` flag

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,1 +1,1 @@
-{ "docsIAv2": true }
+{}


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/manovotny-docs-11268-remove-srcappwebsite-c1b068

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

Removing the feature flag introduced in #2857. It's no longer needed now that we've launched and some time has passed.

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

Removed `docsIAv2` from `flags.json`.

### Deadline

~https://github.com/clerk/clerk/pull/1935 needs to be merged first. Otherwise, it will revert to the old sidebar nav.~ Merged! ✅ 

The preview link above will show the old nav until that's merged.