### PR TITLE
Add redirect for enterprise SSO 404

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2256,6 +2256,10 @@
     "destination": "/docs/guides/organizations/overview"
   },
   {
+    "source": "/docs/organizations/add-members/enterprise-connections",
+    "destination": "/docs/guides/organizations/add-members/sso"
+  },
+  {
     "source": "/docs/components/waitlist",
     "destination": "/docs/reference/components/authentication/waitlist"
   },


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-add-redirect-for-404/organizations/add-members/enterprise-connections -> https://clerk.com/docs/pr/ss-add-redirect-for-404/guides/organizations/add-members/sso

### What does this solve? What changed?

Slack context: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1772133395041129

### Deadline

URGENT. 

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
