### PR TITLE
Add core-2 to build ignorePaths and redirect protected routes

### DIFF
--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -149,6 +149,7 @@ async function main() {
     ignoreLinks: ['/docs/quickstart'],
     ignorePaths: [
       '/docs/core-1',
+      '/docs/core-2',
       '/docs/reference/backend-api',
       '/docs/reference/frontend-api',
       '/docs/reference/platform-api',

--- a/scripts/check-redirects.ts
+++ b/scripts/check-redirects.ts
@@ -64,6 +64,7 @@ interface ProtectedRoute {
 const PROTECTED_ROUTES = [
   '/docs/api/instance_keys',
   '/docs/core-1/[[...slug]]',
+  '/docs/core-2/[precomputeCode]/[[...slug]]',
   '/docs/experiment-create_account_from_docs_quickstart/[experiment]',
   '/docs/experiment-nextjs_quickstart_template/[experiment]',
   '/docs/images/[[...slug]]',


### PR DESCRIPTION
## Summary
- Add `/docs/core-2` to `ignorePaths` in the build script so archived core-2 pages aren't validated during main branch builds
- Add `/docs/core-2/[precomputeCode]/[[...slug]]` to `PROTECTED_ROUTES` in the redirect checker to prevent static redirects from shadowing the dynamic catch-all route

Core-2 docs are now archived (served from a frozen branch, noindexed, with an "archived version" banner). These are the same protections already in place for core-1.

**Related:** Companion PR https://github.com/clerk/clerk/pull/2172.

## Test plan
- [ ] Verify build script skips `/docs/core-2` pages during validation
- [ ] Verify redirect checker does not flag the core-2 catch-all route as conflicting

🤖 Generated with [Claude Code](https://claude.com/claude-code)