### PR TITLE
fix(enumeration): Add web3 wallet handling

### DIFF
--- a/docs/guides/secure/user-enumeration-protection.mdx
+++ b/docs/guides/secure/user-enumeration-protection.mdx
@@ -34,7 +34,7 @@ Strict enumeration covers:
 
 - Sign up: If you sign up with an email or phone number that already exists, Clerk won't send a verification code. Instead, it sends a notification (email or SMS) letting the account owner know someone tried to sign up, and suggesting they sign in instead.
 - Sign in: When the account exists, sign-in proceeds normally. When it doesn't, Clerk's behavior depends on the strategy:
-  - **Password**: The attempt is rejected without revealing whether the account exists.
+  - **Password or Web3 wallet**: The attempt is rejected without revealing whether the account exists.
   - **Email code or email link**: Clerk sends a notification to the address explaining that someone tried to sign in, and suggesting they sign up instead.
   - **Phone code**: Clerk shows the verification screen as if a message was sent, but doesn't actually send anything.
     - Because SMS can be costly during an enumeration attack, Clerk doesn't send SMS for sign-in attempts to non-existent accounts. We're exploring ways to add SMS notifications as we develop our anti-fraud protections.


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve? What changed?

Two seconds after the first version of the docs were merged I realized we should add that web3 wallet is handled in the same way as password. Looking the docs it looks like generally style this as "Web3 wallet".

### Deadline

No rush

### Other resources

Plain thread where someone was confused about web3 wallet plus strict enumeration checks (plus we had a backend bug that is now fixed):

https://app.plain.com/workspace/w_01GT53BQWV3DFW6ECTWZNQ1E9K/thread/th_01KJRMNPTZXNX74AQ21QMGWEV0/
