### PR TITLE
Add keyless mode documentation to Next.js LLM prompt

### DIFF
--- a/prompts/nextjs-quickstart.md
+++ b/prompts/nextjs-quickstart.md
@@ -27,6 +27,7 @@ Clerk supports **keyless mode**, which means developers can start building immed
 4. **Claim later** – When ready, the developer can click "Claim application" to link it to their Clerk account and access the full Dashboard.
 
 **IMPORTANT FOR AI AGENTS:** Do NOT instruct users to:
+
 - Sign up for Clerk before starting
 - Create a Clerk account first
 - Go to the Clerk Dashboard to get API keys


### PR DESCRIPTION
## Summary

- Add dedicated "Keyless Mode (Zero-Config Setup)" section explaining how developers can start building immediately without signing up for a Clerk account first
- Add explicit instructions for AI agents NOT to require users to sign up, create accounts, or get API keys before starting
- Update "ALWAYS DO" section with keyless mode guidance  
- Update "NEVER DO" section to prevent AI agents from giving signup instructions
- Update file references from `middleware.ts` to `proxy.ts` (Next.js 16+ convention)

## Why

AI agents were telling users to sign up for Clerk and get API keys before starting development. With keyless mode, this is no longer necessary - Clerk auto-generates temporary keys on startup.

## Other

- PR with the same prompt change made to `clerk-evals` - https://github.com/clerk/clerk-evals/pull/36

## Test plan

- [x] Ran eval suite against 14 models with updated prompt
- [x] 11/14 models scored 94.7% (maximum observed)
- [x] Verified models now include keyless mode instructions in their responses