### PR TITLE
fix(core-3): correct @clerk/react version in upgrade guide

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -802,7 +802,7 @@ The following changes only apply to specific SDKs. Select your SDK below for add
 
     ```json {{ del: [1], ins: [2], prettier: false }}
     "@clerk/clerk-react": "^5.0.0",
-    "@clerk/react": "^7.0.0",
+    "@clerk/react": "^6.0.0",
     ```
   </Tab>
 


### PR DESCRIPTION
## Summary
- Fix incorrect `@clerk/react` version in Core 3 upgrade guide: `^7.0.0` → `^6.0.0`
- The latest published version on npm is `6.0.0`, not `7.0.0`

Reported by [@_miguelangel on X](https://x.com/_miguelangel/status/2029009461810217387)
