### PR TITLE
docs: improve Core 3 upgrade prompt for ClerkProvider and CLI emphasis

### DIFF
--- a/prompts/core-3-upgrade.md
+++ b/prompts/core-3-upgrade.md
@@ -371,7 +371,7 @@ For Chrome Extension: `__unstable__createClerkClient` → `createClerkClient` (f
 
 ### 6.1 – Always Run the CLI First
 
-**The CLI's jscodeshift-based codemods are far more thorough than manual file scanning.** The CLI performs AST-level transformations and will catch usages that simple text search may miss (e.g., re-exported components, aliased imports, dynamically constructed props). **Always run `npx @clerk/upgrade` before attempting any manual changes.**
+**The CLI's codemods are more thorough than manual file scanning.** The CLI performs AST-level transformations and will catch usages that simple text search may miss (e.g., re-exported components, aliased imports, dynamically constructed props). **Always run `npx @clerk/upgrade` before attempting any manual changes.**
 
 Do NOT try to manually scan and fix files as a substitute for the CLI. Manual grep-based scanning will miss:
 - Files that re-export Clerk components through intermediate modules


### PR DESCRIPTION
## Summary
- Make `ClerkProvider` inside `<body>` a prominent, general Next.js requirement instead of conditional on Next.js 16 + cacheComponents
- Emphasize that the CLI's jscodeshift-based codemods are more thorough than manual grep scanning, and should always be run first
- Add `ClerkProvider` placement and Astro files to the post-CLI verification checklist

## Context
Two issues were identified with the Core 3 upgrade LLM prompt:
1. The `ClerkProvider` must be inside `<body>` requirement was buried and narrowly scoped — the CLI codemod handles this for all Next.js projects
2. Manual file scanning missed files that the CLI's AST-level approach caught — the prompt now explicitly warns against substituting manual scanning for the CLI
