### PR TITLE
Remove asterisk from Developer role permissions

### DIFF
--- a/docs/guides/dashboard/overview.mdx
+++ b/docs/guides/dashboard/overview.mdx
@@ -596,7 +596,7 @@ The **Developer** role focuses on technical configuration and integrations with 
         <CompareYes />
       </td>
 
-      <td><ComparePartial>Dev only\*</ComparePartial></td>
+      <td><ComparePartial>Dev only</ComparePartial></td>
 
       <td>
         <CompareNotApplicable />
@@ -702,7 +702,7 @@ The **Developer** role focuses on technical configuration and integrations with 
         <CompareNo />
       </td>
 
-      <td><ComparePartial>Dev only\*</ComparePartial></td>
+      <td><ComparePartial>Dev only</ComparePartial></td>
     </tr>
   </tbody>
 </ComparisonTable>


### PR DESCRIPTION
### What does this solve? What changed?

Removed the trailing asterisk from "Dev only\*" text in the Developer role's permissions table in the Dashboard overview guide. The asterisk was confusing and didn't add value, so this simplifies the display to just "Dev only".

### Deadline

No rush

🤖 Generated with Claude Code