### PR TITLE
feat: Add `needs_client_trust` status

### DIFF
--- a/docs/_partials/expo/email-pass-sign-in.mdx
+++ b/docs/_partials/expo/email-pass-sign-in.mdx
@@ -17,6 +17,7 @@ export default function Page() {
   const [password, setPassword] = React.useState('')
   const [code, setCode] = React.useState('')
   const [useBackupCode, setUseBackupCode] = React.useState(false)
+  const [showEmailCode, setShowEmailCode] = React.useState(false)
 
   // Handle the submission of the sign-in form
   const onSignInPress = React.useCallback(async () => {
@@ -31,11 +32,18 @@ export default function Page() {
           router.push(decorateUrl('/'))
         },
       })
+    } else if (signIn.status === 'needs_client_trust') {
+      // 'needs_client_trust' is returned when Client Trust is enabled
+      // and the user is signing in from a new device.
+      // Client Trust requires email code verification.
+      // See https://clerk.com/docs/guides/secure/client-trust
+      await signIn.mfa.sendEmailCode()
+      setShowEmailCode(true)
     }
   }, [signIn, emailAddress, password, router])
 
-  // Handle the submission of the MFA code
-  const onVerifyPress = React.useCallback(async () => {
+  // Handle the submission of the MFA TOTP code
+  const onVerifyTOTPPress = React.useCallback(async () => {
     if (useBackupCode) {
       await signIn.mfa.verifyBackupCode({ code })
     } else {
@@ -51,11 +59,56 @@ export default function Page() {
     }
   }, [signIn, code, useBackupCode, router])
 
+  // Handle the submission of the email verification code
+  const onVerifyEmailCodePress = React.useCallback(async () => {
+    await signIn.mfa.verifyEmailCode({ code })
+
+    if (signIn.status === 'complete') {
+      await signIn.finalize({
+        navigate: ({ decorateUrl }) => {
+          router.push(decorateUrl('/'))
+        },
+      })
+    }
+  }, [signIn, code, router])
+
   if (signIn.status === 'complete' || isSignedIn) {
     return null
   }
 
-  // Display MFA verification form
+  // Display email code verification form for Client Trust
+  // 'needs_client_trust' is returned when Client Trust is enabled
+  // and the user is signing in from a new device.
+  // See https://clerk.com/docs/guides/secure/client-trust
+  if (signIn.status === 'needs_client_trust' || showEmailCode) {
+    return (
+      <ThemedView style={styles.container}>
+        <ThemedText type="title" style={styles.title}>
+          Verify your email
+        </ThemedText>
+        <ThemedText style={styles.description}>
+          A verification code has been sent to your email.
+        </ThemedText>
+        <TextInput
+          style={styles.input}
+          value={code}
+          placeholder="Enter verification code"
+          placeholderTextColor="#666666"
+          onChangeText={(code) => setCode(code)}
+          keyboardType="numeric"
+        />
+        <Pressable
+          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+          onPress={onVerifyEmailCodePress}
+        >
+          <ThemedText style={styles.buttonText}>Verify</ThemedText>
+        </Pressable>
+      </ThemedView>
+    )
+  }
+
+  // Display MFA TOTP verification form
+  // 'needs_second_factor' is returned when the user has MFA enabled.
   if (signIn.status === 'needs_second_factor') {
     return (
       <ThemedView style={styles.container}>
@@ -79,7 +132,7 @@ export default function Page() {
         </View>
         <Pressable
           style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
-          onPress={onVerifyPress}
+          onPress={onVerifyTOTPPress}
         >
           <ThemedText style={styles.buttonText}>Verify</ThemedText>
         </Pressable>

--- a/docs/guides/development/custom-flows/authentication/email-password.mdx
+++ b/docs/guides/development/custom-flows/authentication/email-password.mdx
@@ -370,7 +370,7 @@ This guide will walk you through how to build a custom email/password sign-up an
   <If sdk={["nextjs", "react", "expo", "js-frontend", "react-router", "tanstack-react-start"]}>
     1. Initiate the sign-in process by collecting the user's email address and password with the [`signIn.password()`](/docs/reference/javascript/sign-in-future#password) method.
     1. If the attempt is successful, finalize the sign-in with the [`signIn.finalize()`](/docs/reference/javascript/sign-in-future#finalize) method to set the newly created session as the active session.
-    1. If the `signIn.status` is `'needs_second_factor'`, display a form to collect the TOTP code and verify it with the [`signIn.mfa.verifyTOTP()`](/docs/reference/javascript/sign-in-future#mfa-verify-totp) method. For more information on this requirement, see the [Client Trust](/docs/guides/secure/client-trust) guide.
+    1. If the `signIn.status` is `'needs_client_trust'` or `'needs_second_factor'`, the user must complete a [second factor verification](!second-factor-verification). `'needs_client_trust'` is returned when [Client Trust](/docs/guides/secure/client-trust) is enabled and the user is signing in from a new device. Check `supportedSecondFactors` for `email_code`, send an email verification code with the [`signIn.mfa.sendEmailCode()`](/docs/reference/javascript/sign-in-future#mfa-send-email-code) method, and verify it with the [`signIn.mfa.verifyEmailCode()`](/docs/reference/javascript/sign-in-future#mfa-verify-email-code) method. `'needs_second_factor'` is returned when the user has [MFA](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication) enabled. For details on handling TOTP and backup codes, see the [MFA custom flow guide](/docs/guides/development/custom-flows/authentication/email-password-mfa).
 
     <If notSdk="expo">
       **This example is written for Next.js App Router but it can be adapted for any React-based framework, such as React Router or Tanstack React Start.**
@@ -381,10 +381,12 @@ This guide will walk you through how to build a custom email/password sign-up an
       import * as React from 'react'
       import { useSignIn } from '@clerk/nextjs'
       import { useRouter } from 'next/navigation'
+      import type { EmailCodeFactor } from '@clerk/types'
 
       export default function SignInForm() {
         const { signIn, errors, fetchStatus } = useSignIn()
         const router = useRouter()
+        const [showEmailCode, setShowEmailCode] = React.useState(false)
 
         const handleSubmit = async (formData: FormData) => {
           const emailAddress = formData.get('email') as string
@@ -405,18 +407,30 @@ This guide will walk you through how to build a custom email/password sign-up an
                 }
               },
             })
+          } else if (
+            signIn.status === 'needs_client_trust' ||
+            signIn.status === 'needs_second_factor'
+          ) {
+            // 'needs_client_trust' is returned when Client Trust is enabled
+            // and the user is signing in from a new device.
+            // 'needs_second_factor' is returned when the user has MFA enabled.
+            // In both cases, check supportedSecondFactors for 'email_code'.
+            // See https://clerk.com/docs/guides/secure/client-trust
+            const emailCodeFactor = signIn.supportedSecondFactors.find(
+              (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+            )
+
+            if (emailCodeFactor) {
+              await signIn.mfa.sendEmailCode()
+              setShowEmailCode(true)
+            }
           }
         }
 
-        const handleSubmitTOTP = async (formData: FormData) => {
+        const handleVerifyEmailCode = async (formData: FormData) => {
           const code = formData.get('code') as string
-          const useBackupCode = formData.get('useBackupCode') === 'on'
 
-          if (useBackupCode) {
-            await signIn.mfa.verifyBackupCode({ code })
-          } else {
-            await signIn.mfa.verifyTOTP({ code })
-          }
+          await signIn.mfa.verifyEmailCode({ code })
 
           if (signIn.status === 'complete') {
             await signIn.finalize({
@@ -432,21 +446,16 @@ This guide will walk you through how to build a custom email/password sign-up an
           }
         }
 
-        if (signIn.status === 'needs_second_factor') {
+        if (showEmailCode) {
           return (
             <div>
-              <h1>Verify your account</h1>
-              <form action={handleSubmitTOTP}>
+              <h1>Verify your email</h1>
+              <p>A verification code has been sent to your email.</p>
+              <form action={handleVerifyEmailCode}>
                 <div>
-                  <label htmlFor="code">Code</label>
+                  <label htmlFor="code">Enter verification code</label>
                   <input id="code" name="code" type="text" />
                   {errors.fields.code && <p>{errors.fields.code.message}</p>}
-                </div>
-                <div>
-                  <label>
-                    Use backup code
-                    <input type="checkbox" name="useBackupCode" />
-                  </label>
                 </div>
                 <button type="submit" disabled={fetchStatus === 'fetching'}>
                   Verify
@@ -533,10 +542,11 @@ This guide will walk you through how to build a custom email/password sign-up an
             switch signIn.status {
             case .complete:
               dump(clerk.session)
-            case .needsSecondFactor:
-              // This is required when Client Trust is enabled and the user
-              // is signing in from a new device.
-              // See https://clerk.com/docs/guides/secure/client-trust.
+            case .needsClientTrust, .needsSecondFactor:
+              // .needsClientTrust is returned when Client Trust is enabled
+              // and the user is signing in from a new device.
+              // .needsSecondFactor is returned when the user has MFA enabled.
+              // See https://clerk.com/docs/guides/secure/client-trust
               signIn = try await signIn.sendMfaEmailCode()
               showEmailCode = true
             default:
@@ -619,10 +629,11 @@ This guide will walk you through how to build a custom email/password sign-up an
                             SignIn.Status.COMPLETE -> {
                                 _uiState.value = UiState.SignedIn
                             }
+                            SignIn.Status.NEEDS_CLIENT_TRUST,
                             SignIn.Status.NEEDS_SECOND_FACTOR -> {
-                                // Check if email_code is a valid second factor
-                                // This is required when Client Trust is enabled and the user
-                                // is signing in from a new device.
+                                // NEEDS_CLIENT_TRUST is returned when Client Trust is enabled
+                                // and the user is signing in from a new device.
+                                // NEEDS_SECOND_FACTOR is returned when the user has MFA enabled.
                                 // See https://clerk.com/docs/guides/secure/client-trust
                                 val hasEmailCode = signIn.supportedSecondFactors?.any {
                                     it.strategy == "email_code"

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -117,10 +117,11 @@ To blend a sign-up and sign-in flow into a single flow, you must treat it as a s
               }
             },
           })
-        } else if (signIn.status === 'needs_second_factor') {
-          // Check if email_code is a valid second factor
-          // This is required when Client Trust is enabled and the user
-          // is signing in from a new device.
+        } else if (signIn.status === 'needs_second_factor' || signIn.status === 'needs_client_trust') {
+          // 'needs_second_factor' is returned when the user has MFA enabled.
+          // 'needs_client_trust' is returned when Client Trust is enabled
+          // and the user is signing in from a new device.
+          // Both statuses are handled the same way.
           // See https://clerk.com/docs/guides/secure/client-trust
           const emailCodeFactor = signIn.supportedSecondFactors.find(
             (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',

--- a/docs/guides/secure/client-trust.mdx
+++ b/docs/guides/secure/client-trust.mdx
@@ -38,12 +38,12 @@ Client Trust is automatically enabled for Clerk applications created after Novem
 
 ## Impact on custom sign-in flows
 
-If you've built a [custom sign-in flow](!custom-flow) that allows password-based sign-ins using the Clerk API or SDKs, you'll need to handle the `needs_second_factor` status that Client Trust can trigger.
+If you've built a [custom sign-in flow](!custom-flow) that allows password-based sign-ins using the Clerk API or SDKs, you'll need to handle the `needs_client_trust` status that Client Trust can trigger.
 
-When Client Trust requires verification, the sign-in attempt will return a status of `needs_second_factor` with `email_code` in the `supportedSecondFactors` array. Your flow should:
+When Client Trust requires verification, the sign-in attempt will return a status of `needs_client_trust` with `email_code` or `phone_code` in the `supportedSecondFactors` array. This status behaves the same as `needs_second_factor` — use the same `prepareSecondFactor()` and `attemptSecondFactor()` methods to complete the verification. Your flow should:
 
-1. Check if the sign-in status is `needs_second_factor`.
-1. Check if `email_code` is in the `supportedSecondFactors` array.
+1. Check if the sign-in status is `needs_client_trust`.
+1. Check if `email_code` or `phone_code` is in the `supportedSecondFactors` array.
 1. Call `prepareSecondFactor()` to send the verification code to the user's email address or phone number.
 1. Collect the code from the user.
 1. Call `attemptSecondFactor()` to verify the code.
@@ -52,7 +52,7 @@ When Client Trust requires verification, the sign-in attempt will return a statu
 For a complete implementation example, see the [email/password custom flow guide](/docs/guides/development/custom-flows/authentication/email-password#sign-in-flow).
 
 > [!TIP]
-> If your application supports both Client Trust and user-enabled MFA, make sure to check for all possible [second factor](!second-factor) strategies when handling the `needs_second_factor` status.
+> If your application supports both Client Trust and user-enabled MFA, make sure to handle both the `needs_client_trust` and `needs_second_factor` statuses. The `needs_client_trust` status is returned when Client Trust triggers on a new device, while `needs_second_factor` is returned when the user has MFA enabled on their account.
 
 ## Limitations
 

--- a/docs/reference/javascript/sign-in.mdx
+++ b/docs/reference/javascript/sign-in.mdx
@@ -27,6 +27,7 @@ The following steps outline the sign-in process:
   - `'needs_identifier'`: The user's identifier (e.g., email address, phone number, username) hasn't been provided.
   - `'needs_first_factor'`: One of the following [first factor verification strategies](/docs/reference/javascript/sign-in) is missing: `'email_link'`, `'email_code'`, `'phone_code'`, `'web3_base_signature'`, `'web3_metamask_signature'`, `'web3_coinbase_wallet_signature'`, `'web3_okx_wallet_signature'`, `'web3_solana_signature'`, or `'oauth_provider'`.
   - `'needs_second_factor'`: One of the following [second factor verification strategies](/docs/reference/javascript/sign-in) is missing: `'phone_code'` or `'totp'`.
+  - `'needs_client_trust'`: The user is signing in from a new device and must complete a [second factor verification](!second-factor-verification) to establish [client trust](/docs/guides/secure/client-trust). Behaves the same as `'needs_second_factor'`. See [Client Trust](/docs/guides/secure/client-trust) for more information.
   - `'needs_new_password'`: The user needs to set a new password.
 
   ---


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/tom-user-4736-add-status-needsclienttrust-0e5c21/guides/secure/client-trust
- https://clerk.com/docs/guides/development/custom-flows/authentication/email-password
- https://clerk.com/docs/pr/tom-user-4736-add-status-needsclienttrust-0e5c21/guides/development/custom-flows/authentication/email-password
- https://clerk.com/docs/pr/tom-user-4736-add-status-needsclienttrust-0e5c21/guides/development/custom-flows/authentication/sign-in-or-up

### What does this solve? What changed?

The new `needs_client_trust` status provides clearer semantics for developers implementing custom sign-in flows. Previously, Client Trust verification was indicated by `needs_second_factor`, which was confusing because it conflated device trust verification with user-enabled MFA. The new status makes it explicit when verification is required due to Client Trust vs. user MFA settings.

- Adds documentation and code examples for the new `needs_client_trust` sign-in status, which is returned when Client Trust is enabled and the user is signing in from a new device
- Updates the Client Trust guide to clarify the distinction between `needs_client_trust` and `needs_second_factor` statuses
- Updates custom flow examples (Next.js, Expo, Swift, Kotlin) to properly handle both statuses

#### Documentation updates:
- `docs/guides/secure/client-trust.mdx`: Updated to reference the new `needs_client_trust` status instead of overloading `needs_second_factor`. Clarified that phone_code is also a supported verification method.
- `docs/reference/javascript/sign-in.mdx`: Added needs_client_trust to the list of possible sign-in statuses with explanation.

#### Code example updates:
- `docs/guides/development/custom-flows/authentication/email-password.mdx`: Updated Next.js, Swift, and Kotlin examples to handle both `needs_client_trust` and `needs_second_factor` statuses. Simplified the Next.js example to focus on email code verification (TOTP/backup code handling moved to MFA guide).
- `docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx`: Updated to check for both statuses with improved comments.
- `docs/_partials/expo/email-pass-sign-in.mdx`: Added separate handling for needs_client_trust with email code verification, distinct from MFA TOTP verification.


### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- Core 3 Release

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
