### PR TITLE
Fix getToken template arg name

### DIFF
--- a/docs/guides/development/testing/postman-or-insomnia.mdx
+++ b/docs/guides/development/testing/postman-or-insomnia.mdx
@@ -22,7 +22,7 @@ Give your template a unique name, such as _'testing-template'_. Set the **Token 
 Visit your frontend that is using the same Clerk Application and instance that you want to test. Sign in as a user. The user that you sign in as will be the user you test with in Postman or Insomnia. You can create several tokens for several different users. Once you have signed in, open your Dev Tools and go to the **Console** tab. Enter the following command:
 
 ```js
-await window.Clerk.session.getToken({ jwt_template: '<the template name you chose above>' })
+await window.Clerk.session.getToken({ template: '<the template name you chose above>' })
 ```
 
 ![The Dev Tools Console with the command 'await window.Clerk.session.getToken()' entered. The token is logged to the console](/docs/images/testing/get-token-from-console.webp)


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- The docs include an example call to the Clerk JS client, with a call to `getToken()`, and using a `jwt_template` property in the GetTokenOptions object. That property is actually named `template`.

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Fixes the incorrect call parameters to use the correct `template` property.

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
