### PR TITLE
Add a script and workflow to weekly report the top 404s of the week

### DIFF
--- a/.github/workflows/report-top-404s.yml
+++ b/.github/workflows/report-top-404s.yml
@@ -12,11 +12,12 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun run scripts/report-top-404s.ts
         env:
           DOCS_404_POSTHOG_PROJECT_ID: ${{ vars.DOCS_404_POSTHOG_PROJECT_ID }}
+          DOCS_404_POSTHOG_INSIGHT_ID: ${{ vars.DOCS_404_POSTHOG_INSIGHT_ID }}
           DOCS_404_POSTHOG_API_KEY: ${{ secrets.DOCS_404_POSTHOG_API_KEY }}
           DOCS_404_SLACK_BOT_TOKEN: ${{ secrets.DOCS_404_SLACK_BOT_TOKEN }}
           DOCS_404_SLACK_CHANNEL: ${{ vars.DOCS_404_SLACK_CHANNEL }}

--- a/scripts/report-top-404s.ts
+++ b/scripts/report-top-404s.ts
@@ -1,4 +1,5 @@
 const POSTHOG_PROJECT_ID = process.env.DOCS_404_POSTHOG_PROJECT_ID
+const POSTHOG_INSIGHT_ID = process.env.DOCS_404_POSTHOG_INSIGHT_ID
 const POSTHOG_API_KEY = process.env.DOCS_404_POSTHOG_API_KEY
 const SLACK_BOT_TOKEN = process.env.DOCS_404_SLACK_BOT_TOKEN
 const SLACK_CHANNEL = process.env.DOCS_404_SLACK_CHANNEL
@@ -51,6 +52,10 @@ const main = async () => {
     }),
   })
 
+  if (!response.ok) {
+    throw new Error(`PostHog API error: ${response.statusText}`)
+  }
+
   const data = await response.json()
 
   const topFive404s = data.results.map((result: any) => result.label).slice(0, 5) as string[]
@@ -60,6 +65,8 @@ const main = async () => {
 
   if (SLACK_BOT_TOKEN && SLACK_CHANNEL) {
     const slackMessage = {
+      // A fallback message for environments the structured (blocks) message is not supported
+      text: `Top 5 Docs 404s (Last 7 Days):\n${formattedList}`,
       blocks: [
         {
           type: 'header',
@@ -75,15 +82,19 @@ const main = async () => {
             text: formattedList,
           },
         },
-        {
-          type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: 'https://us.posthog.com/project/86309/insights/3iJsZYub | View all 404s of the week in PostHog',
-            },
-          ],
-        },
+        ...(POSTHOG_INSIGHT_ID
+          ? [
+              {
+                type: 'context',
+                elements: [
+                  {
+                    type: 'mrkdwn',
+                    text: `https://us.posthog.com/project/${POSTHOG_PROJECT_ID}/insights/${POSTHOG_INSIGHT_ID} | View all 404s of the week in PostHog`,
+                  },
+                ],
+              },
+            ]
+          : []),
       ],
     }
 
@@ -99,7 +110,12 @@ const main = async () => {
       }),
     })
 
+    if (!slackResponse.ok) {
+      throw new Error(`Slack API error: ${slackResponse.statusText}`)
+    }
+
     const slackData = await slackResponse.json()
+
     if (!slackData.ok) {
       throw new Error(`Slack API error: ${slackData.error}`)
     }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

<img width="698" height="244" alt="Screenshot 2026-02-24 at 4 25 19 PM" src="https://github.com/user-attachments/assets/7a48493e-d295-4a4d-abfb-a41cf3d15d64" />

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Added a script that pulls from posthog the top 5 reported 404s of the week and creates a comment in slack
- Added a github workflow running a cron weekly that runs the script

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- no rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
