### PR TITLE
docs: rename activeSessions to signedInSessions in Client reference

### DIFF
--- a/docs/reference/javascript/client.mdx
+++ b/docs/reference/javascript/client.mdx
@@ -32,7 +32,7 @@ The `Client` object also holds information about any sign in or sign up attempts
 
   ---
 
-  - `activeSessions`
+  - `signedInSessions`
   - [`Session[]`](/docs/reference/javascript/session)
 
   A list of active sessions on this client.


### PR DESCRIPTION
The activeSessions property was renamed to signedInSessions in the SDK. Updates documentation to reflect current API.

### 🔎 Previews:

- `docs/reference/javascript/client.mdx`

### What does this solve?

The `Client` object documentation shows `activeSessions` as a current property, but the SDK renamed this to signedInSessions`. Developers referencing the docs will use the deprecated property name.

**SDK Evidence:**
  - Type definition in `packages/shared/src/types/client.ts` uses `signedInSessions`
  - Upgrade codemod `packages/upgrade/src/codemods/transform-remove-deprecated-props.cjs` explicitly renames `activeSessions` → `signedInSessions`

### What changed?

- Renamed `activeSessions` to `signedInSessions` in the Client object properties documentation to match the current SDK API

