### PR TITLE
docs: make Core 3 upgrade guide more beginner-friendly

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -33,6 +33,7 @@ To run the CLI, open your terminal, navigate to your project directory, and run 
 
 ```npm
 npx @clerk/upgrade
+```
 
 The CLI will walk you through the changes it detects. For most projects, this will handle the majority of the upgrade automatically.
 


### PR DESCRIPTION
## Summary

- Adds a "Preparing to upgrade" section with Node.js version check and recommendation to update to latest Core 2 first
- Adds a dedicated "Upgrade using the CLI" section with `CodeBlockTabs` for all four package managers (npm, yarn, pnpm, bun), replacing the single-line CLI mention
- Updates the Overview to lead with the most user-facing change (component consolidation) and link to the CLI section
- Adds Astro caveat note and sets expectations for the rest of the guide

Addresses [USER-4734](https://linear.app/clerk/issue/USER-4734) — feedback that the Core 3 upgrade guide has a more advanced tone compared to the Core 2 guide and could better serve less experienced users.

## Test plan

- [ ] Verify the page renders correctly on the preview deployment
- [ ] Confirm `CodeBlockTabs` renders all four package manager tabs
- [ ] Confirm the `#upgrade-using-the-cli` and `#sdk-specific-changes` anchor links work