### PR TITLE
fix: development instances are capped at 500 users.

### DIFF
--- a/docs/guides/development/managing-environments.mdx
+++ b/docs/guides/development/managing-environments.mdx
@@ -17,7 +17,7 @@ Some notable examples of `Development`-only characteristics in a Clerk applicati
 - [The Account Portal](/docs/guides/account-portal/overview) will use a Clerk development domain that ends with `accounts.dev` instead of your app's production domain.
 - OAuth consent screens will show the development domain that ends with `accounts.dev` instead of your production domain.
 - Search engines will not be able to crawl and index your application.
-- Development instances are capped at 100 users, and user data can not be transferred between instances.
+- Development instances are capped at 500 users, and user data can not be transferred between instances.
 - The architecture of Clerk's sessions management is different in development environments compared to production environments, due to the need to communicate cross-domain between `localhost` and `<slug>.accounts.dev`. The `__clerk_db_jwt` object is _only_ used in development environments. For more specific details on the differences between Clerk's session management architecture in development and production environments, see the [technical breakdown below](#session-architecture-differences).
 
 > [!NOTE]


### PR DESCRIPTION
While investigating support rotation requests, it
was discovered that the apparent user limit for 
development instances is 500, but the docs state 
100 user limit. Update the docs to match the 
development instance limit.

### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

-

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

-

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
