### PR TITLE
Update TanStack Start quickstart for keyless mode

### DIFF
--- a/docs/getting-started/quickstart.tanstack-react-start.mdx
+++ b/docs/getting-started/quickstart.tanstack-react-start.mdx
@@ -193,7 +193,7 @@ sdk: tanstack-react-start
 
   <Include src="_partials/quickstarts/create-first-user-step" />
 
-  3. To make configuration changes to your Clerk development instance, claim the Clerk keys that were generated for you by selecting **Claim your application** in the bottom right of your app. This will associate the application with your Clerk account.
+  3. To make configuration changes to your Clerk development instance, claim the Clerk keys that were generated for you by selecting **Configure your application** in the bottom right of your app. This will associate the application with your Clerk account.
 </Steps>
 
 ## Next steps


### PR DESCRIPTION
### What does this solve? What changed?
TanStack Start supports keyless mode since https://github.com/clerk/javascript/pull/7518, so this aligns the TanStack Start quickstart with the Next.js quickstart's keyless onboarding flow.

- Remove the "Set up a Clerk application" prerequisite from the TanStack Start quickstart
- Remove the "Set your Clerk API keys" step (`.env` file setup)
- Add "Claim your application" step at the end, matching the Next.js quickstart pattern

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

Closes [USER-4447](https://linear.app/clerk/issue/USER-4447/docs-update-tanstack-quickstart-for-keyless)

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
