### PR TITLE
Fix incorrect domain value in satellite middleware example

### DIFF
--- a/docs/guides/dashboard/dns-domains/satellite-domains.mdx
+++ b/docs/guides/dashboard/dns-domains/satellite-domains.mdx
@@ -121,7 +121,7 @@ To access authentication state from a satellite domain, users will be transparen
           NEXT_PUBLIC_CLERK_SIGN_UP_URL=https://primary.dev/sign-up
 
           # Development example:
-          # NEXT_PUBLIC_CLERK_DOMAIN=http://localhost:3001
+          # NEXT_PUBLIC_CLERK_DOMAIN=localhost:3001
           # NEXT_PUBLIC_CLERK_SIGN_IN_URL=http://localhost:3000/sign-in
           # NEXT_PUBLIC_CLERK_SIGN_UP_URL=http://localhost:3000/sign-up
           ```
@@ -136,7 +136,7 @@ To access authentication state from a satellite domain, users will be transparen
           CLERK_SIGN_UP_URL=https://primary.dev/sign-up
 
           # Development example:
-          # CLERK_DOMAIN=http://localhost:3001
+          # CLERK_DOMAIN=localhost:3001
           # CLERK_SIGN_IN_URL=http://localhost:3000/sign-in
           # CLERK_SIGN_UP_URL=http://localhost:3000/sign-up
           ```
@@ -258,8 +258,8 @@ To access authentication state from a satellite domain, users will be transparen
                 const primarySignInUrl = 'https://primary.dev/sign-in'
                 const primarySignUpUrl = 'https://primary.dev/sign-up'
                 // Or, in development:
-                // const primarySignInUrl = 'http:localhost:3000/sign-in';
-                // const primarySignUpUrl = 'http:localhost:3000/sign-up';
+                // const primarySignInUrl = 'http://localhost:3000/sign-in';
+                // const primarySignUpUrl = 'http://localhost:3000/sign-up';
 
                 return (
                   <html lang="en">
@@ -288,8 +288,8 @@ To access authentication state from a satellite domain, users will be transparen
                 const primarySignInUrl = 'https://primary.dev/sign-in'
                 const primarySignUpUrl = 'https://primary.dev/sign-up'
                 // Or, in development:
-                // const primarySignInUrl = 'http:localhost:3000/sign-in';
-                // const primarySignUpUrl = 'http:localhost:3000/sign-up';
+                // const primarySignInUrl = 'http://localhost:3000/sign-in';
+                // const primarySignUpUrl = 'http://localhost:3000/sign-up';
 
                 return (
                   <ClerkProvider
@@ -330,7 +330,7 @@ To access authentication state from a satellite domain, users will be transparen
             // signUpUrl: 'http://localhost:3000/sign-up',
             domain: 'satellite.dev',
             // Or, in development:
-            // domain: 'http://localhost:3001',
+            // domain: 'localhost:3001',
           }
 
           export default clerkMiddleware(async (auth, req) => {
@@ -398,8 +398,8 @@ To access authentication state from a satellite domain, users will be transparen
                   signInUrl: 'https://primary.dev/sign-in',
                   signUpUrl: 'https://primary.dev/sign-up',
                   // Or, in development:
-                  // signInUrl: 'http:localhost:3000/sign-in',
-                  // signUpUrl: 'http:localhost:3000/sign-up',
+                  // signInUrl: 'http://localhost:3000/sign-in',
+                  // signUpUrl: 'http://localhost:3000/sign-up',
                   isSatellite: true,
                   domain: (url) => url.host,
                 } as const,
@@ -412,8 +412,8 @@ To access authentication state from a satellite domain, users will be transparen
               signInUrl: 'https://primary.dev/sign-in',
               signUpUrl: 'https://primary.dev/sign-up',
               // Or, in development:
-              // signInUrl: 'http:localhost:3000/sign-in',
-              // signUpUrl: 'http:localhost:3000/sign-up',
+              // signInUrl: 'http://localhost:3000/sign-in',
+              // signUpUrl: 'http://localhost:3000/sign-up',
             })
             ```
         </Tab>


### PR DESCRIPTION
🔎 Previews:
https://clerk.com/docs/pr/folke-fix-satellite-domain-middleware-example/guides/dashboard/dns-domains/satellite-domains

### What does this solve? What changed?
The clerkMiddleware example in the satellite domains guide (Properties tab) shows `domain: 'https://satellite.dev'`, which is incorrect. The domain option expects only the hostname with no scheme.
                                                                                                                                                                
This breaks production satellite apps because domain is passed directly to `parsePublishableKey()` in https://github.com/clerk/javascript/blob/main/packages/shared/src/keys.ts, which constructs the frontend API URL as `clerk.${domain}`. Passing `https://satellite.dev` produces `clerk.https://satellite.dev` — an invalid FAPI URL that silently breaks auth. This only affects production instances (the code path is skipped for dev), which is why it's easy to miss during testing.

Changed `domain: 'https://satellite.dev'` → `domain: 'satellite.dev'` in the middleware example. The env var example (`NEXT_PUBLIC_CLERK_DOMAIN=satellite.dev`) on the same page was already correct.

### Deadline
No rush, but sooner is better — this is actively confusing customers in production

