### PR TITLE
Temporarily disable <If /> SDK validation for Core 3, Development SDK-specificity, and native mobile docs sidebars

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1241,8 +1241,9 @@ Testing with a simple page.`,
     expect(output).toContain(`warning sdk \"astro\" in <If /> is not a valid SDK`)
   })
 
-  // TODO: Temporarily skipped during large-scale SDK changes — re-enable when safeFail is restored in validateIfComponents.ts
-  console.warn('⚠️  <If> SDK not in frontmatter test skipped (validation temporarily disabled)')
+  // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
+  // Change back when `safeFail` is restored in validateIfComponents.ts
+  console.warn('⚠️  TEMPORARILY DISABLED: <If> SDK not in frontmatter test skipped')
   test.skip('<If> SDK not in frontmatter fails the build', async () => {
     const { tempDir } = await createTempFiles([
       {
@@ -1281,8 +1282,9 @@ Testing with a simple page.`,
     )
   })
 
-  // TODO: Temporarily skipped during large-scale SDK changes — re-enable when safeFail is restored in validateIfComponents.ts
-  console.warn('⚠️  <If> SDK not in manifest test skipped (validation temporarily disabled)')
+  // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
+  // Change back when `safeFail` is restored in validateIfComponents.ts
+  console.warn('⚠️  TEMPORARILY DISABLED: <If> SDK not in manifest test skipped')
   test.skip('<If> SDK not in manifest fails the build', async () => {
     const { tempDir } = await createTempFiles([
       {

--- a/scripts/lib/plugins/validateIfComponents.ts
+++ b/scripts/lib/plugins/validateIfComponents.ts
@@ -82,10 +82,9 @@ export const validateIfComponents =
           const available = doc.sdk.includes(sdk)
 
           if (available === false) {
-            // TODO: Temporarily disabled during large-scale SDK changes — change back to safeFail when done
-            console.warn(
-              `⚠️  <If /> sdk "${sdk}" not in frontmatter for ${filePath} (validation temporarily disabled)`,
-            )
+            // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
+            // Change back to `safeFail` when done.
+            console.warn(`⚠️  TEMPORARILY DISABLED: <If /> sdk "${sdk}" not in frontmatter for ${filePath}`)
           }
         })()
         ;(() => {
@@ -95,10 +94,9 @@ export const validateIfComponents =
           const available = availableSDKs.includes(sdk)
 
           if (available === false) {
-            // TODO: Temporarily disabled during large-scale SDK changes — change back to safeFail when done
-            console.warn(
-              `⚠️  <If /> sdk "${sdk}" not in manifest for ${doc.file.href} (validation temporarily disabled)`,
-            )
+            // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
+            // Change back to `safeFail` when done.
+            console.warn(`⚠️  TEMPORARILY DISABLED: <If /> sdk "${sdk}" not in manifest for ${doc.file.href}`)
           }
         })()
       })


### PR DESCRIPTION
## Summary
- Replaced `safeFail` calls with `console.warn` in `validateIfComponents.ts` so builds no longer fail when `<If />` components reference SDKs not yet in the manifest or frontmatter
- Skipped 2 corresponding tests in `build-docs.test.ts` that assert the build throws on these conditions
- All changes marked with `TODO` comments for easy reversal

This is temporary while large-scale SDK changes are in flight (Core 3, development SDK-specificity, native mobile docs sidebars).

## Test plan
- [x] `pnpm test` passes (build-docs suite: 155 passed, 2 skipped)
- [x] Warnings print to console but do not fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)