### PR TITLE
Change tab naming for MCP server guide

### DIFF
--- a/docs/guides/development/mcp/connect-mcp-client.mdx
+++ b/docs/guides/development/mcp/connect-mcp-client.mdx
@@ -36,7 +36,7 @@ To complete the integration, you'll need to connect an MCP-compatible client to 
 
     1. Navigate to **Cursor Settings**. To find this, open the **Command Palette** (`Cmd/Ctrl + Shift + P`) and search for **Cursor Settings**, or select the gear icon in the top right corner of the app.
     1. In the sidenav, select **Tools & MCP**. If you don't see this, you may need to update Cursor to the latest version.
-    1. Click the **New MCP Server** button, which will open up a new tab with the MCP configuration JSON file.
+    1. Select the **New MCP Server** option, which will open up a new tab with the MCP configuration JSON file.
     1. Add the following configuration to the JSON file:
 
     ```json


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

While reviewing this PR, I noticed that the tab in Cursor settings for MCP had changed naming (**Tools & MCP**), and our docs was still referring to the old naming (**Tools & Integrations**). 

This PR makes sure we align with the new naming. 
