### PR TITLE
Algolia Search - validate that the `canonical` is in the frontmatter of every doc

### DIFF
--- a/scripts/update-algolia-records.ts
+++ b/scripts/update-algolia-records.ts
@@ -64,11 +64,13 @@ const frontmatterSchema = z.object({
   availableSdks: z.string().optional(),
   activeSdk: z.string().optional(),
   redirectPage: z.string().optional(),
-  search: z.object({
-    exclude: z.boolean().optional(),
-    keywords: z.array(z.string()).optional(),
-    rank: z.number().optional(),
-  }).optional(),
+  search: z
+    .object({
+      exclude: z.boolean().optional(),
+      keywords: z.array(z.string()).optional(),
+      rank: z.number().optional(),
+    })
+    .optional(),
   canonical: z.string(),
 })
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- The Algolia search records require that `canonical` be defined in the records to properly create the search hit url, but we aren't validating that its defined before creating the records. https://github.com/clerk/clerk/pull/1991#discussion_r2710003777

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- This uses a zod schema to validate docs frontmatter from the dist folder.

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
