### PR TITLE
Update user cap for development instances to 100

### DIFF
--- a/docs/guides/development/managing-environments.mdx
+++ b/docs/guides/development/managing-environments.mdx
@@ -17,7 +17,7 @@ Some notable examples of `Development`-only characteristics in a Clerk applicati
 - [The Account Portal](/docs/guides/account-portal/overview) will use a Clerk development domain that ends with `accounts.dev` instead of your app's production domain.
 - OAuth consent screens will show the development domain that ends with `accounts.dev` instead of your production domain.
 - Search engines will not be able to crawl and index your application.
-- Development instances are capped at 500 users, and user data can not be transferred between instances.
+- Development instances are capped at 100 users, and user data can not be transferred between instances.
 - The architecture of Clerk's sessions management is different in development environments compared to production environments, due to the need to communicate cross-domain between `localhost` and `<slug>.accounts.dev`. The `__clerk_db_jwt` object is _only_ used in development environments. For more specific details on the differences between Clerk's session management architecture in development and production environments, see the [technical breakdown below](#session-architecture-differences).
 
 > [!NOTE]


### PR DESCRIPTION
### 🔎 Previews:

https://clerk.com/docs/pr/jigarp-fix-dev-user-limit/guides/development/managing-environments


### What does this solve? What changed? ###
- Our docs shows the cap at 500, which I believe was the old one. It is now 100 dev users by default.

### Deadline

No rush



