### PR TITLE
chore(ci): Set minimal token permissions

### DIFF
--- a/.github/workflows/check-do-not-merge.yml
+++ b/.github/workflows/check-do-not-merge.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   allow-merge:
     name: Allow Merge

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -46,6 +49,9 @@ jobs:
     needs: check_quickstarts
     if: contains(needs.check_quickstarts.outputs.output, 'Please update the corresponding quickstarts in the Dashboard')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/plain-ingest.yml
+++ b/.github/workflows/plain-ingest.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 */3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Index Documents

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,6 +7,9 @@ on:
       - 'scripts/build-docs.test.ts'
       - 'scripts/lib/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 🔎 Previews:

No changes.

### What does this solve? What changed?

This fixes a few GitHub code scanning alerts by limiting the scope of `GITHUB_TOKEN` in our workflows. It limits the blast radius if CI is compromised.

### Deadline

No rush

### Other resources

Not sure if everyone can see it, but the findings were in https://github.com/clerk/clerk-docs/security/code-scanning