### PR TITLE
fix old vercel mcp package install

### DIFF
--- a/docs/guides/ai/mcp/build-mcp-server.mdx
+++ b/docs/guides/ai/mcp/build-mcp-server.mdx
@@ -64,11 +64,11 @@ sdk: nextjs, expressjs
   To get started, this implementation requires the following packages to be installed in your project:
 
   <If sdk="nextjs">
-    - [`@vercel/mcp-adapter`](https://github.com/vercel/mcp-adapter): A utility library that simplifies building an MCP server by handling the core protocol logic for you. It also includes an authentication wrapper that allows you to plug in your own token validation - in this case, using Clerk's OAuth tokens.
+    - [`mcp-handler`](https://github.com/vercel/mcp-adapter): A utility library that simplifies building an MCP server by handling the core protocol logic for you. It also includes an authentication wrapper that allows you to plug in your own token validation - in this case, using Clerk's OAuth tokens.
     - [`@clerk/mcp-tools`](https://github.com/clerk/mcp-tools): A helper library built on top of the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) used to connect Clerk OAuth with MCP easily.
 
     ```npm
-    npm install @vercel/mcp-adapter @clerk/mcp-tools
+    npm install mcp-handler @clerk/mcp-tools
     ```
   </If>
 
@@ -92,7 +92,7 @@ sdk: nextjs, expressjs
 
     ```ts {{ filename: 'app/[transport]/route.ts' }}
     import { verifyClerkToken } from '@clerk/mcp-tools/next'
-    import { createMcpHandler, withMcpAuth } from '@vercel/mcp-adapter'
+    import { createMcpHandler, withMcpAuth } from 'mcp-handler'
     import { auth, clerkClient } from '@clerk/nextjs/server'
 
     const clerk = await clerkClient()
@@ -144,7 +144,7 @@ sdk: nextjs, expressjs
   <If sdk="nextjs">
     ```ts {{ filename: 'app/[transport]/route.ts', mark: [[7, 25]] }}
     import { verifyClerkToken } from '@clerk/mcp-tools/next'
-    import { createMcpHandler, withMcpAuth } from '@vercel/mcp-adapter'
+    import { createMcpHandler, withMcpAuth } from 'mcp-handler'
     import { auth, clerkClient } from '@clerk/nextjs/server'
 
     const clerk = await clerkClient()


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- n/a

### What does this solve? What changed?

<!--
Why does this change need to happen? The vercel mcp hanfler npm package moved, so following along in these docs causes an old package to be installed and then the user has to figure out where the new vercel `mcp-handler` package is and install it
How does this PR solve that problem you mentioned above? This just updates the docs to use the new npm package. Here is the npm docs for the old package that even states the package has moved 
https://www.npmjs.com/package/@vercel/mcp-adapter

Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

-Why does this change need to happen? The vercel mcp hanfler npm package moved, so following along in these docs causes an old package to be installed and then the user has to figure out where the new vercel `mcp-handler` package is and install it
-How does this PR solve that problem you mentioned above? This just updates the docs to use the new npm package. Here is the npm docs for the old package that even states the package has moved 
https://www.npmjs.com/package/@vercel/mcp-adapter

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
npm: https://www.npmjs.com/package/@vercel/mcp-adapter
new vercel mcp docs: https://github.com/vercel/mcp-handler
