### PR TITLE
docs: update migration guide with CSV support and correct schema link

### DIFF
--- a/docs/guides/development/migrating/overview.mdx
+++ b/docs/guides/development/migrating/overview.mdx
@@ -5,7 +5,7 @@ description: Guides on how to move your user data from another authentication pl
 
 ## Migration tooling
 
-To aid in basic migrations, Clerk provides an open-source script that takes a JSON file as input, containing a list of users, and creates a user in Clerk using the Backend API. The script respects the [backend rate limits](/docs/guides/how-clerk-works/system-limits#backend-api-requests) and gracefully handles errors. We suggest you customize the [Zod schema](https://github.com/clerk/migration-script/blob/main/index.ts#L25-L43){{ target: '_blank' }} to your application's needs.
+To aid in basic migrations, Clerk provides an open-source script that takes a JSON or CSV file as input, containing a list of users, and creates a user in Clerk using the Backend API. The CSV can be a custom file or an [export from the Clerk Dashboard](#export-your-users-data-from-the-clerk-dashboard). The script respects the [backend rate limits](/docs/guides/how-clerk-works/system-limits#backend-api-requests) and gracefully handles errors. We suggest you customize the [Zod schema](https://github.com/clerk/migration-script/blob/main/src/migrate/validator.ts){{ target: '_blank' }} to your application's needs.
 
 To use Clerk's migration script, clone the [repository](https://github.com/clerk/migration-script) and follow the instructions in the `README`.
 


### PR DESCRIPTION
Fixing a 404 after the refactor, but also noting that we can do CSV import/migration now (https://github.com/clerk/migration-script/pull/11).

See [DOCS-11239](https://linear.app/clerk/issue/DOCS-11239/feedback-for-guidesdevelopmentmigratingoverview) for more information.

### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-fix-migration-link/guides/development/migrating/overview

### What does this solve?

- Adds documentation for CSV file support in the migration script
- Corrects the link to point to the actual Zod schema file in the repository

### What changed?

- Updated migration tooling section to mention CSV file support alongside JSON
- Added reference to Clerk Dashboard export feature
- Changed Zod schema link from the repo root to the actual validator.ts file