### PR TITLE
Add callout about why vercel.app domains cant be used for prod

### DIFF
--- a/docs/guides/development/deployment/vercel.mdx
+++ b/docs/guides/development/deployment/vercel.mdx
@@ -37,3 +37,10 @@ To configure Clerk within your Vercel preview environment, see the [guide for co
 ## Deploy to production
 
 If you would like to deploy your Vercel project to production, you will need to add your **production** API keys to your Vercel project. You will also need a domain that you own, as you cannot use a `*.vercel.app` domain for production. Refer to the [Deploy to production](/docs/guides/development/deployment/production) guide for more information.
+
+> [!QUIZ]
+> Why can't you use a `*.vercel.app` domain for production?
+>
+> ---
+>
+> To deploy to production, you need to set DNS records, which isn't possible with `vercel.app` domains.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-docs-11366/guides/development/deployment/vercel#deploy-to-production

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- A user wanted to understand why vercel.app domains couldn't be used for prod
https://linear.app/clerk/issue/DOCS-11366/feedback-for-guidesdevelopmentdeploymentvercel

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Adds a callout with the brief explanation

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
