### PR TITLE
Algolia Search - Opt in to writing dev index records to Algoila

### DIFF
--- a/scripts/update-algolia-records.ts
+++ b/scripts/update-algolia-records.ts
@@ -610,7 +610,9 @@ async function main() {
     if (DEBUG_SEARCH_BRANCH !== undefined) {
       console.log(`⚠︎ DEBUG MODE - Using branch: ${DEBUG_SEARCH_BRANCH}`)
     } else {
-      console.log(`To update the dev algolia search index on a preview deployment, you must set the DEBUG_SEARCH_BRANCH environment variable`)
+      console.log(
+        `To update the dev algolia search index on a preview deployment, you must set the DEBUG_SEARCH_BRANCH environment variable`,
+      )
       process.exit(0)
     }
   }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- NA - Tooling

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- We don't want every branch to push search records to Algolia, as it inflates our Algolia bill unnecessarily

### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Adds an env of `DEBUG_SEARCH_BRANCH` that when set to a branch name, eg `main`, `core-1`, `core-3` will use that branch name to push the records up to `clerk_dev` for testing & debugging purposes, either to modify the records creation or make changes in clerk/clerk.
- Disables by default pushing records on preview deployments

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
