### PR TITLE
Update membership limit for orgs to 20 members without the add-on

### DIFF
--- a/docs/guides/organizations/configure.mdx
+++ b/docs/guides/organizations/configure.mdx
@@ -37,13 +37,13 @@ Once Organizations are enabled, you can configure core features and behaviors, s
 
 There is no limit to the number of Organizations a user can be a member of.
 
-Each Organization allows a maximum of 5 members by default. You can increase this limit as your customer base grows, or set different limits for individual Organizations if you have different pricing tiers.
+Each Organization allows a maximum of 5 members by default. You can increase this limit as your customer base grows, or set different limits for individual Organizations.
 
 To change the membership limit for all Organizations in your application:
 
 1. In the Clerk Dashboard, navigate to the [**Organizations Settings**](https://dashboard.clerk.com/~/organizations-settings) page.
 1. In the **Default membership limit** section, update the membership limit.
-   - **Without B2B Authentication add-on**: Allows a maximum of 5 members in an Organization
+   - **Without B2B Authentication add-on**: Allows a maximum of 20 members in an Organization
    - **With B2B Authentication add-on**: Allows unlimited members in an Organization
 
 To change the membership limit for a specific Organization:


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/stef-update-org-members-5-to-20/guides/organizations/configure

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- We keep the default to be 5 members per org. They can increase the limit up to 20 in the Hobby plan. For unlimited or above 20 they need the B2B Authentication add-on.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- Urgent

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
