### PR TITLE
chore: Replace inline link with custom `<AddToCursorButton />`

### DIFF
--- a/docs/guides/development/mcp/clerk-mcp-server.mdx
+++ b/docs/guides/development/mcp/clerk-mcp-server.mdx
@@ -20,7 +20,10 @@ To complete the integration, you'll need to connect your AI agent to Clerk's MCP
 <Tabs items={["Cursor", "Claude", "VSCode", "Windsurf", "Zed", "Codex", "Other clients"]}>
   <Tab>
     ### Connecting Cursor to Clerk's MCP server
-    <AddToCursorButton href="https://cursor.com/en-US/install-mcp?name=clerk&config=eyJ1cmwiOiJodHRwczovL21jcC5jbGVyay5jb20vbWNwIn0%3D" />
+
+    <AddToCursorButton
+      href="https://cursor.com/en-US/install-mcp?name=clerk&config=eyJ1cmwiOiJodHRwczovL21jcC5jbGVyay5jb20vbWNwIn0%3D"
+    />
 
     Alternatively, you can manually configure it:
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk-git-alexcarpenter-add-to-cursor-button.clerkstage.dev/docs/pr/alexcarpenter-add-to-cursor-button/guides/development/mcp/clerk-mcp-server

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- Replace inline line with lined image to custom `<AddToCursorButton />`
- https://github.com/clerk/clerk/pull/1981

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

-

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
