### PR TITLE
Task components: Add missing setup instructions for JavaScript example

### DIFF
--- a/docs/reference/components/authentication/task-choose-organization.mdx
+++ b/docs/reference/components/authentication/task-choose-organization.mdx
@@ -30,7 +30,7 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
       return (
         <html lang="en">
           <body>
-            <ClerkProvider taskUrls={{ 'choose-organization': '/onboarding/choose-organization' }}>
+            <ClerkProvider taskUrls={{ 'choose-organization': '/session-tasks/choose-organization' }}>
               {children}
             </ClerkProvider>
           </body>
@@ -39,7 +39,7 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
     }
     ```
 
-    ```tsx {{ filename: 'app/onboarding/choose-organization/page.tsx' }}
+    ```tsx {{ filename: 'app/session-tasks/choose-organization/page.tsx' }}
     import { TaskChooseOrganization } from '@clerk/nextjs'
 
     export default function Page() {
@@ -66,7 +66,7 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
       <React.StrictMode>
         <ClerkProvider
           publishableKey={PUBLISHABLE_KEY}
-          taskUrls={{ 'choose-organization': '/onboarding/choose-organization' }}
+          taskUrls={{ 'choose-organization': '/session-tasks/choose-organization' }}
         >
           <App />
         </ClerkProvider>
@@ -74,7 +74,7 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
     )
     ```
 
-    ```jsx {{ filename: 'src/onboarding/choose-organization.tsx' }}
+    ```jsx {{ filename: 'src/session-tasks/choose-organization.tsx' }}
     import { TaskChooseOrganization } from '@clerk/clerk-react'
 
     const ChooseOrganizationPage = () => <TaskChooseOrganization redirectUrlComplete="/dashboard" />
@@ -93,14 +93,14 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
 
     export default function App() {
       return (
-        <ClerkProvider taskUrls={{ 'choose-organization': '/onboarding/choose-organization' }}>
+        <ClerkProvider taskUrls={{ 'choose-organization': '/session-tasks/choose-organization' }}>
           <Outlet />
         </ClerkProvider>
       )
     }
     ```
 
-    ```tsx {{ filename: 'app/routes/onboarding/choose-organization.tsx' }}
+    ```tsx {{ filename: 'app/routes/session-tasks/choose-organization.tsx' }}
     import { TaskChooseOrganization } from '@clerk/react-router'
 
     export default function ChooseOrganizationPage() {
@@ -149,11 +149,11 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
     }
 
     export default ClerkApp(App, {
-      taskUrls: { 'choose-organization': '/onboarding/choose-organization' },
+      taskUrls: { 'choose-organization': '/session-tasks/choose-organization' },
     })
     ```
 
-    ```tsx {{ filename: 'app/routes/onboarding.choose-organization.tsx' }}
+    ```tsx {{ filename: 'app/routes/session-tasks.choose-organization.tsx' }}
     import { TaskChooseOrganization } from '@clerk/remix'
 
     export default function ChooseOrganizationPage() {
@@ -178,7 +178,7 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
             <HeadContent />
           </head>
           <body>
-            <ClerkProvider taskUrls={{ 'choose-organization': '/onboarding/choose-organization' }}>
+            <ClerkProvider taskUrls={{ 'choose-organization': '/session-tasks/choose-organization' }}>
               {children}
             </ClerkProvider>
             <Scripts />
@@ -188,11 +188,11 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
     }
     ```
 
-    ```tsx {{ filename: 'src/routes/onboarding/choose-organization.tsx' }}
+    ```tsx {{ filename: 'src/routes/session-tasks/choose-organization.tsx' }}
     import { TaskChooseOrganization } from '@clerk/tanstack-react-start'
     import { createFileRoute } from '@tanstack/react-router'
 
-    export const Route = createFileRoute('/onboarding/choose-organization')({
+    export const Route = createFileRoute('/session-tasks/choose-organization')({
       component: ChooseOrganizationPage,
     })
 
@@ -205,6 +205,21 @@ If you want to customize the route where the `<TaskChooseOrganization />` compon
 
 <If sdk="js-frontend">
   ## Usage with JavaScript
+
+  You first need to set the `taskUrls` option on the [`clerk.load()`](/docs/reference/javascript/clerk#load) method so that users are redirected to the page where you host the `<TaskChooseOrganization />` component when they have a pending `choose-organization` session task.
+
+  ```js {{ filename: 'main.ts', collapsible: true }}
+  import { Clerk } from '@clerk/clerk-js'
+
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load({
+    taskUrls: {
+      'choose-organization': '/session-tasks/choose-organization',
+    },
+  })
+  ```
 
   The following methods available on an instance of the [`Clerk`](/docs/reference/javascript/clerk) class are used to render and control the `<TaskChooseOrganization />` component:
 

--- a/docs/reference/components/authentication/task-reset-password.mdx
+++ b/docs/reference/components/authentication/task-reset-password.mdx
@@ -30,7 +30,7 @@ If you want to customize the route where the `<TaskResetPassword />` component i
       return (
         <html lang="en">
           <body>
-            <ClerkProvider taskUrls={{ 'reset-password': '/onboarding/reset-password' }}>
+            <ClerkProvider taskUrls={{ 'reset-password': '/session-tasks/reset-password' }}>
               {children}
             </ClerkProvider>
           </body>
@@ -39,7 +39,7 @@ If you want to customize the route where the `<TaskResetPassword />` component i
     }
     ```
 
-    ```tsx {{ filename: 'app/onboarding/reset-password/page.tsx' }}
+    ```tsx {{ filename: 'app/session-tasks/reset-password/page.tsx' }}
     import { TaskResetPassword } from '@clerk/nextjs'
 
     export default function Page() {
@@ -66,7 +66,7 @@ If you want to customize the route where the `<TaskResetPassword />` component i
       <React.StrictMode>
         <ClerkProvider
           publishableKey={PUBLISHABLE_KEY}
-          taskUrls={{ 'reset-password': '/onboarding/reset-password' }}
+          taskUrls={{ 'reset-password': '/session-tasks/reset-password' }}
         >
           <App />
         </ClerkProvider>
@@ -74,7 +74,7 @@ If you want to customize the route where the `<TaskResetPassword />` component i
     )
     ```
 
-    ```jsx {{ filename: 'src/onboarding/reset-password.tsx' }}
+    ```jsx {{ filename: 'src/session-tasks/reset-password.tsx' }}
     import { TaskResetPassword } from '@clerk/clerk-react'
 
     const ResetPasswordPage = () => <TaskResetPassword redirectUrlComplete="/dashboard" />
@@ -93,14 +93,14 @@ If you want to customize the route where the `<TaskResetPassword />` component i
 
     export default function App() {
       return (
-        <ClerkProvider taskUrls={{ 'reset-password': '/onboarding/reset-password' }}>
+        <ClerkProvider taskUrls={{ 'reset-password': '/session-tasks/reset-password' }}>
           <Outlet />
         </ClerkProvider>
       )
     }
     ```
 
-    ```tsx {{ filename: 'app/routes/onboarding/reset-password.tsx' }}
+    ```tsx {{ filename: 'app/routes/session-tasks/reset-password.tsx' }}
     import { TaskResetPassword } from '@clerk/react-router'
 
     export default function ResetPasswordPage() {
@@ -149,11 +149,11 @@ If you want to customize the route where the `<TaskResetPassword />` component i
     }
 
     export default ClerkApp(App, {
-      taskUrls: { 'reset-password': '/onboarding/reset-password' },
+      taskUrls: { 'reset-password': '/session-tasks/reset-password' },
     })
     ```
 
-    ```tsx {{ filename: 'app/routes/onboarding.reset-password.tsx' }}
+    ```tsx {{ filename: 'app/routes/session-tasks.reset-password.tsx' }}
     import { TaskResetPassword } from '@clerk/remix'
 
     export default function ResetPasswordPage() {
@@ -178,7 +178,7 @@ If you want to customize the route where the `<TaskResetPassword />` component i
             <HeadContent />
           </head>
           <body>
-            <ClerkProvider taskUrls={{ 'reset-password': '/onboarding/reset-password' }}>
+            <ClerkProvider taskUrls={{ 'reset-password': '/session-tasks/reset-password' }}>
               {children}
             </ClerkProvider>
             <Scripts />
@@ -188,11 +188,11 @@ If you want to customize the route where the `<TaskResetPassword />` component i
     }
     ```
 
-    ```tsx {{ filename: 'src/routes/onboarding/reset-password.tsx' }}
+    ```tsx {{ filename: 'src/routes/session-tasks/reset-password.tsx' }}
     import { TaskResetPassword } from '@clerk/tanstack-react-start'
     import { createFileRoute } from '@tanstack/react-router'
 
-    export const Route = createFileRoute('/onboarding/reset-password')({
+    export const Route = createFileRoute('/session-tasks/reset-password')({
       component: ResetPasswordPage,
     })
 
@@ -205,6 +205,21 @@ If you want to customize the route where the `<TaskResetPassword />` component i
 
 <If sdk="js-frontend">
   ## Usage with JavaScript
+
+  You first need to set the `taskUrls` option on the [`clerk.load()`](/docs/reference/javascript/clerk#load) method so that users are redirected to the page where you host the `<TaskResetPassword />` component when they have a pending `reset-password` session task.
+
+  ```js {{ filename: 'main.ts', collapsible: true }}
+  import { Clerk } from '@clerk/clerk-js'
+
+  const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+  const clerk = new Clerk(clerkPubKey)
+  await clerk.load({
+    taskUrls: {
+      'reset-password': '/session-tasks/reset-password',
+    },
+  })
+  ```
 
   The following methods available on an instance of the [`Clerk`](/docs/reference/javascript/clerk) class are used to render and control the `<TaskResetPassword />` component:
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-update-task-components/nextjs/reference/components/authentication/task-choose-organization
- https://clerk.com/docs/pr/aa-update-task-components/nextjs/reference/components/authentication/task-reset-password

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

When configuring session tasks for your app, you need to set up the `taskUrls` option. This PR adds the instructions that were missing for JavaScript in the task component references (`<TaskChooseOrganization/>` and `<TaskResetPassword />`).

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

No rush