### PR TITLE
Update Clerk package references

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/ios-v1.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/ios-v1.mdx
@@ -31,8 +31,8 @@ sdk: ios
     .target(
       name: "YourApp",
       dependencies: [
-        .product(name: "ClerkKit", package: "Clerk"),
-        .product(name: "ClerkKitUI", package: "Clerk") // Optional if using ClerkKitUI
+        .product(name: "ClerkKit", package: "clerk-ios"),
+        .product(name: "ClerkKitUI", package: "clerk-ios") // Optional if using ClerkKitUI
       ]
     ),
   ]

--- a/docs/reference/native-mobile/installation.ios.mdx
+++ b/docs/reference/native-mobile/installation.ios.mdx
@@ -29,8 +29,8 @@ targets: [
   .target(
     name: "YourApp",
     dependencies: [
-      .product(name: "ClerkKit", package: "Clerk"),
-      .product(name: "ClerkKitUI", package: "Clerk")
+      .product(name: "ClerkKit", package: "clerk-ios"),
+      .product(name: "ClerkKitUI", package: "clerk-ios")
     ]
   )
 ]


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/sean-update-package-instructions/ios/reference/native-mobile/installation#install-via-package-swift
- https://clerk.com/docs/pr/sean-update-package-instructions/guides/development/upgrading/upgrade-guides/ios-v1#package-swift

### What does this solve? What changed?

Updated package name in instructions
