### PR TITLE
fix: move satellite domain upgrade info to upgrade guide

### DIFF
--- a/docs/guides/dashboard/dns-domains/satellite-domains.mdx
+++ b/docs/guides/dashboard/dns-domains/satellite-domains.mdx
@@ -29,9 +29,6 @@ Users must complete both the sign-in and sign-up flows on the primary domain by 
 
 ### How authentication syncing works
 
-> [!CAUTION]
-> If you are upgrading from Core 2, see the [migration section](#migrating-from-core-2) for behavior changes that may affect your satellite applications.
-
 The syncing behavior between satellite and primary domains is controlled by the `satelliteAutoSync` option.
 
 With `satelliteAutoSync: false` (the default), satellite domains do not automatically sync authentication state with the primary domain when a user visits the page. This means there is no upfront performance cost for users visiting a satellite domain. Authentication state is only synced when a user initiates a sign-in or sign-up action:
@@ -447,35 +444,3 @@ If you set `satelliteAutoSync: true`, the satellite domain will automatically re
 
   You can repeat this process and create as many satellite applications as you need.
 </Steps>
-
-## Migrating from Core 2
-
-In Core 2, satellite applications automatically synced authentication state with the primary domain on every first page load by redirecting users to the primary domain and back. This happened regardless of whether the user had an active session, which caused unnecessary latency for apps where most visitors are anonymous.
-
-In Core 3, this behavior is controlled by the `satelliteAutoSync` option, which defaults to `false`. This means satellite apps no longer perform automatic redirects on first visit.
-
-### What changed
-
-| | Core 2 | Core 3 (default) |
-| - | - | - |
-| First visit to satellite | Redirects to primary domain to sync state, then back | No redirect, page loads immediately |
-| Sign-in flow | Same as Core 3 | User selects "Sign in" → redirected to primary → signs in → redirected back |
-| Already signed in on primary | Automatically synced on first visit | Only synced after user selects "Sign in" (redirect is instant, no user action needed) |
-| Sign-out | Signs out from all domains | Signs out from all domains |
-| Performance | Redirect on every first visit | No upfront cost |
-
-### To preserve Core 2 behavior
-
-If your application relies on users being automatically recognized on the satellite domain without selecting "Sign in", set `satelliteAutoSync` to `true`:
-
-```ts {{ prettier: false }}
-// In your middleware options or ClerkProvider props
-{
-  isSatellite: true,
-  domain: 'satellite.dev',
-  signInUrl: 'https://primary.dev/sign-in',
-  satelliteAutoSync: true, // Opt-in to automatic sync on first load
-}
-```
-
-If you have any questions about satellite domains, or you're having any trouble setting this up, contact [support@clerk.com](mailto:support@clerk.com)

--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -15,6 +15,7 @@ Core 3 focuses on consistency and cleanup across Clerk's SDKs while keeping upgr
 - **Appearance updates:** `appearance.layout` is now `appearance.options`, `showOptionalFields` defaults to `false`, and color variables apply at full opacity.
 - **Behavior alignment:** redirect props and legacy billing flags are removed in favor of the newer patterns.
 - **Platform requirements:** Node.js 20.9.0+ is required across the updated packages.
+- **Satellite apps:** Satellite apps no longer perform automatic redirects on first visit.
 
 Use `npx @clerk/upgrade` to scan your project and speed up the migration.
 
@@ -106,7 +107,7 @@ The following breaking changes apply to all Clerk SDKs.
   <AccordionPanel>
     The `colorRing` and `colorModalBackdrop` CSS variables now render at full opacity when modified via the appearance prop or CSS variables. Previously, provided colors were rendered at 15% opacity.
 
-    If you were relying on the previous behavior, you may need to adjust your color values to include the desired opacity:
+    If you were relying on the Core 2 behavior, you may need to adjust your color values to include the desired opacity:
 
     ```diff
       <ClerkProvider
@@ -395,12 +396,13 @@ The following deprecated APIs have been removed from all Clerk SDKs.
   titles={[
     "<code>showOptionalFields</code> now defaults to <code>false</code>",
     "<code>ClerkAPIError.kind</code> value updated",
+    "Satellite apps no longer perform automatic redirects on first visit",
   ]}
 >
   <AccordionPanel>
     The default value of `appearance.layout.showOptionalFields` (now `appearance.options.showOptionalFields`) has changed from `true` to `false`. Optional fields are now hidden by default during sign up.
 
-    To restore the previous behavior, explicitly set the option:
+    To restore the Core 2 behavior, explicitly set the option:
 
     ```jsx
     <ClerkProvider
@@ -424,6 +426,82 @@ The following deprecated APIs have been removed from all Clerk SDKs.
     ```
 
     Most users should not be affected. If you were checking this string directly (e.g., `error.constructor.kind === 'ClerkApiError'`), update the comparison value.
+  </AccordionPanel>
+
+  <AccordionPanel>
+    In Core 2, satellite applications automatically synced authentication state with the primary domain on every first page load by redirecting users to the primary domain and back. This happened regardless of whether the user had an active session, which caused unnecessary latency for apps where most visitors are anonymous.
+
+    In Core 3, this behavior is controlled by the `satelliteAutoSync` option, which defaults to `false`. This means satellite apps no longer perform automatic redirects on first visit and users are not automatically recognized on the satellite domain unless they select "Sign in".
+
+    | | Core 2 | Core 3 (default) |
+    | - | - | - |
+    | First visit to satellite | Redirects to primary domain to sync state, then back | No redirect, page loads immediately |
+    | Sign-in flow | Same as Core 3 | User selects "Sign in" → redirected to primary → signs in → redirected back |
+    | Already signed in on primary | Automatically synced on first visit | Only synced after user selects "Sign in" (redirect is instant, no user action needed) |
+    | Sign-out | Signs out from all domains | Signs out from all domains |
+    | Performance | Redirect on every first visit | No upfront cost |
+
+    To restore the Core 2 behavior, in the your satellite domain's app, set `satelliteAutoSync` to `true` in your middleware and `<ClerkProvider>` component.
+
+    <CodeBlockTabs options={["Middleware", "<ClerkProvider>"]}>
+      ```ts {{ filename: 'proxy.ts' }}
+        import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+        // Set the homepage as a public route
+        const isPublicRoute = createRouteMatcher(['/'])
+
+        const options = {
+          isSatellite: true,
+          signInUrl: 'https://primary.dev/sign-in',
+          signUpUrl: 'https://primary.dev/sign-up',
+          domain: 'https://satellite.dev',
+      +   satelliteAutoSync: true,
+        }
+
+        export default clerkMiddleware(async (auth, req) => {
+          if (isPublicRoute(req)) return // if it's a public route, do nothing
+          await auth.protect() // for any other route, require auth
+        }, options)
+
+        export const config = {
+          matcher: [
+            // Skip Next.js internals and all static files, unless found in search params
+            '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+            // Always run for API routes
+            '/(api|trpc)(.*)',
+          ],
+        }
+      ```
+
+      ```tsx {{ filename: 'app/layout.tsx' }}
+        import { ClerkProvider } from '@clerk/nextjs'
+
+        export default function RootLayout({ children }: { children: React.ReactNode }) {
+          const primarySignInUrl = 'https://primary.dev/sign-in'
+          const primarySignUpUrl = 'https://primary.dev/sign-up'
+
+          return (
+            <html lang="en">
+              <body>
+                <ClerkProvider
+                  isSatellite
+      +           satelliteAutoSync={true}
+                  domain={(url) => url.host}
+                  signInUrl={primarySignInUrl}
+                  signUpUrl={primarySignUpUrl}
+                >
+                  <title>Satellite Next.js app</title>
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                  {children}
+                </ClerkProvider>
+              </body>
+            </html>
+          )
+        }
+      ```
+    </CodeBlockTabs>
+
+    If you have any questions about satellite domains, or you're having any trouble setting this up, see the [guide on satellite domains](/docs/guides/dashboard/dns-domains/satellite-domains) or contact [support@clerk.com](mailto:support@clerk.com)
   </AccordionPanel>
 </Accordion>
 
@@ -553,7 +631,7 @@ The following changes only apply to specific SDKs. Select your SDK below for add
     // nuxt.config.ts
     export default defineNuxtConfig({
       clerk: {
-        routingStrategy: 'hash', // Restore previous behavior
+        routingStrategy: 'hash', // Restore Core 2 behavior
       },
     })
     ```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1607,12 +1607,12 @@
                           "items": [
                             [
                               {
-                                "title": "Core 2",
-                                "href": "/docs/guides/development/upgrading/upgrade-guides/core-2"
-                              },
-                              {
                                 "title": "Core 3",
                                 "href": "/docs/guides/development/upgrading/upgrade-guides/core-3"
+                              },
+                              {
+                                "title": "Core 2",
+                                "href": "/docs/guides/development/upgrading/upgrade-guides/core-2"
                               },
                               {
                                 "title": "Node to Express",


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-fix-satellite-domain-info/guides/development/upgrading/upgrade-guides/core-3#behavior-changes

### What does this solve?

<!-- Why does this change need to happen? Include any links to Slack discussions, Linear comments, etc. -->

- [feat(docs): document satelliteAutoSync option for satellite domains (](https://github.com/clerk/clerk-docs/pull/2873/commits/feb4f72f34d563bfdacd1a380456c96825aff081) PR added a "Migrating from Core 2" section to the guide on satellite domains - we want to keep this information in the upgrade guide.
<img width="1512" height="907" alt="Screenshot 2026-02-03 at 12 55 05" src="https://github.com/user-attachments/assets/394109ec-b9f1-4e8c-8263-1353f75c8391" />


### What changed?

<!-- How does this PR solve that problem you mentioned above? Describe your changes. -->

- Updates the Core 3 upgrade guide to mention the changes surrounding satellite domains

<!--
### Deadline

When do you need this PR reviewed/shipped by?
Optional - uncomment if needed. If not provided, we will prioritize it ourselves.
-->
02/05/26 (ideal, but no rush)