### PR TITLE
feat(docs): remove private beta warning for Solana authentication in documentation

### DIFF
--- a/docs/_partials/authentication/web3/solana-private-beta-callout.mdx
+++ b/docs/_partials/authentication/web3/solana-private-beta-callout.mdx
@@ -1,2 +1,0 @@
-> [!WARNING]
-> The Sign in with Solana authentication strategy is currently in private beta. If you're interested in participating, please contact [Clerk's support team](https://clerk.com/support). Availability may be limited and is subject to change.

--- a/docs/guides/configure/auth-strategies/web3/solana.mdx
+++ b/docs/guides/configure/auth-strategies/web3/solana.mdx
@@ -13,8 +13,6 @@ description: Learn how to set up Web3 authentication with Solana.
   ]}
 />
 
-<Include src="_partials/authentication/web3/solana-private-beta-callout" />
-
 Enabling [Solana](https://solana.com/solana-wallets) as a Web3 provider allows your users to sign in and up to your Clerk application with their Solana enabled wallet.
 
 While we allow users to sign in with specific Web3 wallets (e.g., Coinbase Wallet, MetaMask), these methods all rely on the wallet's [Ethereum](https://ethereum.org/) address. With **Sign in with Solana**, users instead are prompted to choose their preferred Solana wallet provider and authenticate using their Solana wallet address. This means the sign-in flow isn't tied to any single wallet app; users can select whichever Solana wallet they prefer, unlike the other Web3 authentication strategies that  depend on specific Ethereum-based wallets.

--- a/docs/reference/javascript/sign-in.mdx
+++ b/docs/reference/javascript/sign-in.mdx
@@ -258,8 +258,6 @@ const signIn = await clerk.signIn.authenticateWithOKXWallet()
 
 ### `authenticateWithSolana()`
 
-<Include src="_partials/authentication/web3/solana-private-beta-callout" />
-
 Initiates an authentication flow using the user's Solana wallet provider, allowing users to authenticate via their Solana wallet address. This method prompts the user to connect their Solana wallet and sign a message to verify ownership of the wallet address. The `walletName` parameter specifies which Solana wallet provider to use for the authentication process, which is required to initiate the connection and signature request.
 
 ```typescript

--- a/docs/reference/javascript/sign-up.mdx
+++ b/docs/reference/javascript/sign-up.mdx
@@ -316,8 +316,6 @@ const signUp = await clerk.signUp.authenticateWithOKXWallet()
 
 ### `authenticateWithSolana()`
 
-<Include src="_partials/authentication/web3/solana-private-beta-callout" />
-
 Initiates an authentication flow using the user's Solana wallet provider, allowing users to authenticate via their Solana wallet address. This method prompts the user to connect their Solana wallet and sign a message to verify ownership of the wallet address. The `walletName` parameter specifies which Solana wallet provider to use for the authentication process, which is required to initiate the connection and signature request.
 
 ```typescript

--- a/docs/reference/javascript/types/web3-wallet.mdx
+++ b/docs/reference/javascript/types/web3-wallet.mdx
@@ -123,8 +123,6 @@ type EthereumWeb3Provider =
 
 ## `SolanaWeb3Provider`
 
-<Include src="_partials/authentication/web3/solana-private-beta-callout" />
-
 A type that represents the Solana Web3 provider. This is independent of the specific Solana wallet used as users can use any [Solana wallet](https://solana.com/solana-wallets) that supports signing messages.
 
 ```ts


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- [Preview Link](https://clerk-docs-git-kenton-user-4349-remove-private-beta-warn-369b55.clerkstage.dev/)

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- We are moving the Solana Auth strategy to GA and this would require us to remove the private beta callout from the docs regarding Solana.

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- This PR removes the callout and the respective pages where it is referenced

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
