### PR TITLE
Add platform API to overview of API reference

### DIFF
--- a/docs/reference/api/overview.mdx
+++ b/docs/reference/api/overview.mdx
@@ -9,6 +9,6 @@ While accessing Clerk functionality via SDK is the easiest path, Clerk offers tw
 
 [The Clerk Backend API](/docs/reference/backend-api){{ target: '_blank' }} is meant to be accessed by backend servers. Use this API if you need to update data inside of Clerk's systems outside the concept of a session, like coordinating data sync operations with third-parties or fetching and updating configuration settings.
 
-[The Clerk Platform API](/docs/reference/platform-api){{ target: '_blank' }} is meant to be accessed by backend servers. Use this API if you need to manage resources of a workspace such as your Clerk applications, domains and application transfers.
+[The Clerk Platform API](/docs/reference/platform-api){{ target: '_blank' }} is meant to be accessed by backend servers. Use this API if you need to manage resources of a workspace such as your Clerk applications, domains, and application transfers.
 
 For more information about how Clerk works, see the [dedicated guide](/docs/guides/how-clerk-works/overview).


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-add-platform-api-overview/reference/api/overview

### What does this solve?

This PR follows this recently [merged PR](https://github.com/clerk/clerk-docs/pull/2944) adding the Platform API to the sidebar. The Platform API also needed to be added to the API reference overview, which is what this PR does. 
 
### What changed?

Adds Platform API to the API reference overview. 
