### PR TITLE
Update old openapi redocly link to scalar

### DIFF
--- a/docs/guides/development/migrating/overview.mdx
+++ b/docs/guides/development/migrating/overview.mdx
@@ -22,7 +22,7 @@ Each of these have trade-offs you'll need to consider for your application and i
 
 With basic export/import, you're taking an export from your previous tool and importing data into Clerk. The most common way to handle this is by making use of the [`CreateUser`](/docs/reference/backend-api/tag/users/post/users){{ target: '_blank' }} Backend API endpoint. It's important to note that the `CreateUser` endpoint is rate limited. For more information, see the [guide on rate limits](/docs/guides/how-clerk-works/system-limits#backend-api-requests).
 
-You'll also need to provide your `password_hasher` value (the hashing algorithm used to generate the password digest) and in some instances Clerk will transparently upgrade your users' password hashes to the more secure Bcrypt hashing algorithm. More details on this topic are available in the [Backend API reference docs](/docs/reference/backend-api/tag/Users#operation/CreateUser!path=password_hasher\&t=request){{ target: '_blank' }}.
+You'll also need to provide your `password_hasher` value (the hashing algorithm used to generate the password digest) and in some instances Clerk will transparently upgrade your users' password hashes to the more secure Bcrypt hashing algorithm. More details on this topic are available in the [Backend API reference docs](/docs/reference/backend-api/tag/users/post/users.body.password_hasher#tag/users/post/users){{ target: '_blank' }}.
 
 ### Considerations
 

--- a/docs/guides/development/migrating/overview.mdx
+++ b/docs/guides/development/migrating/overview.mdx
@@ -22,7 +22,7 @@ Each of these have trade-offs you'll need to consider for your application and i
 
 With basic export/import, you're taking an export from your previous tool and importing data into Clerk. The most common way to handle this is by making use of the [`CreateUser`](/docs/reference/backend-api/tag/users/post/users){{ target: '_blank' }} Backend API endpoint. It's important to note that the `CreateUser` endpoint is rate limited. For more information, see the [guide on rate limits](/docs/guides/how-clerk-works/system-limits#backend-api-requests).
 
-You'll also need to provide your `password_hasher` value (the hashing algorithm used to generate the password digest) and in some instances Clerk will transparently upgrade your users' password hashes to the more secure Bcrypt hashing algorithm. More details on this topic are available in the [Backend API reference docs](/docs/reference/backend-api/tag/users/post/users.body.password_hasher#tag/users/post/users){{ target: '_blank' }}.
+You'll also need to provide your `password_hasher` value (the hashing algorithm used to generate the password digest) and in some instances Clerk will transparently upgrade your users' password hashes to the more secure Bcrypt hashing algorithm. More details on this topic are available in the [Backend API reference docs](/docs/reference/backend-api/2026-05-12/tag/users/POST/users.body.password_hasher#tag/users/post/users){{ target: '_blank' }}.
 
 ### Considerations
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/nick-update-redocly-link-to-scalar/guides/development/migrating/overview

Note that reference docs pages are currently broken in preview environments (fixed here https://github.com/clerk/clerk/pull/2146)

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Old link to bapi reference docs using old redocly pathname syntax, updated to scalar pathname

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
