### PR TITLE
Fix icon get started with orgs quickstsart 

### DIFF
--- a/docs/guides/organizations/getting-started.mdx
+++ b/docs/guides/organizations/getting-started.mdx
@@ -9,7 +9,7 @@ sdk: nextjs, react, react-router, astro, nuxt
     {
       title: "Follow the quickstart guide",
       link: "/docs/getting-started/quickstart",
-      icon: "nextjs",
+      icon: "clerk",
     },
   ]}
 />


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

When working on this guide for Core 3, I noticed the icon was "nextjs" for the Quickstart link, which doesnt work for the other SDKs that this page is scoped to. This PR fixes it to make it a "clerk" icon which is more general. 

### Deadline

ASAP. 

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
