### PR TITLE
Fixes Conductor config

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "cp $CONDUCTOR_ROOT_PATH/.env.local .env.local && cp -r $CONDUCTOR_ROOT_PATH/.vercel . && npm install",
+    "setup": "npm i",
     "run": "npm run dev",
     "archive": ""
   }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- N/A

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

Conductor throws an error/warning because there's no env vars for this project.

<img width="808" height="192" alt="CleanShot 2026-01-13 at 12 38 05@2x" src="https://github.com/user-attachments/assets/0b5502fb-adc3-4a87-8f2f-11ed108ca2cd" />

```
cp: /Users/manovotny/Developer/clerk-docs/.env.local: No such file or directory
```

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Removes Conductor copy commands for `.env.local` and `.vercel`. 