### PR TITLE
Change wording of callout for clarification on CAPTCHA options

### DIFF
--- a/docs/_partials/bot-protection-callout.mdx
+++ b/docs/_partials/bot-protection-callout.mdx
@@ -1,0 +1,3 @@
+> [!WARNING]
+> If your application previously had the **Invisible** CAPTCHA type selected, it's highly recommended to switch to the **Smart** option, as the **Invisible** option is deprecated.
+> For newer applications, CAPTCHA type options are no longer shown in the Dashboard. Bot protection uses the **Smart** option by default and is enabled by turning on the **Bot sign-up protection** toggle only.

--- a/docs/guides/development/custom-flows/authentication/bot-sign-up-protection.mdx
+++ b/docs/guides/development/custom-flows/authentication/bot-sign-up-protection.mdx
@@ -13,9 +13,7 @@ Clerk provides the ability to add a CAPTCHA widget to your sign-up flows to prot
   1. In the Clerk Dashboard, navigate to the [**Attack protection**](https://dashboard.clerk.com/~/user-authentication/attack-protection) page.
   1. Enable the **Bot sign-up protection** toggle.
 
-  > [!WARNING]
-  > If your application previously had the **Invisible** CAPTCHA type selected, it's highly recommended to switch to the **Smart** option, as the **Invisible** option is deprecated.
-  > For newer applications, CAPTCHA type options are no longer shown in the Dashboard. Bot protection uses the **Smart** option by default and is enabled by turning on the **Bot sign-up protection** toggle only.
+  <Include src="_partials/bot-protection-callout" />
 
   ## Add the CAPTCHA widget to your custom sign-up form
 

--- a/docs/guides/secure/bot-protection.mdx
+++ b/docs/guides/secure/bot-protection.mdx
@@ -11,9 +11,7 @@ To protect your sign-ups from bots, Clerk leverages data from our CDN to determi
 1. Enable the **Bot sign-up protection** toggle.
    - When enabled, users suspected of being a bot will be shown an interactive challenge (like clicking a checkbox) to verify they are human. The CAPTCHA widget will only be shown if the client is suspected to be a bot.
 
-> [!WARNING]
-> If your application previously had the **Invisible** CAPTCHA type selected, it's highly recommended to switch to the **Smart** option, as the **Invisible** option is deprecated.
-> For newer applications, CAPTCHA type options are no longer shown in the Dashboard. Bot protection uses the **Smart** option by default and is enabled by turning on the **Bot sign-up protection** toggle only.
+<Include src="_partials/bot-protection-callout" />
 
 ## Limitations
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-docs-11345/guides/secure/bot-protection
- https://clerk.com/docs/pr/ss-docs-11345/guides/development/custom-flows/authentication/bot-sign-up-protection

### What does this solve?

Linear: https://linear.app/clerk/issue/DOCS-11345/feedback-for-guidesdevelopmentcustom-flowsauthenticationbot-sign-up

Users are confused by the `Warning` callout referencing CAPTCHA type options, since those options have been removed from the Dashboard. For most users, bot protection is now enabled solely via the Bot sign-up protection toggle.

However, after syncing with #team-dashboard, I confirmed that CAPTCHA type options still appear only for applications that previously had the Invisible CAPTCHA type enabled or for users on an older core version of the Dashboard (legacy). 

Here is the code showing that behaviour:

```tsx
{shouldShowInvisibleCaptchaOption ? (
      <LegacyBotProtections
            userSettings={userSettings}
            form={form}
            {...botProtectionsState}
      />
   ) : (
    <BotProtections
      userSettings={userSettings}
      form={form}
       {...botProtectionsState}
   />
)}
```
### What changed?

Changed the wording of the callout to clarify this behaviour. 