### PR TITLE
Adds to `Migrate from Firebase` on `Integrate Firebase with Clerk` deprecation callout/warning

### DIFF
--- a/docs/guides/development/integrations/databases/firebase.mdx
+++ b/docs/guides/development/integrations/databases/firebase.mdx
@@ -32,6 +32,8 @@ description: Learn how to integrate Clerk into your Firebase application.
 
 > [!WARNING]
 > The Firebase integration is no longer supported and maintained. For new applications, you **cannot** enable the integration. However, existing applications with the integration previously enabled will continue to function and can still be configured, but once disabled, **it cannot be re-enabled**.
+>
+> Learn how to [migrate your Firebase users to Clerk](/docs/guides/development/migrating/firebase).
 
 Integrating Firebase with Clerk gives you the benefits of using Firebase's features while leveraging Clerk's authentication, prebuilt components, and webhooks.
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/manovotny-docs-11356-add-link-to-migrate-d1a1fe/guides/development/integrations/databases/firebase

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- Users are missing that there's an optional migration path forward ([example](https://x.com/krutosh/status/2008249521286062311)).

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Adds a link on the integration page pointing to the migration page.

<img width="1532" height="1354" alt="CleanShot 2026-01-05 at 17 07 37@2x" src="https://github.com/user-attachments/assets/312db72e-26d2-4e7f-9f68-c1784ea3adb1" />