### PR TITLE
Fix formatting in Postman or Insomnia testing guide

### DIFF
--- a/docs/guides/development/testing/postman-or-insomnia.mdx
+++ b/docs/guides/development/testing/postman-or-insomnia.mdx
@@ -22,7 +22,7 @@ Give your template a unique name, such as _'testing-template'_. Set the **Token 
 Visit your frontend that is using the same Clerk Application and instance that you want to test. Sign in as a user. The user that you sign in as will be the user you test with in Postman or Insomnia. You can create several tokens for several different users. Once you have signed in, open your Dev Tools and go to the **Console** tab. Enter the following command:
 
 ```js
-await window.Clerk.session.getToken({ template: '<the template name you chose above>' })
+await window.Clerk.session.getToken({ jwt_template: '<the template name you chose above>' })
 ```
 
 ![The Dev Tools Console with the command 'await window.Clerk.session.getToken()' entered. The token is logged to the console](/docs/images/testing/get-token-from-console.webp)


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/guides/development/testing/postman-or-insomnia

### What does this solve?

- Critical Postman/Insomnia Testing Step

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->
- Following is the screenshot which show that existing key name is not able to fetch jwt_template token. 
<img width="1917" height="378" alt="image" src="https://github.com/user-attachments/assets/a05f44d4-527e-402d-a46b-66d4e597a1c5" />


### What changed?
<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->
- With existing command, we are not able to fetch jwt_token, and with given fix it solve the problem.

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
