### PR TITLE
fix: Update `<TaskSetupMfa />` references to `<TaskSetupMFA />`

### DIFF
--- a/docs/guides/configure/session-tasks.mdx
+++ b/docs/guides/configure/session-tasks.mdx
@@ -34,7 +34,7 @@ The following table lists the available tasks and their corresponding components
 | - | - |
 | [Personal Accounts disabled (default)](/docs/guides/organizations/configure#enable-organizations) | [`<TaskChooseOrganization />`](/docs/reference/components/authentication/task-choose-organization) |
 | [Force password reset](/docs/guides/secure/password-protection-and-rules#manually-set-a-password-as-compromised) | [`<TaskResetPassword />`](/docs/reference/components/authentication/task-reset-password) |
-| [Require multi-factor authentication](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication) | [`<TaskSetupMfa />`](/docs/reference/components/authentication/task-setup-mfa) |
+| [Require multi-factor authentication](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication) | [`<TaskSetupMFA />`](/docs/reference/components/authentication/task-setup-mfa) |
 
 ### No components, no problem
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3380,7 +3380,7 @@
                           "href": "/docs/reference/components/authentication/task-reset-password"
                         },
                         {
-                          "title": "`<TaskSetupMfa />`",
+                          "title": "`<TaskSetupMFA />`",
                           "href": "/docs/reference/components/authentication/task-setup-mfa"
                         },
                         {

--- a/docs/reference/components/authentication/task-setup-mfa.mdx
+++ b/docs/reference/components/authentication/task-setup-mfa.mdx
@@ -1,26 +1,26 @@
 ---
-title: '`<TaskSetupMfa />` component'
-description: Clerk's <TaskSetupMfa /> component renders a UI for resolving the `setup-mfa` task.
+title: '`<TaskSetupMFA />` component'
+description: Clerk's <TaskSetupMFA /> component renders a UI for resolving the `setup-mfa` task.
 sdk: js-frontend, nextjs, react, react-router, tanstack-react-start
 ---
 
-![The \<TaskSetupMfa /> component renders a UI for resolving the setup-mfa session task.](/docs/images/ui-components/task-setup-mfa.png){{ style: { maxWidth: '460px' } }}
+![The \<TaskSetupMFA /> component renders a UI for resolving the setup-mfa session task.](/docs/images/ui-components/task-setup-mfa.png){{ style: { maxWidth: '460px' } }}
 
-The `<TaskSetupMfa />` component renders a UI for resolving the `setup-mfa` [session task](!session-tasks). You can further customize your `<TaskSetupMfa />` component by passing additional [properties](#properties) at the time of rendering.
+The `<TaskSetupMFA />` component renders a UI for resolving the `setup-mfa` [session task](!session-tasks). You can further customize your `<TaskSetupMFA />` component by passing additional [properties](#properties) at the time of rendering.
 
 > [!IMPORTANT]
-> The `<TaskSetupMfa/>` component cannot render when a user doesn't have current session tasks.
+> The `<TaskSetupMFA/>` component cannot render when a user doesn't have current session tasks.
 
-## When to use `<TaskSetupMfa />`
+## When to use `<TaskSetupMFA />`
 
-Clerk's sign-in flows, such as the [Sign-in Account Portal page](/docs/guides/account-portal/overview#sign-in), [`<SignInButton />`](/docs/reference/components/unstyled/sign-in-button), and [`<SignIn />`](/docs/reference/components/authentication/sign-in) component, automatically handle the `setup-mfa` session task flow for you, including rendering the `<TaskSetupMfa />` component when needed.
+Clerk's sign-in flows, such as the [Sign-in Account Portal page](/docs/guides/account-portal/overview#sign-in), [`<SignInButton />`](/docs/reference/components/unstyled/sign-in-button), and [`<SignIn />`](/docs/reference/components/authentication/sign-in) component, automatically handle the `setup-mfa` session task flow for you, including rendering the `<TaskSetupMFA />` component when needed.
 
-If you want to customize the route where the `<TaskSetupMfa />` component is rendered or customize its appearance, you can host it yourself within your application.
+If you want to customize the route where the `<TaskSetupMFA />` component is rendered or customize its appearance, you can host it yourself within your application.
 
 <If notSdk="js-frontend">
   ## Example
 
-  The following example demonstrates how to host the `<TaskSetupMfa />` component on a custom page. You first need to [set the `taskUrls` option on your Clerk integration](/docs/guides/configure/session-tasks#using-the-task-urls-option) so that users are redirected to the page where you host the `<TaskSetupMfa />` component when they have a pending `setup-mfa` session task.
+  The following example demonstrates how to host the `<TaskSetupMFA />` component on a custom page. You first need to [set the `taskUrls` option on your Clerk integration](/docs/guides/configure/session-tasks#using-the-task-urls-option) so that users are redirected to the page where you host the `<TaskSetupMFA />` component when they have a pending `setup-mfa` session task.
 
   <If sdk="nextjs">
     ```tsx {{ filename: 'app/layout.tsx', mark: [7] }}
@@ -40,10 +40,10 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
     ```
 
     ```tsx {{ filename: 'app/session-tasks/setup-mfa/page.tsx' }}
-    import { TaskSetupMfa } from '@clerk/nextjs'
+    import { TaskSetupMFA } from '@clerk/nextjs'
 
     export default function Page() {
-      return <TaskSetupMfa redirectUrlComplete="/dashboard" />
+      return <TaskSetupMFA redirectUrlComplete="/dashboard" />
     }
     ```
   </If>
@@ -75,9 +75,9 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
     ```
 
     ```jsx {{ filename: 'src/session-tasks/setup-mfa.tsx' }}
-    import { TaskSetupMfa } from '@clerk/react'
+    import { TaskSetupMFA } from '@clerk/react'
 
-    const SetupMfaPage = () => <TaskSetupMfa redirectUrlComplete="/dashboard" />
+    const SetupMfaPage = () => <TaskSetupMFA redirectUrlComplete="/dashboard" />
 
     export default SetupMfaPage
     ```
@@ -101,10 +101,10 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
     ```
 
     ```tsx {{ filename: 'app/routes/session-tasks/setup-mfa.tsx' }}
-    import { TaskSetupMfa } from '@clerk/react-router'
+    import { TaskSetupMFA } from '@clerk/react-router'
 
     export default function SetupMfaPage() {
-      return <TaskSetupMfa redirectUrlComplete="/dashboard" />
+      return <TaskSetupMFA redirectUrlComplete="/dashboard" />
     }
     ```
   </If>
@@ -136,7 +136,7 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
     ```
 
     ```tsx {{ filename: 'src/routes/session-tasks/setup-mfa.tsx' }}
-    import { TaskSetupMfa } from '@clerk/tanstack-react-start'
+    import { TaskSetupMFA } from '@clerk/tanstack-react-start'
     import { createFileRoute } from '@tanstack/react-router'
 
     export const Route = createFileRoute('/session-tasks/setup-mfa')({
@@ -144,7 +144,7 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
     })
 
     function SetupMfaPage() {
-      return <TaskSetupMfa redirectUrlComplete="/dashboard" />
+      return <TaskSetupMFA redirectUrlComplete="/dashboard" />
     }
     ```
   </If>
@@ -153,7 +153,7 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
 <If sdk="js-frontend">
   ## Usage with JavaScript
 
-  You first need to set the `taskUrls` option on the [`clerk.load()`](/docs/reference/javascript/clerk#load) method so that users are redirected to the page where you host the `<TaskSetupMfa />` component when they have a pending `setup-mfa` session task.
+  You first need to set the `taskUrls` option on the [`clerk.load()`](/docs/reference/javascript/clerk#load) method so that users are redirected to the page where you host the `<TaskSetupMFA />` component when they have a pending `setup-mfa` session task.
 
   ```js {{ filename: 'main.ts', collapsible: true }}
   import { Clerk } from '@clerk/clerk-js'
@@ -168,38 +168,38 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
   })
   ```
 
-  The following methods available on an instance of the [`Clerk`](/docs/reference/javascript/clerk) class are used to render and control the `<TaskSetupMfa />` component:
+  The following methods available on an instance of the [`Clerk`](/docs/reference/javascript/clerk) class are used to render and control the `<TaskSetupMFA />` component:
 
-  - [`mountTaskSetupMfa()`](#mount-task-setup-mfa)
-  - [`unmountTaskSetupMfa()`](#unmount-task-setup-mfa)
+  - [`mountTaskSetupMFA()`](#mount-task-setup-mfa)
+  - [`unmountTaskSetupMFA()`](#unmount-task-setup-mfa)
 
   The following examples assume that you have followed the [quickstart](/docs/js-frontend/getting-started/quickstart) in order to add Clerk to your JavaScript application.
 
-  ### `mountTaskSetupMfa()`
+  ### `mountTaskSetupMFA()`
 
-  Render the `<TaskSetupMfa />` component to an HTML `<div>` element.
+  Render the `<TaskSetupMFA />` component to an HTML `<div>` element.
 
   ```typescript
-  function mountTaskSetupMfa(node: HTMLDivElement, props?: TaskSetupMfaProps): void
+  function mountTaskSetupMFA(node: HTMLDivElement, props?: TaskSetupMFAProps): void
   ```
 
-  #### `mountTaskSetupMfa()` params
+  #### `mountTaskSetupMFA()` params
 
   <Properties>
     - `node `
     - [`HTMLDivElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement)
 
-    The `<div>` element used to render in the `<TaskSetupMfa />` component
+    The `<div>` element used to render in the `<TaskSetupMFA />` component
 
     ---
 
     - `props?`
-    - [`TaskSetupMfaProps`](#properties)
+    - [`TaskSetupMFAProps`](#properties)
 
-    The properties to pass to the `<TaskSetupMfa />` component.
+    The properties to pass to the `<TaskSetupMFA />` component.
   </Properties>
 
-  #### `mountTaskSetupMfa()` usage
+  #### `mountTaskSetupMFA()` usage
 
   ```typescript {{ filename: 'main.ts', mark: [26] }}
   import { Clerk } from '@clerk/clerk-js'
@@ -227,21 +227,21 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
 
         const taskSetupMfaDiv = document.getElementById('task-setup-mfa')
 
-        clerk.mountTaskSetupMfa(taskSetupMfaDiv)
+        clerk.mountTaskSetupMFA(taskSetupMfaDiv)
       }
     }
   }
   ```
 
-  ### `unmountTaskSetupMfa()`
+  ### `unmountTaskSetupMFA()`
 
-  Unmount and run cleanup on an existing `<TaskSetupMfa />` component instance.
+  Unmount and run cleanup on an existing `<TaskSetupMFA />` component instance.
 
   ```typescript
-  function unmountTaskSetupMfa(node: HTMLDivElement): void
+  function unmountTaskSetupMFA(node: HTMLDivElement): void
   ```
 
-  #### `unmountTaskSetupMfa()` params
+  #### `unmountTaskSetupMFA()` params
 
   <Properties>
     - `node `
@@ -250,7 +250,7 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
     The container `<div>` element with a rendered `<SignUp />` component instance
   </Properties>
 
-  #### `unmountTaskSetupMfa()` usage
+  #### `unmountTaskSetupMFA()` usage
 
   ```typescript {{ filename: 'main.ts', mark: [30] }}
   import { Clerk } from '@clerk/clerk-js'
@@ -278,11 +278,11 @@ If you want to customize the route where the `<TaskSetupMfa />` component is ren
 
         const taskSetupMfaDiv = document.getElementById('task-setup-mfa')
 
-        clerk.mountTaskSetupMfa(taskSetupMfaDiv)
+        clerk.mountTaskSetupMFA(taskSetupMfaDiv)
 
         // ...
 
-        clerk.unmountTaskSetupMfa(taskSetupMfaDiv)
+        clerk.unmountTaskSetupMFA(taskSetupMfaDiv)
       }
     }
   }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/vaggelis-fix-task-setup-mfa-naming/guides/configure/session-tasks
- https://clerk.com/docs/pr/vaggelis-fix-task-setup-mfa-naming/reference/components/authentication/task-setup-mfa

### What does this solve? What changed?

- We have rename the component from `<TaskSetupMfa />` references to `<TaskSetupMFA />` (this is not breaking as it's not released yet)

### Deadline
- N/A

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
