### PR TITLE
Add Vite environment variable tabs

### DIFF
--- a/docs/_partials/environment-variables.mdx
+++ b/docs/_partials/environment-variables.mdx
@@ -1,6 +1,6 @@
 For the `FORCE` and `FALLBACK` variables, it's recommended to define both sign-up and sign-in variables, as some users may choose to sign up instead after attempting to sign in, and vice versa.
 
-<Tabs items={["General", "Next.js"]}>
+<Tabs items={["General", "Next.js", "Vite"]}>
   <Tab>
     | Variable | Description | Example |
     | - | - | - |
@@ -21,5 +21,16 @@ For the `FORCE` and `FALLBACK` variables, it's recommended to define both sign-u
     | `NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs up. | `/dashboard` |
     | `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. | `/dashboard` |
     | `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. | `/dashboard` |
+  </Tab>
+
+  <Tab>
+    | Variable | Description | Example |
+    | - | - | - |
+    | `VITE_CLERK_SIGN_IN_URL` | The full URL or path to your sign-in page. Needs to point to your primary application on the client-side. **Required for a satellite application in a development instance.** | `/sign-in` |
+    | `VITE_CLERK_SIGN_UP_URL` | The full URL or path to your sign-up page. Needs to point to your primary application on the client-side. **Required for a satellite application in a development instance.** | `/sign-up` |
+    | `VITE_CLERK_SIGN_IN_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs in. | `/dashboard` |
+    | `VITE_CLERK_SIGN_UP_FORCE_REDIRECT_URL` | If provided, this URL will always be redirected to after the user signs up. | `/dashboard` |
+    | `VITE_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. | `/dashboard` |
+    | `VITE_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` | The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. | `/dashboard` |
   </Tab>
 </Tabs>

--- a/docs/guides/development/clerk-environment-variables.mdx
+++ b/docs/guides/development/clerk-environment-variables.mdx
@@ -25,7 +25,7 @@ However, **it's recommended to use environment variables instead of these props 
 
 To access your Clerk app in your local project, you must specify your app's [Publishable Keys](!publishable-key) for use in the frontend, and [Secret Keys](!secret-key) for use in the backend.
 
-<Tabs items={["General", "Next.js"]}>
+<Tabs items={["General", "Next.js", "Vite"]}>
   <Tab>
     | Variable | Description |
     | - | - |
@@ -39,13 +39,19 @@ To access your Clerk app in your local project, you must specify your app's [Pub
     | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Your Clerk app's [Publishable Key](!publishable-key). It will be prefixed with `pk_test_` in development instances and `pk_live_` in production instances. |
     | `CLERK_SECRET_KEY` | Your Clerk app's [Secret Key](!secret-key). It will be prefixed with `sk_test_` in development instances and `sk_live_` in production instances. **Do not expose this on the frontend with a public environment variable**. |
   </Tab>
+
+  <Tab>
+    | Variable | Description |
+    | - | - |
+    | `VITE_CLERK_PUBLISHABLE_KEY` | Your Clerk app's [Publishable Key](!publishable-key). It will be prefixed with `pk_test_` in development instances and `pk_live_` in production instances. |
+  </Tab>
 </Tabs>
 
 ## API and SDK configuration
 
 The following environment variables enable you to configure API and SDK behavior, such as what version of the SDK your project uses, what proxy URL you use to connect to Clerk's Frontend API, and more.
 
-<Tabs items={["General", "Next.js"]}>
+<Tabs items={["General", "Next.js", "Vite"]}>
   <Tab>
     | Variable | Description |
     | - | - |
@@ -70,13 +76,24 @@ The following environment variables enable you to configure API and SDK behavior
     | `CLERK_ENCRYPTION_KEY` | Sets the encryption key to securely propagate `clerkMiddleware` dynamic keys during request time. A 128-bit, pseudorandom value should be used. See [Dynamic keys](/docs/reference/nextjs/clerk-middleware#dynamic-keys) to learn more. |
     | `CLERK_JWT_KEY` | Sets the JWT verification key that Clerk will use to provide networkless JWT session token verification. Refer to [Manual JWT verification](/docs/guides/sessions/manual-jwt-verification). |
   </Tab>
+
+  <Tab>
+    | Variable | Description |
+    | - | - |
+    | `VITE_CLERK_JS_URL` | Sets the URL that `@clerk/react` should hot-load `@clerk/clerk-js` from. |
+    | `VITE_CLERK_JS_VERSION` | Sets the npm version for `@clerk/clerk-js`. |
+    | `VITE_CLERK_API_URL` | Sets the Clerk API URL for debugging. Defaults to `"https://api.clerk.com"` |
+    | `VITE_CLERK_API_VERSION` | Sets the version of the Clerk API to use. Defaults to `"v1"` |
+    | `VITE_CLERK_FAPI` | Sets the URL to your Clerk app's Frontend API. |
+    | `VITE_CLERK_PROXY_URL` | Sets the URL for your proxy. |
+  </Tab>
 </Tabs>
 
 ## Satellite domains
 
 Clerk supports sharing sessions across different domains by adding one or many satellite domains to an application. See [the satellite domains guide](/docs/guides/dashboard/dns-domains/satellite-domains) for more information.
 
-<Tabs items={["General", "Next.js"]}>
+<Tabs items={["General", "Next.js", "Vite"]}>
   <Tab>
     | Variable | Description |
     | - | - |
@@ -89,6 +106,13 @@ Clerk supports sharing sessions across different domains by adding one or many s
     | - | - |
     | `NEXT_PUBLIC_CLERK_DOMAIN` | Sets your satellite application's domain. Required to share sessions across multiple domains. |
     | `NEXT_PUBLIC_CLERK_IS_SATELLITE` | Indicates whether or not the application is a satellite application. |
+  </Tab>
+
+  <Tab>
+    | Variable | Description |
+    | - | - |
+    | `VITE_CLERK_DOMAIN` | Sets your satellite application's domain. Required to share sessions across multiple domains. |
+    | `VITE_CLERK_IS_SATELLITE` | Indicates whether or not the application is a satellite application. |
   </Tab>
 </Tabs>
 
@@ -104,7 +128,7 @@ The following environment variable allows you to protect your webhook signing se
 
 Clerk provides environment variables for opting out of telemetry data collection. See [the telemetry documentation](/docs/guides/how-clerk-works/security/clerk-telemetry) for more information.
 
-<Tabs items={["General", "Next.js"]}>
+<Tabs items={["General", "Next.js", "Vite"]}>
   <Tab>
     | Variable | Description |
     | - | - |
@@ -118,13 +142,20 @@ Clerk provides environment variables for opting out of telemetry data collection
     | `NEXT_PUBLIC_CLERK_TELEMETRY_DISABLED` | Set this to `1` to disable Clerk's telemetry data collection. |
     | `NEXT_PUBLIC_CLERK_TELEMETRY_DEBUG` | Set this to `1` to prevent telemetry data from being sent to Clerk. It will be logged to the console instead. |
   </Tab>
+
+  <Tab>
+    | Variable | Description |
+    | - | - |
+    | `VITE_CLERK_TELEMETRY_DISABLED` | Set this to `1` to disable Clerk's telemetry data collection. |
+    | `VITE_CLERK_TELEMETRY_DEBUG` | Set this to `1` to prevent telemetry data from being sent to Clerk. It will be logged to the console instead. |
+  </Tab>
 </Tabs>
 
 ## Deprecated
 
 The following environment variables are deprecated but still supported to avoid breaking changes. Don't use them in new projects. It is recommended to switch to using the recommended alternatives in old projects.
 
-<Tabs items={["General", "Next.js"]}>
+<Tabs items={["General", "Next.js", "Vite"]}>
   <Tab>
     | Variable | Description |
     | - | - |
@@ -137,5 +168,12 @@ The following environment variables are deprecated but still supported to avoid 
     | - | - |
     | `NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL` | Full URL or path to navigate to after successful sign up. Defaults to `/`. `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` and `NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL` have priority and should be used instead. |
     | `NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL` | Full URL or path to navigate to after successful sign in. Defaults to `/`. `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` and `NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL` have priority and should be used instead. |
+  </Tab>
+
+  <Tab>
+    | Variable | Description |
+    | - | - |
+    | `VITE_CLERK_AFTER_SIGN_UP_URL` | Full URL or path to navigate to after successful sign up. Defaults to `/`. `VITE_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` and `VITE_CLERK_SIGN_UP_FORCE_REDIRECT_URL` have priority and should be used instead. |
+    | `VITE_CLERK_AFTER_SIGN_IN_URL` | Full URL or path to navigate to after successful sign in. Defaults to `/`. `VITE_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` and `VITE_CLERK_SIGN_IN_FORCE_REDIRECT_URL` have priority and should be used instead. |
   </Tab>
 </Tabs>


### PR DESCRIPTION
### 🔎 Previews:

- 

### What does this solve? What changed?

Added Vite support to the Clerk environment variables reference documentation. All tabbed sections now include a "Vite" tab alongside "General" and "Next.js" tabs, using the `VITE_` public variable prefix pattern. This provides clear configuration guidance for developers building Vite-based frontend applications with Clerk.

Updated sections:
- Clerk Publishable and Secret Keys
- API and SDK configuration
- Satellite domains
- Telemetry
- Deprecated variables
- Sign-in/sign-up redirects (in partial)

### Deadline

No rush

### Other resources

-