### PR TITLE
Fix 404 errors for react-router declarative-mode docs

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2935,6 +2935,10 @@
     "destination": "/docs/guides/development/declarative-mode"
   },
   {
+    "source": "/docs/reference/react-router/declarative-mode",
+    "destination": "/docs/guides/development/declarative-mode"
+  },
+  {
     "source": "/docs/reference/react-router/verifying-oauth-access-tokens",
     "destination": "/docs/guides/development/verifying-oauth-access-tokens"
   },


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/guides/development/declarative-mode

### What does this solve?

Fixes [DOCS-11402](https://linear.app/clerk/issue/DOCS-11402): A third of the recent 404 errors have been to `/docs/reference/react-router/declarative-mode`. This endpoint should redirect to the correct docs location.

### What changed?

Added a redirect from `/docs/reference/react-router/declarative-mode` to `/docs/guides/development/declarative-mode` to handle requests to the old/broken URL path.