### PR TITLE
Correct DMARC claim in docs

### DIFF
--- a/docs/guides/development/troubleshooting/email-deliverability.mdx
+++ b/docs/guides/development/troubleshooting/email-deliverability.mdx
@@ -7,7 +7,7 @@ A lot goes into making sure verification emails make it to your customers as qui
 
 In development instances, all emails are sent from `@accounts.dev` domain. In production instances, they are sent from your own domain e.g. `@example.com`.
 
-During production instance set up, Clerk will have you set up the required records to configure `SPF` and `DKIM` for security and deliverability. We also recommend [setting up `DMARC`](#setup-dmarc-email-authentication) for additional security and deliverability.
+During production instance set up, Clerk will have you set up the required records to configure `SPF` and `DKIM` for security and deliverability. It's also recommended to [set up `DMARC`](#setup-dmarc-email-authentication) for additional security and deliverability.
 
 ## Best practices
 


### PR DESCRIPTION
The docs previously claimed that Clerk would have you set up DNS records for DMARC, which is not true. This small PR corrects that claim.

### 🔎 Previews:

- https://clerk.com/docs/pr/jedmarc-correction/guides/development/troubleshooting/email-deliverability