### PR TITLE
Handle `redirect_url` with custom SSO button

### DIFF
--- a/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
@@ -40,16 +40,17 @@ You must configure your application instance through the Clerk Dashboard for the
     1. Include them in the `redirectUrl` (SSO callback URL) so they survive the OAuth round-trip
     1. Use them to determine the `redirectUrlComplete`
 
-    The SSO callback URL acts as an intermediate stop—when the OAuth provider redirects back to this URL, your SSO callback page must read the preserved parameters from the URL and pass them as props to the `<AuthenticateWithRedirectCallback>` component. This is required because `handleRedirectCallback` doesn't automatically read redirect parameters from the URL query string.
+    The SSO callback URL acts as an intermediate stop.
+    When the OAuth provider redirects back to this URL, `handleRedirectCallback()` automatically reads the redirect parameters from the URL query string to determine where to navigate after authentication completes.
 
     <CodeBlockTabs options={["Sign in page", "SSO callback page"]}>
       ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
       'use client'
 
       import * as React from 'react'
-      import { OAuthStrategy } from '@clerk/types'
       import { useSignIn } from '@clerk/nextjs'
       import { useSearchParams } from 'next/navigation'
+      import type { OAuthStrategy } from '@clerk/types'
 
       // Redirect parameter keys that should be preserved through the OAuth flow
       const PRESERVED_REDIRECT_PARAMS = [
@@ -58,8 +59,6 @@ You must configure your application instance through the Clerk Dashboard for the
         'sign_in_force_redirect_url',
         'sign_up_fallback_redirect_url',
         'sign_up_force_redirect_url',
-        'after_sign_in_url',
-        'after_sign_up_url',
       ] as const
 
       export default function Page() {
@@ -68,12 +67,10 @@ You must configure your application instance through the Clerk Dashboard for the
 
         if (!signIn) return null
 
-        // Build the SSO callback URL with preserved redirect parameters
-        // This ensures redirect information survives the OAuth round-trip
-        const buildSSOCallbackURL = (): string => {
+        const signInWith = (strategy: OAuthStrategy) => {
+          // Build the SSO callback URL with preserved redirect parameters
+          // This ensures redirect information survives the OAuth round-trip
           const callbackUrl = new URL('/sign-in/sso-callback', window.location.origin)
-
-          // Preserve any redirect parameters from the current URL
           for (const param of PRESERVED_REDIRECT_PARAMS) {
             const value = searchParams.get(param)
             if (value) {
@@ -81,46 +78,26 @@ You must configure your application instance through the Clerk Dashboard for the
             }
           }
 
-          return callbackUrl.toString()
-        }
+          // Determine where to navigate after OAuth completes
+          // Priority: redirect_url > sign_in_force_redirect_url > sign_in_fallback_redirect_url > default
+          const redirectUrlComplete =
+            searchParams.get('redirect_url') ||
+            searchParams.get('sign_in_force_redirect_url') ||
+            searchParams.get('sign_in_fallback_redirect_url') ||
+            '/'
 
-        // Determine where to navigate after OAuth completes
-        // Priority: redirect_url > sign_in_force_redirect_url > sign_in_fallback_redirect_url > default
-        const getRedirectUrlComplete = (): string => {
-          // redirect_url takes highest priority (e.g., from OAuth App integration flows)
-          const redirectUrl = searchParams.get('redirect_url')
-          if (redirectUrl) return redirectUrl
-
-          // Force redirect URL always wins when set
-          const forceRedirect = searchParams.get('sign_in_force_redirect_url')
-          if (forceRedirect) return forceRedirect
-
-          // Fallback redirect URL is used when no higher-priority redirect is set
-          const fallbackRedirect = searchParams.get('sign_in_fallback_redirect_url')
-          if (fallbackRedirect) return fallbackRedirect
-
-          // Default: navigate to session tasks page to handle any pending tasks
-          // Learn more: https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
-          return '/sign-in/tasks'
-        }
-
-        const signInWith = (strategy: OAuthStrategy) => {
           return signIn
             .authenticateWithRedirect({
               strategy,
               // The SSO callback URL with preserved redirect parameters
-              redirectUrl: buildSSOCallbackURL(),
+              redirectUrl: callbackUrl.toString(),
               // Where to navigate after the OAuth flow completes
-              redirectUrlComplete: getRedirectUrlComplete(),
-            })
-            .then((res) => {
-              console.log(res)
+              redirectUrlComplete,
             })
             .catch((err: any) => {
               // See https://clerk.com/docs/guides/development/custom-flows/error-handling
               // for more info on error handling
-              console.log(err.errors)
-              console.error(err, null, 2)
+              console.error(JSON.stringify(err, null, 2))
             })
         }
 
@@ -138,29 +115,13 @@ You must configure your application instance through the Clerk Dashboard for the
       'use client'
 
       import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
-      import { useSearchParams } from 'next/navigation'
 
       export default function Page() {
-        const searchParams = useSearchParams()
-
-        // Read redirect parameters from the URL and pass them as props
-        // The handleRedirectCallback method doesn't read from URL search params automatically,
-        // so we must explicitly pass these values
-        const redirectUrl = searchParams.get('redirect_url') ?? undefined
-        const signInFallbackRedirectUrl = searchParams.get('sign_in_fallback_redirect_url') ?? undefined
-        const signInForceRedirectUrl = searchParams.get('sign_in_force_redirect_url') ?? undefined
-        const signUpFallbackRedirectUrl = searchParams.get('sign_up_fallback_redirect_url') ?? undefined
-        const signUpForceRedirectUrl = searchParams.get('sign_up_force_redirect_url') ?? undefined
-
+        // handleRedirectCallback() automatically reads redirect parameters
+        // from the URL query string (e.g., redirect_url, sign_in_fallback_redirect_url)
         return (
           <>
-            <AuthenticateWithRedirectCallback
-              redirectUrl={redirectUrl}
-              signInFallbackRedirectUrl={signInFallbackRedirectUrl}
-              signInForceRedirectUrl={signInForceRedirectUrl}
-              signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
-              signUpForceRedirectUrl={signUpForceRedirectUrl}
-            />
+            <AuthenticateWithRedirectCallback />
 
             {/* Required for sign-up flows
             Clerk's bot sign-up protection is enabled by default */}
@@ -585,20 +546,10 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
       export default function Page() {
         const searchParams = useSearchParams()
 
-        // Read redirect parameters from the URL
-        // The handleRedirectCallback method doesn't read from URL search params automatically,
-        // so we must explicitly pass these values as props
-        const redirectUrl = searchParams.get('redirect_url') ?? undefined
-        const signInFallbackRedirectUrl = searchParams.get('sign_in_fallback_redirect_url') ?? undefined
-        const signInForceRedirectUrl = searchParams.get('sign_in_force_redirect_url') ?? undefined
-        const signUpFallbackRedirectUrl = searchParams.get('sign_up_fallback_redirect_url') ?? undefined
-        const signUpForceRedirectUrl = searchParams.get('sign_up_force_redirect_url') ?? undefined
-
         // Build the continue URL with preserved redirect parameters
         // This ensures redirect information is available on the continue page
         const buildContinueSignUpUrl = (): string => {
-          // Use a placeholder base URL since we only need the path and search params
-          const continueUrl = new URL('/sign-in/continue', 'http://placeholder')
+          const continueUrl = new URL('/sign-in/continue', window.location.origin)
 
           // Preserve any redirect parameters from the current URL
           for (const param of PRESERVED_REDIRECT_PARAMS) {
@@ -611,20 +562,13 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
           return continueUrl.pathname + continueUrl.search
         }
 
-        // Set the `continueSignUpUrl` to the route of your "Continue" page
-        // Once a user authenticates with the OAuth provider, they will be redirected to that route
+        // handleRedirectCallback() automatically reads redirect parameters from URL query string
+        // Set `continueSignUpUrl` to the route of your "Continue" page for handling missing requirements
         // The URL includes preserved redirect parameters so the continue page knows where to
-        // navigate after the sign-up is complete
+        // navigate after sign-up is complete
         return (
           <>
-            <AuthenticateWithRedirectCallback
-              continueSignUpUrl={buildContinueSignUpUrl()}
-              redirectUrl={redirectUrl}
-              signInFallbackRedirectUrl={signInFallbackRedirectUrl}
-              signInForceRedirectUrl={signInForceRedirectUrl}
-              signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
-              signUpForceRedirectUrl={signUpForceRedirectUrl}
-            />
+            <AuthenticateWithRedirectCallback continueSignUpUrl={buildContinueSignUpUrl()} />
 
             {/* Required for sign-up flows
             Clerk's bot sign-up protection is enabled by default */}

--- a/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
@@ -597,7 +597,8 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
         // Build the continue URL with preserved redirect parameters
         // This ensures redirect information is available on the continue page
         const buildContinueSignUpUrl = (): string => {
-          const continueUrl = new URL('/sign-in/continue', window.location.origin)
+          // Use a placeholder base URL since we only need the path and search params
+          const continueUrl = new URL('/sign-in/continue', 'http://placeholder')
 
           // Preserve any redirect parameters from the current URL
           for (const param of PRESERVED_REDIRECT_PARAMS) {

--- a/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
@@ -21,6 +21,27 @@ You must configure your application instance through the Clerk Dashboard for the
 
     <Include src="_partials/custom-flows/sso-connections" />
 
+    ### Understanding redirect URLs
+
+    When calling `authenticateWithRedirect()`, you must provide two redirect URLs:
+
+    - **`redirectUrl`**: The URL the OAuth provider redirects back to after authentication. This is your SSO callback page (e.g., `/sign-in/sso-callback`). This URL should include any redirect parameters that need to be preserved through the OAuth flow.
+    - **`redirectUrlComplete`**: The final destination URL after the entire OAuth flow completes successfully.
+
+    #### Preserving redirect parameters
+
+    When users are redirected to your sign-in page, they may arrive with query parameters like `redirect_url` (e.g., from an [OAuth App integration flow](/docs/guides/configure/auth-strategies/oauth/scoped-access)),
+    or `sign_in_fallback_redirect_url`.
+    These parameters specify where the user should be redirected after authentication.
+
+    To properly handle these scenarios, you must:
+
+    1. Read any redirect parameters from the current URL
+    1. Include them in the `redirectUrl` (SSO callback URL) so they survive the OAuth round-trip
+    1. Use them to determine the `redirectUrlComplete`
+
+    The SSO callback URL acts as an intermediate stop—when the OAuth provider redirects back to this URL, Clerk's callback handler reads the preserved parameters and uses them to complete the navigation.
+
     <CodeBlockTabs options={["Sign in page", "SSO callback page"]}>
       ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
       'use client'
@@ -28,27 +49,69 @@ You must configure your application instance through the Clerk Dashboard for the
       import * as React from 'react'
       import { OAuthStrategy } from '@clerk/types'
       import { useSignIn } from '@clerk/nextjs'
-      import { useSearchParams } from "next/navigation";
+      import { useSearchParams } from 'next/navigation'
+
+      // Redirect parameter keys that should be preserved through the OAuth flow
+      const PRESERVED_REDIRECT_PARAMS = [
+        'redirect_url',
+        'sign_in_fallback_redirect_url',
+        'sign_in_force_redirect_url',
+        'sign_up_fallback_redirect_url',
+        'sign_up_force_redirect_url',
+        'after_sign_in_url',
+        'after_sign_up_url',
+      ] as const
 
       export default function Page() {
         const { signIn } = useSignIn()
+        const searchParams = useSearchParams()
 
         if (!signIn) return null
 
-        const searchParams = useSearchParams();
-        const redirectUrl = searchParams.get("redirect_url");
-        const redirectUrlComplete =
-          // If a redirect URL is provided it should be handled to e.g. enable OAuth App integration flows
-          redirectUrl || 
-          // Learn more about session tasks at https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
-          '/sign-in/tasks',
+        // Build the SSO callback URL with preserved redirect parameters
+        // This ensures redirect information survives the OAuth round-trip
+        const buildSSOCallbackURL = (): string => {
+          const callbackUrl = new URL('/sign-in/sso-callback', window.location.origin)
+
+          // Preserve any redirect parameters from the current URL
+          for (const param of PRESERVED_REDIRECT_PARAMS) {
+            const value = searchParams.get(param)
+            if (value) {
+              callbackUrl.searchParams.set(param, value)
+            }
+          }
+
+          return callbackUrl.toString()
+        }
+
+        // Determine where to navigate after OAuth completes
+        // Priority: redirect_url > sign_in_force_redirect_url > sign_in_fallback_redirect_url > default
+        const getRedirectUrlComplete = (): string => {
+          // redirect_url takes highest priority (e.g., from OAuth App integration flows)
+          const redirectUrl = searchParams.get('redirect_url')
+          if (redirectUrl) return redirectUrl
+
+          // Force redirect URL always wins when set
+          const forceRedirect = searchParams.get('sign_in_force_redirect_url')
+          if (forceRedirect) return forceRedirect
+
+          // Fallback redirect URL is used when no higher-priority redirect is set
+          const fallbackRedirect = searchParams.get('sign_in_fallback_redirect_url')
+          if (fallbackRedirect) return fallbackRedirect
+
+          // Default: navigate to session tasks page to handle any pending tasks
+          // Learn more: https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
+          return '/sign-in/tasks'
+        }
 
         const signInWith = (strategy: OAuthStrategy) => {
           return signIn
             .authenticateWithRedirect({
               strategy,
-              redirectUrl: '/sign-in/sso-callback',
-              redirectUrlComplete
+              // The SSO callback URL with preserved redirect parameters
+              redirectUrl: buildSSOCallbackURL(),
+              // Where to navigate after the OAuth flow completes
+              redirectUrlComplete: getRedirectUrlComplete(),
             })
             .then((res) => {
               console.log(res)
@@ -77,6 +140,8 @@ You must configure your application instance through the Clerk Dashboard for the
       export default function Page() {
         // Handle the redirect flow by calling the Clerk.handleRedirectCallback() method
         // or rendering the prebuilt <AuthenticateWithRedirectCallback/> component.
+        // The component reads the preserved redirect parameters from the URL and
+        // handles navigation to the final destination.
         return (
           <>
             <AuthenticateWithRedirectCallback />
@@ -369,10 +434,11 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
 
       import { useState } from 'react'
       import { useSignUp } from '@clerk/nextjs'
-      import { useRouter } from 'next/navigation'
+      import { useRouter, useSearchParams } from 'next/navigation'
 
       export default function Page() {
         const router = useRouter()
+        const searchParams = useSearchParams()
         // Use `useSignUp()` hook to access the `SignUp` object
         // `missing_requirements` and `missingFields` are only available on the `SignUp` object
         const { isLoaded, signUp, setActive } = useSignUp()
@@ -386,6 +452,25 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
 
         const status = signUp?.status
         const missingFields = signUp?.missingFields ?? []
+
+        // Determine where to navigate after sign-up completes
+        // Priority: redirect_url > sign_up_force_redirect_url > sign_up_fallback_redirect_url > default
+        const getRedirectUrlComplete = (): string => {
+          // redirect_url takes highest priority (e.g., from OAuth App integration flows)
+          const redirectUrl = searchParams.get('redirect_url')
+          if (redirectUrl) return redirectUrl
+
+          // Force redirect URL always wins when set
+          const forceRedirect = searchParams.get('sign_up_force_redirect_url')
+          if (forceRedirect) return forceRedirect
+
+          // Fallback redirect URL is used when no higher-priority redirect is set
+          const fallbackRedirect = searchParams.get('sign_up_fallback_redirect_url')
+          if (fallbackRedirect) return fallbackRedirect
+
+          // Default destination
+          return '/'
+        }
 
         const handleChange = (field: string, value: string) => {
           setFormData((prev) => ({ ...prev, [field]: value }))
@@ -410,7 +495,8 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
                     return
                   }
 
-                  router.push('/')
+                  // Navigate to the appropriate redirect URL
+                  router.push(getRedirectUrlComplete())
                 },
               })
             }
@@ -466,14 +552,46 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
       ```
 
       ```tsx {{ filename: 'app/sign-in/sso-callback/page.tsx' }}
+      'use client'
+
       import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
+      import { useSearchParams } from 'next/navigation'
+
+      // Redirect parameter keys that should be preserved when navigating to the continue page
+      const PRESERVED_REDIRECT_PARAMS = [
+        'redirect_url',
+        'sign_in_fallback_redirect_url',
+        'sign_in_force_redirect_url',
+        'sign_up_fallback_redirect_url',
+        'sign_up_force_redirect_url',
+      ] as const
 
       export default function Page() {
+        const searchParams = useSearchParams()
+
+        // Build the continue URL with preserved redirect parameters
+        // This ensures redirect information is available on the continue page
+        const buildContinueSignUpUrl = (): string => {
+          const continueUrl = new URL('/sign-in/continue', window.location.origin)
+
+          // Preserve any redirect parameters from the current URL
+          for (const param of PRESERVED_REDIRECT_PARAMS) {
+            const value = searchParams.get(param)
+            if (value) {
+              continueUrl.searchParams.set(param, value)
+            }
+          }
+
+          return continueUrl.pathname + continueUrl.search
+        }
+
         // Set the `continueSignUpUrl` to the route of your "Continue" page
         // Once a user authenticates with the OAuth provider, they will be redirected to that route
+        // The URL includes preserved redirect parameters so the continue page knows where to
+        // navigate after the sign-up is complete
         return (
           <>
-            <AuthenticateWithRedirectCallback continueSignUpUrl="/sign-in/continue" />
+            <AuthenticateWithRedirectCallback continueSignUpUrl={buildContinueSignUpUrl()} />
 
             {/* Required for sign-up flows
             Clerk's bot sign-up protection is enabled by default */}

--- a/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
@@ -28,18 +28,27 @@ You must configure your application instance through the Clerk Dashboard for the
       import * as React from 'react'
       import { OAuthStrategy } from '@clerk/types'
       import { useSignIn } from '@clerk/nextjs'
+      import { useSearchParams } from "next/navigation";
 
       export default function Page() {
         const { signIn } = useSignIn()
 
         if (!signIn) return null
 
+        const searchParams = useSearchParams();
+        const redirectUrl = searchParams.get("redirect_url");
+        const redirectUrlComplete =
+          // If a redirect URL is provided it should be handled to e.g. enable OAuth App integration flows
+          redirectUrl || 
+          // Learn more about session tasks at https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
+          '/sign-in/tasks',
+
         const signInWith = (strategy: OAuthStrategy) => {
           return signIn
             .authenticateWithRedirect({
               strategy,
               redirectUrl: '/sign-in/sso-callback',
-              redirectUrlComplete: '/sign-in/tasks', // Learn more about session tasks at https://clerk.com/docs/guides/development/custom-flows/overview#session-tasks
+              redirectUrlComplete
             })
             .then((res) => {
               console.log(res)

--- a/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/oauth-connections.mdx
@@ -40,7 +40,7 @@ You must configure your application instance through the Clerk Dashboard for the
     1. Include them in the `redirectUrl` (SSO callback URL) so they survive the OAuth round-trip
     1. Use them to determine the `redirectUrlComplete`
 
-    The SSO callback URL acts as an intermediate stop—when the OAuth provider redirects back to this URL, Clerk's callback handler reads the preserved parameters and uses them to complete the navigation.
+    The SSO callback URL acts as an intermediate stop—when the OAuth provider redirects back to this URL, your SSO callback page must read the preserved parameters from the URL and pass them as props to the `<AuthenticateWithRedirectCallback>` component. This is required because `handleRedirectCallback` doesn't automatically read redirect parameters from the URL query string.
 
     <CodeBlockTabs options={["Sign in page", "SSO callback page"]}>
       ```tsx {{ filename: 'app/sign-in/[[...sign-in]]/page.tsx' }}
@@ -135,16 +135,32 @@ You must configure your application instance through the Clerk Dashboard for the
       ```
 
       ```tsx {{ filename: 'app/sign-in/sso-callback/page.tsx' }}
+      'use client'
+
       import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
+      import { useSearchParams } from 'next/navigation'
 
       export default function Page() {
-        // Handle the redirect flow by calling the Clerk.handleRedirectCallback() method
-        // or rendering the prebuilt <AuthenticateWithRedirectCallback/> component.
-        // The component reads the preserved redirect parameters from the URL and
-        // handles navigation to the final destination.
+        const searchParams = useSearchParams()
+
+        // Read redirect parameters from the URL and pass them as props
+        // The handleRedirectCallback method doesn't read from URL search params automatically,
+        // so we must explicitly pass these values
+        const redirectUrl = searchParams.get('redirect_url') ?? undefined
+        const signInFallbackRedirectUrl = searchParams.get('sign_in_fallback_redirect_url') ?? undefined
+        const signInForceRedirectUrl = searchParams.get('sign_in_force_redirect_url') ?? undefined
+        const signUpFallbackRedirectUrl = searchParams.get('sign_up_fallback_redirect_url') ?? undefined
+        const signUpForceRedirectUrl = searchParams.get('sign_up_force_redirect_url') ?? undefined
+
         return (
           <>
-            <AuthenticateWithRedirectCallback />
+            <AuthenticateWithRedirectCallback
+              redirectUrl={redirectUrl}
+              signInFallbackRedirectUrl={signInFallbackRedirectUrl}
+              signInForceRedirectUrl={signInForceRedirectUrl}
+              signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
+              signUpForceRedirectUrl={signUpForceRedirectUrl}
+            />
 
             {/* Required for sign-up flows
             Clerk's bot sign-up protection is enabled by default */}
@@ -569,6 +585,15 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
       export default function Page() {
         const searchParams = useSearchParams()
 
+        // Read redirect parameters from the URL
+        // The handleRedirectCallback method doesn't read from URL search params automatically,
+        // so we must explicitly pass these values as props
+        const redirectUrl = searchParams.get('redirect_url') ?? undefined
+        const signInFallbackRedirectUrl = searchParams.get('sign_in_fallback_redirect_url') ?? undefined
+        const signInForceRedirectUrl = searchParams.get('sign_in_force_redirect_url') ?? undefined
+        const signUpFallbackRedirectUrl = searchParams.get('sign_up_fallback_redirect_url') ?? undefined
+        const signUpForceRedirectUrl = searchParams.get('sign_up_force_redirect_url') ?? undefined
+
         // Build the continue URL with preserved redirect parameters
         // This ensures redirect information is available on the continue page
         const buildContinueSignUpUrl = (): string => {
@@ -591,7 +616,14 @@ With OAuth flows, it's common for users to try to _sign in_ with an OAuth provid
         // navigate after the sign-up is complete
         return (
           <>
-            <AuthenticateWithRedirectCallback continueSignUpUrl={buildContinueSignUpUrl()} />
+            <AuthenticateWithRedirectCallback
+              continueSignUpUrl={buildContinueSignUpUrl()}
+              redirectUrl={redirectUrl}
+              signInFallbackRedirectUrl={signInFallbackRedirectUrl}
+              signInForceRedirectUrl={signInForceRedirectUrl}
+              signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
+              signUpForceRedirectUrl={signUpForceRedirectUrl}
+            />
 
             {/* Required for sign-up flows
             Clerk's bot sign-up protection is enabled by default */}


### PR DESCRIPTION
because when the SSO button is used in an OAuth App (3rd party integration) flow, the user must be redirected to the consent page / 3rd party callback page. (This is a little confusing because the OAuth app here is not the same as the OAuth provider/strategy for the SSO button)

### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

-

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

-

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
