### PR TITLE
Fix broken Next.js and Remix guide URLs in docs

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -3027,6 +3027,14 @@
     "destination": "/docs/guides/users/reading"
   },
   {
+    "source": "/docs/reference/nextjs/custom-signup-signin-pages",
+    "destination": "/docs/guides/development/custom-sign-in-or-up-page"
+  },
+  {
+    "source": "/docs/reference/remix/custom-signup-signin-pages",
+    "destination": "/docs/guides/development/custom-sign-in-or-up-page"
+  },
+  {
     "source": "/docs/reference/nextjs/custom-sign-in-or-up-page",
     "destination": "/docs/guides/development/custom-sign-in-or-up-page"
   },


### PR DESCRIPTION
### 🔎 Previews:

- N/A (redirect-only change)

### What does this solve? What changed?

- Fixes broken documentation links (404s) in the Clerk Dashboard onboarding flow. When users click "Continue to the Next.js guide" or "Continue to the Remix guide" buttons, they were redirected to non-existent documentation pages.
- The Dashboard was linking to `/docs/reference/{nextjs,remix}/custom-signup-signin-pages`, but these pages no longer exist under the new documentation structure. This PR adds permanent redirects from the old URLs to the current guide: `/docs/guides/development/custom-sign-in-or-up-page`.

### Deadline

- No rush

### Other resources

- User report: https://github.com/clerk/clerk-docs/issues/3076
- Linear: https://linear.app/clerk/issue/DOCS-11495/nextjs-guide-issue
- Dashboard fix: https://github.com/clerk/dashboard/pull/8415