### PR TITLE
feat(docs): Document additional supported but insecure hashers

### DIFF
--- a/docs/reference/backend/user/create-user.mdx
+++ b/docs/reference/backend/user/create-user.mdx
@@ -88,7 +88,7 @@ function createUser(params: CreateUserParams): Promise<User>
   ---
 
   - `passwordHasher?`
-  - `'argon2i' | 'argon2id' | 'awscognito' | 'bcrypt' | 'bcrypt_sha256_django' | 'md5' | 'md5_salted' | 'pbkdf2_sha256' | 'pbkdf2_sha256_django' | 'pbkdf2_sha1' | 'phpass' | 'scrypt_firebase' | 'scrypt_werkzeug' | 'sha256'`
+  - `'argon2i' | 'argon2id' | 'awscognito' | 'bcrypt' | 'bcrypt_sha256_django' | 'md5' | 'md5_salted' | 'pbkdf2_sha256' | 'pbkdf2_sha256_django' | 'pbkdf2_sha1' | 'phpass' | 'scrypt_firebase' | 'scrypt_werkzeug' | 'sha256' | 'sha256_salted' | 'sha512_symfony'`
 
   The hashing algorithm that was used to generate the password digest.
   The algorithms we support at the moment are:

--- a/docs/reference/backend/user/update-user.mdx
+++ b/docs/reference/backend/user/update-user.mdx
@@ -100,7 +100,7 @@ function updateUser(userId: string, params: UpdateUserParams): Promise<User>
   ---
 
   - `passwordHasher?`
-  - `'argon2i' | 'argon2id' | 'bcrypt' | 'bcrypt_sha256_django' | 'md5' | 'pbkdf2_sha256' | 'pbkdf2_sha256_django' | 'pbkdf2_sha1' | 'phpass' | 'scrypt_firebase' | 'scrypt_werkzeug' | 'sha256' | 'sha512_symfony'`
+  - `'argon2i' | 'argon2id' | 'bcrypt' | 'bcrypt_sha256_django' | 'md5' | 'md5_salted' | 'pbkdf2_sha256' | 'pbkdf2_sha256_django' | 'pbkdf2_sha1' | 'phpass' | 'scrypt_firebase' | 'scrypt_werkzeug' | 'sha256' | 'sha256_salted' | 'sha512_symfony'`
 
   The hashing algorithm that was used to generate the password digest. Each of the supported hashers expects the incoming digest to be in a particular format. See the [Clerk Backend API reference](/docs/reference/backend-api/tag/users/post/users){{ target: '_blank' }} for more information.
 


### PR DESCRIPTION
We already supported salted MD5 and SHA256 hashers, and recently added support for the legacy Symfony salted SHA512 hasher. Document these, including that users will be migrated to bcrypt on sign in.

### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

-

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

-

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
