### PR TITLE
feat(public-user-data): add username into public user data

### DIFF
--- a/docs/reference/javascript/types/public-user-data.mdx
+++ b/docs/reference/javascript/types/public-user-data.mdx
@@ -48,4 +48,11 @@ Information about the user that's publicly available.
   - `string | null`
 
   The user's ID.
+
+  ---
+
+  - `username?`
+  - `string | null`
+
+  The user's username.
 </Properties>


### PR DESCRIPTION
Update PublicUserData with username field.

### 🔎 Previews:

<img width="1475" height="730" alt="image" src="https://github.com/user-attachments/assets/49d4f5c0-ffd2-4716-9867-00cb699b8d74" />

### What does this solve? What changed?

Add username field into PublicUserData object.

