### PR TITLE
Build Script - Copy the public folder in to the dist folder to keep consistency

### DIFF
--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1216,12 +1216,14 @@ ${yaml.stringify({
 
   abortSignal?.throwIfAborted()
 
-  if (config.flags.watch) {
-    // Copy over the public folder
-    if (config.publicPath) {
-      await fs.cp(config.publicPath, path.join(config.distTempPath, '_public'), { recursive: true })
-    }
+  // Copy over the public folder
+  if (config.publicPath) {
+    await fs.cp(config.publicPath, path.join(config.distTempPath, '_public'), { recursive: true })
+  }
 
+  abortSignal?.throwIfAborted()
+
+  if (config.flags.watch) {
     // While in dev, we just want to symlink the new dist to the dist folder
     // This removes the issue that fs.cp can't replace a folder
     // We don't need to worry about the public folder because in dev clerk/clerk just looks in the original public folder
@@ -1235,9 +1237,6 @@ ${yaml.stringify({
   } else if (process.env.VERCEL === '1') {
     // In vercel ci the temp dir and the final dir will be on separate partitions so fs.rename() will fail
     await fs.cp(config.distTempPath, config.distFinalPath, { recursive: true })
-    if (config.publicPath) {
-      await fs.cp(config.publicPath, path.join(config.distFinalPath, '_public'), { recursive: true })
-    }
     // We don't need to worry about temp folders as the ci runner will be destroyed after this anyways
   } else {
     // During a standard build
@@ -1249,10 +1248,6 @@ ${yaml.stringify({
     await fs.cp(config.distTempPath, config.distFinalPath, { recursive: true })
     // Remove the temp dist folder
     await fs.rm(config.distTempPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
-    // Copy over the public folder
-    if (config.publicPath) {
-      await fs.cp(config.publicPath, path.join(config.distFinalPath, '_public'), { recursive: true })
-    }
   }
 
   abortSignal?.throwIfAborted()


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- Currently the public folder isn't copied in to the dist folder when the script is in watch / dev mode

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Copies the public folder in to the dist folder

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
