### PR TITLE
docs: add redirects for Next.js route handlers and server actions

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -3384,5 +3384,21 @@
   {
     "source": "/docs/authentication/api-keys",
     "destination": "/docs/guides/development/machine-auth/api-keys"
+  },
+  {
+    "source": "/docs/references/nextjs/route-handlers",
+    "destination": "/docs/reference/nextjs/app-router/route-handlers"
+  },
+  {
+    "source": "/docs/references/nextjs/server-actions",
+    "destination": "/docs/reference/nextjs/app-router/server-actions"
+  },
+  {
+    "source": "/docs/reference/nextjs/route-handlers",
+    "destination": "/docs/reference/nextjs/app-router/route-handlers"
+  },
+  {
+    "source": "/docs/reference/nextjs/server-actions",
+    "destination": "/docs/reference/nextjs/app-router/server-actions"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

Currently failing:

- https://clerk.com/docs/references/nextjs/route-handlers
- https://clerk.com/docs/references/nextjs/server-actions

These should redirect now:

- https://clerk.com/docs/pr/manovotny-florence/references/nextjs/route-handlers
- https://clerk.com/docs/pr/manovotny-florence/references/nextjs/server-actions

### What does this solve?

Originally found by our scanner:

<img width="2342" height="172" alt="CleanShot 2026-01-29 at 11 09 02@2x" src="https://github.com/user-attachments/assets/a6040281-79d2-429c-bbd4-fbe2097fb14e" />

Adds missing redirect entries for Next.js route handlers and server actions documentation to ensure users are properly redirected to the new app-router documentation locations.

### What changed?

Added four redirect entries to `redirects/static/docs.json`:
- Redirects for both `/docs/references/nextjs/route-handlers` and `/docs/reference/nextjs/route-handlers` to `/docs/reference/nextjs/app-router/route-handlers`
- Redirects for both `/docs/references/nextjs/server-actions` and `/docs/reference/nextjs/server-actions` to `/docs/reference/nextjs/app-router/server-actions`

This handles both the typo variant (with `references` plural) and the correct singular form to improve user experience.