### PR TITLE
Add reference link to Wailist component

### DIFF
--- a/docs/guides/secure/restricting-access.mdx
+++ b/docs/guides/secure/restricting-access.mdx
@@ -45,7 +45,7 @@ Additional features available in **Restricted** mode:
 ![\<Waitlist /> component](/docs/images/ui-components/waitlist.svg)
 
 > [!NOTE]
-> If you're using Next.js, the`<Waitlist />` component is available in `@clerk/nextjs@6.2.0` and above.
+> If you're using Next.js, the [`<Waitlist />`](/docs/reference/components/authentication/waitlist) component is available in `@clerk/nextjs@6.2.0` and above.
 
 In **Waitlist** mode, users can register their interest in your app by joining a waitlist. This mode is ideal for apps in early development stages or those wanting to generate interest before launch.
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

This PR is in response to user feedback, being confused on the lack of links to be able to implement the `Waitlist` component. 

### What changed?

Adds a reference link. 
