### PR TITLE
fix: move ClerkProvider inside body in Next.js layout snippets

### DIFF
--- a/docs/guides/secure/session-options.mdx
+++ b/docs/guides/secure/session-options.mdx
@@ -98,11 +98,13 @@ The following example demonstrates adding multi-session support to a Next.js App
   export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
       <html lang="en">
-        <ClerkProvider afterMultiSessionSingleSignOutUrl="/">
-          <MultisessionAppSupport>
-            <body>{children}</body>
-          </MultisessionAppSupport>
-        </ClerkProvider>
+        <body>
+          <ClerkProvider afterMultiSessionSingleSignOutUrl="/">
+            <MultisessionAppSupport>
+              {children}
+            </MultisessionAppSupport>
+          </ClerkProvider>
+        </body>
       </html>
     )
   }

--- a/prompts/nextjs-quickstart.md
+++ b/prompts/nextjs-quickstart.md
@@ -11,7 +11,7 @@ Use only the **App Router** approach from Clerk’s current docs:
 
 - **Install** `@clerk/nextjs@latest` - this ensures the application is using the latest Clerk Next.js SDK.
 - **Create** a `proxy.ts` file using `clerkMiddleware()` from `@clerk/nextjs/server`. Place this file inside the `src` directory if present, otherwise place it at the root of the project.
-- **Wrap** your application with `<ClerkProvider>` in your `app/layout.tsx`
+- **Add** `<ClerkProvider>` inside `<body>` in your `app/layout.tsx`
 - **Use** Clerk-provided components like `<SignInButton>`, `<SignUpButton>`, `<UserButton>`, `<Show>` in your layout or pages
 - **Start** developing, sign in or sign up, and confirm user creation
 
@@ -76,9 +76,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <ClerkProvider>
-      <html lang="en">
-        <body>
+    <html lang="en">
+      <body>
+        <ClerkProvider>
           <header>
             <Show when="signed-out">
               <SignInButton />
@@ -89,9 +89,9 @@ export default function RootLayout({
             </Show>
           </header>
           {children}
-        </body>
-      </html>
-    </ClerkProvider>
+        </ClerkProvider>
+      </body>
+    </html>
   );
 }
 ```


### PR DESCRIPTION
## Summary

- Move `<ClerkProvider>` inside `<body>` in the Next.js quickstart prompt layout snippet (`prompts/nextjs-quickstart.md`)
- Move `<ClerkProvider>` inside `<body>` in the multi-session example (`docs/guides/secure/session-options.mdx`)
- Update instruction text to clarify provider should be nested inside `<body>`

For Core 3, `ClerkProvider` must be nested inside `<body>` in Next.js App Router layouts.

## Test plan
- [x] `pnpm build` passes
- [x] `git diff` shows only the 2 intended files changed
