### PR TITLE
Remove unnecessary TODO from MFA session task work 

### DIFF
--- a/docs/reference/components/authentication/task-setup-mfa.mdx
+++ b/docs/reference/components/authentication/task-setup-mfa.mdx
@@ -8,8 +8,6 @@ sdk: js-frontend, nextjs, react, react-router, tanstack-react-start
 
 The `<TaskSetupMFA />` component renders a UI for resolving the `setup-mfa` [session task](!session-tasks). You can further customize your `<TaskSetupMFA />` component by passing additional [properties](#properties) at the time of rendering.
 
-{/* TODO: Update them before merging */}
-
 > [!IMPORTANT]
 > The `<TaskSetupMFA/>` is only available in the following SDKs versions:
 >


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

This [PR](https://github.com/clerk/clerk-docs/pull/3086) went out recently, but a TODO got left in there. The TODO is about updating the versions, which has been done as part of the PR, so this can be removed safely.

### Deadline

ASAP. 

### Other resources

Slack thread: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1771606273610299
