### PR TITLE
Next.js: Remove beforeYouStart from quickstart hero

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -14,13 +14,6 @@ llm:
       link: "https://github.com/clerk/clerk-nextjs-app-quickstart"
     }
   ]}
-  beforeYouStart={[
-    {
-      title: "Set up a Clerk application",
-      link: "/docs/getting-started/quickstart/setup-clerk",
-      icon: "clerk",
-    },
-  ]}
 />
 
 <Steps>


### PR DESCRIPTION
### Previews

- [Next.js Quickstart (App Router)](https://clerk.com/docs/pr/manovotny-quickstart-updates/nextjs/getting-started/quickstart)

### What does this solve? What changed?

Removes the "beforeYouStart" hero section from the Next.js App Router quickstart page. 

Since the Next.js Quickstart App Router quickstart highlights keyless usage, having a Clerk account before you start is not necessary.

### Deadline

No rush

### Other resources

- [Slack thread](https://clerkinc.slack.com/archives/C01QFRQNHSN/p1770661033466699)