### PR TITLE
docs: add TanStack Start section to Core 3 upgrade guide

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -438,7 +438,7 @@ The following deprecated APIs have been removed from all Clerk SDKs.
 
 The following changes only apply to specific SDKs. Select your SDK below for additional upgrade steps.
 
-<Tabs items={['React', 'Next.js', 'TanStack Start', 'Expo', 'Nuxt']}>
+<Tabs items={['React', 'Next.js', 'TanStack React Start', 'Expo', 'Nuxt']}>
   <Tab>
     {/* React */}
 
@@ -499,7 +499,7 @@ The following changes only apply to specific SDKs. Select your SDK below for add
   </Tab>
 
   <Tab>
-    {/* TanStack Start */}
+    {/* TanStack React Start */}
 
     ### Minimum TanStack version increased {{ toc: false }}
 


### PR DESCRIPTION
## Summary

- Adds a **TanStack Start** tab to the SDK-specific changes section of the Core 3 upgrade guide
- Documents the peer dependency requirement: `@tanstack/react-start@^1.157.0` (along with matching `@tanstack/react-router` and `@tanstack/react-router-devtools`)
- Includes a diff example for users who pin TanStack versions

## Test plan

- [ ] Verify the TanStack Start tab renders correctly in the docs preview
- [ ] Confirm tab order is logical: React, Next.js, TanStack Start, Expo, Nuxt