### PR TITLE
Clerk android doc sections

### DIFF
--- a/docs/reference/native-sdks/clerk.mdx
+++ b/docs/reference/native-sdks/clerk.mdx
@@ -4,41 +4,7 @@ description: Use Clerk in your Android app with global access and reactive state
 sdk: android
 ---
 
-`Clerk` is the main entry point for the SDK. Initialize it once at app startup, then access authentication state through reactive flows.
-
-## Initialize Clerk
-
-Initialize Clerk in your `Application` class before using any Clerk features:
-
-<Include src="_partials/android/initialize-clerk" />
-
-Register your Application class in `AndroidManifest.xml`:
-
-```xml
-<application android:name=".MyClerkApp">
-    ...
-</application>
-```
-
-## Listen for initialization
-
-The Clerk SDK initialization is non-blocking. Listen for the SDK to emit a success from `Clerk.isInitialized` to know when it's ready to use:
-
-```kotlin
-import com.clerk.api.Clerk
-import kotlinx.coroutines.flow.combine
-
-combine(Clerk.isInitialized, Clerk.userFlow) { isInitialized, user ->
-    if (isInitialized) {
-        // Clerk is ready
-        if (user != null) {
-            // User is signed in
-        } else {
-            // User is signed out
-        }
-    }
-}
-```
+`Clerk` is the main entry point for the SDK. After you [configure the SDK](/docs/reference/native-sdks/configuration), you can access it in two ways:
 
 ## Access user state
 


### PR DESCRIPTION
### 🔎 Previews:

- [Preview link for `docs/reference/native-sdks/clerk.mdx`](Vercel preview link here)

### What does this solve?

- The Android Clerk SDK documentation was redundant, duplicating content already covered in the "Configure the SDK" guide.
- It also lacked consistency with the iOS version of the Clerk SDK documentation.

### What changed?

- Trimmed the `docs/reference/native-sdks/clerk.mdx` file to only include the "Access user state" and "Access session state" sections.
- Updated the introductory paragraph to link to the "Configure the SDK" guide and align its structure with the iOS Clerk SDK documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5906d1cb-2304-468d-a480-18df8e78ca33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5906d1cb-2304-468d-a480-18df8e78ca33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

