### PR TITLE
Add theming/styling to Expo sign out button example

### DIFF
--- a/docs/_partials/expo/sign-out-custom-flow.mdx
+++ b/docs/_partials/expo/sign-out-custom-flow.mdx
@@ -1,7 +1,8 @@
 ```tsx {{ filename: 'app/components/sign-out-button.tsx', collapsible: true }}
+import { ThemedText } from '@/components/themed-text'
 import { useClerk } from '@clerk/clerk-expo'
 import { useRouter } from 'expo-router'
-import { Text, TouchableOpacity } from 'react-native'
+import { Pressable, StyleSheet } from 'react-native'
 
 export const SignOutButton = () => {
   // Use `useClerk()` to access the `signOut()` function
@@ -21,9 +22,29 @@ export const SignOutButton = () => {
   }
 
   return (
-    <TouchableOpacity onPress={handleSignOut}>
-      <Text>Sign out</Text>
-    </TouchableOpacity>
+    <Pressable
+      style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+      onPress={handleSignOut}
+    >
+      <ThemedText style={styles.buttonText}>Sign out</ThemedText>
+    </Pressable>
   )
 }
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#0a7ea4',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buttonPressed: {
+    opacity: 0.7,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+})
 ```


### PR DESCRIPTION
follow up to https://github.com/clerk/clerk-docs/pull/2952
the sign out button should have had theming/styling - it got left out of the PR 🤒 