### PR TITLE
feat: add last_sign_in_at filter parameters to user list and count docs

### DIFF
--- a/docs/reference/backend/user/get-count.mdx
+++ b/docs/reference/backend/user/get-count.mdx
@@ -63,6 +63,20 @@ The total count of users can be filtered down by adding one or more of these par
   - `string`
 
   Counts users that match the given query. For possible matches, Clerk checks the email addresses, phone numbers, usernames, Web3 wallet addresses, user IDs, first and last names. The query value doesn't need to match the exact value you are looking for, it is capable of partial matches as well.
+
+  ---
+
+  - `lastSignInAtAfter?`
+  - `number`
+
+  Counts users that signed in after the given Unix timestamp (in milliseconds).
+
+  ---
+
+  - `lastSignInAtBefore?`
+  - `number`
+
+  Counts users that signed in before the given Unix timestamp (in milliseconds).
 </Properties>
 
 ## Examples
@@ -81,6 +95,17 @@ The following example retrieves the total number of users matching the query `te
 
 ```tsx
 const response = await clerkClient.users.getCount({ query: 'test' })
+```
+
+### Filter by last sign-in date
+
+Retrieve the total number of users that signed in within a specific time range.
+
+```tsx
+const response = await clerkClient.users.getCount({
+  lastSignInAtAfter: 1700690400000,
+  lastSignInAtBefore: 1700690400010,
+})
 ```
 
 ## Backend API (BAPI) endpoint

--- a/docs/reference/backend/user/get-user-list.mdx
+++ b/docs/reference/backend/user/get-user-list.mdx
@@ -96,6 +96,20 @@ function getUserList(): (params: UserListParams) => Promise<PaginatedResourceRes
   - `number`
 
   Filters users that had session activity since the given date, with day precision. Providing a value with higher precision than day will result in an error. Example: use `1700690400000` to retrieve users that had session activity from 2023-11-23 until the current day. For example: `1700690400000`.
+
+  ---
+
+  - `lastSignInAtAfter?`
+  - `number`
+
+  Filters users that signed in after the given Unix timestamp (in milliseconds).
+
+  ---
+
+  - `lastSignInAtBefore?`
+  - `number`
+
+  Filters users that signed in before the given Unix timestamp (in milliseconds).
 </Properties>
 
 ## Examples
@@ -140,6 +154,18 @@ To do a broader match through a list of fields, you can use the query parameter 
 // Matches users with the string `test` matched in multiple user attributes.
 const { data, totalCount } = await clerkClient.users.getUserList({
   query: 'test',
+})
+```
+
+### Filter by last sign-in date
+
+Retrieve users that signed in within a specific time range.
+
+```tsx
+// Matches users that signed in between the given Unix timestamps.
+const { data, totalCount } = await clerkClient.users.getUserList({
+  lastSignInAtAfter: 1700690400000,
+  lastSignInAtBefore: 1700690400010,
 })
 ```
 


### PR DESCRIPTION
### 🔎 Previews:

User List:

<img width="1492" height="747" alt="image" src="https://github.com/user-attachments/assets/9db5f1bd-1845-430c-9cc9-81780bdee5ea" />

<img width="1492" height="747" alt="image" src="https://github.com/user-attachments/assets/827bf68a-1dc4-4779-8df2-577a7fb0626d" />

User Count:

<img width="1492" height="747" alt="image" src="https://github.com/user-attachments/assets/609c9bc7-41fe-4eef-a77d-37aedb700047" />

<img width="1492" height="747" alt="image" src="https://github.com/user-attachments/assets/812a2d97-29a7-4380-8f17-bd07cd17125c" />

### What does this solve?

People can now query for users who signed in within a specific time window.

### What changed?

In the users `getCount` and `getUserList`

- Added lastSignInAtAfter parameter documentation
- Added lastSignInAtBefore parameter documentation
- Added a new example section showing how to filter by last sign-in date


