### PR TITLE
Fix wrong clerk expo import 

### DIFF
--- a/docs/_partials/custom-flows/create-organizations.mdx
+++ b/docs/_partials/custom-flows/create-organizations.mdx
@@ -228,7 +228,7 @@
   ```tsx {{ filename: 'components/CreateOrganizationWithWarning.tsx' }}
   import { ThemedText } from '@/components/themed-text'
   import { ThemedView } from '@/components/themed-view'
-  import { useOrganizationCreationDefaults, useOrganizationList } from '@clerk/expo'
+  import { useOrganizationCreationDefaults, useOrganizationList } from '@clerk/clerk-expo'
   import { useEffect, useState } from 'react'
   import { Pressable, StyleSheet, TextInput } from 'react-native'
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

While working on other stuff, I noticed we had a Core 3 import rather than a Core 2 import for Expo -> `@clerk/expo` rather than `@clerk/clerk-expo`. 

This PR fixes this. 

### Deadline

ASAP. 

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
