### PR TITLE
Add Android docs for activeUser

### DIFF
--- a/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
+++ b/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
@@ -371,7 +371,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
           when (state) {
             ForgotPasswordEmailViewModel.UiState.Complete -> {
-              Text("Active session: ${Clerk.session?.id}")
+              Text("Active session: ${Clerk.activeSession?.id}")
             }
 
             ForgotPasswordEmailViewModel.UiState.NeedsFirstFactor -> {
@@ -740,7 +740,7 @@ In this case, you can prompt the user to reset their password using the exact sa
           Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               when (state) {
                   ForgotPasswordPhoneViewModel.UiState.Complete -> {
-                      Text("Active session: ${Clerk.session?.id}")
+                      Text("Active session: ${Clerk.activeSession?.id}")
                   }
                   ForgotPasswordPhoneViewModel.UiState.NeedsFirstFactor -> {
                       InputContent(placeholder = "Enter your code", buttonText = "Verify", onClick = onVerify)

--- a/docs/guides/development/custom-flows/authentication/email-password.mdx
+++ b/docs/guides/development/custom-flows/authentication/email-password.mdx
@@ -1126,7 +1126,7 @@ This guide will walk you through how to build a custom email/password sign-up an
                     }
 
                     EmailPasswordSignInViewModel.UiState.SignedIn -> {
-                        Text("Current session: ${Clerk.session?.id}")
+                        Text("Current session: ${Clerk.activeSession?.id}")
                     }
 
                     EmailPasswordSignInViewModel.UiState.Loading ->

--- a/docs/reference/native-sdks/user.mdx
+++ b/docs/reference/native-sdks/user.mdx
@@ -4,7 +4,7 @@ description: Manage the signed-in user with the Clerk Android SDK.
 sdk: android
 ---
 
-Use `User` methods to manage the current user's account. You can access the current user reactively with `Clerk.userFlow` or directly with `Clerk.user`.
+Use `User` methods to manage the current user's account. You can access the current user reactively with `Clerk.userFlow` or directly with `Clerk.activeUser`.
 
 ### Reload user
 


### PR DESCRIPTION
This pull request updates documentation references to reflect recent changes in the Clerk Android SDK. The main focus is on updating property names from `session` and `user` to `activeSession` and `activeUser` for improved clarity and consistency.

**Documentation updates for Clerk Android SDK:**

*Updated property references:*
- Replaced `Clerk.session` with `Clerk.activeSession` in code examples for password reset and email/password sign-in flows in `forgot-password.mdx` and `email-password.mdx`. [[1]](diffhunk://#diff-cced24aed5459a05e1f4b140ad86c99205d3e25f10ac84ce345aaf7dbbbf24edL374-R374) [[2]](diffhunk://#diff-cced24aed5459a05e1f4b140ad86c99205d3e25f10ac84ce345aaf7dbbbf24edL743-R743) [[3]](diffhunk://#diff-e8942f832d1b275ef1aa5a653f9bda6fd5cdf709dc31074b70cb3411383b98e5L1129-R1129)
- Updated the user management documentation to use `Clerk.activeUser` instead of `Clerk.user`.