### PR TITLE
fix: remove unexported EmailCodeFactor type predicate from code examples

### DIFF
--- a/docs/_partials/custom-flows/email-password-sign-in.mdx
+++ b/docs/_partials/custom-flows/email-password-sign-in.mdx
@@ -2,7 +2,6 @@
 'use client'
 
 import { useSignIn } from '@clerk/nextjs'
-import { EmailCodeFactor } from '@clerk/nextjs/types'
 import { useRouter } from 'next/navigation'
 
 export default function Page() {
@@ -46,7 +45,7 @@ export default function Page() {
       // For other second factor strategies,
       // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
       const emailCodeFactor = signIn.supportedSecondFactors.find(
-        (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+        (factor) => factor.strategy === 'email_code',
       )
 
       if (emailCodeFactor) {

--- a/docs/_partials/expo/email-pass-sign-in.mdx
+++ b/docs/_partials/expo/email-pass-sign-in.mdx
@@ -50,7 +50,7 @@ export default function Page() {
       // For other second factor strategies,
       // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
       const emailCodeFactor = signIn.supportedSecondFactors.find(
-        (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+        (factor) => factor.strategy === 'email_code',
       )
 
       if (emailCodeFactor) {

--- a/docs/guides/development/custom-flows/authentication/client-trust.mdx
+++ b/docs/guides/development/custom-flows/authentication/client-trust.mdx
@@ -48,7 +48,6 @@ If Client Trust **and** MFA are enabled, MFA will take precedence and the sign-i
         'use client'
 
         import { useSignIn } from '@clerk/nextjs'
-        import { EmailCodeFactor } from '@clerk/nextjs/types'
         import { useRouter } from 'next/navigation'
 
         export default function Page() {
@@ -86,7 +85,7 @@ If Client Trust **and** MFA are enabled, MFA will take precedence and the sign-i
               // See https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication
       +     } else if (signIn.status === 'needs_client_trust') {
       +       const emailCodeFactor = signIn.supportedSecondFactors.find(
-      +         (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+      +         (factor) => factor.strategy === 'email_code',
       +       )
       + 
       +       if (emailCodeFactor) {
@@ -221,7 +220,7 @@ If Client Trust **and** MFA are enabled, MFA will take precedence and the sign-i
               // See https://clerk.com/docs/guides/development/custom-flows/authentication/multi-factor-authentication
       +     } else if (signIn.status === 'needs_client_trust') {
       +       const emailCodeFactor = signIn.supportedSecondFactors.find(
-      +         (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+      +         (factor) => factor.strategy === 'email_code',
       +       )
       + 
       +       if (emailCodeFactor) {

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -42,7 +42,6 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
   'use client'
 
   import { useSignIn, useSignUp } from '@clerk/nextjs'
-  import { EmailCodeFactor } from '@clerk/nextjs/types'
   import { useRouter } from 'next/navigation'
   import React from 'react'
 
@@ -121,7 +120,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
         // For other second factor strategies,
         // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
         const emailCodeFactor = signIn.supportedSecondFactors.find(
-          (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+          (factor) => factor.strategy === 'email_code',
         )
 
         if (emailCodeFactor) {

--- a/docs/guides/development/custom-flows/error-handling.mdx
+++ b/docs/guides/development/custom-flows/error-handling.mdx
@@ -27,7 +27,6 @@ The following example uses the [email & password sign-in custom flow](/docs/guid
   'use client'
 
   import { useSignIn } from '@clerk/nextjs'
-  import { EmailCodeFactor } from '@clerk/nextjs/types'
   import { useRouter } from 'next/navigation'
 
   export default function Page() {
@@ -71,7 +70,7 @@ The following example uses the [email & password sign-in custom flow](/docs/guid
         // For other second factor strategies,
         // see https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust
         const emailCodeFactor = signIn.supportedSecondFactors.find(
-          (factor): factor is EmailCodeFactor => factor.strategy === 'email_code',
+          (factor) => factor.strategy === 'email_code',
         )
 
         if (emailCodeFactor) {


### PR DESCRIPTION
Previews:                                                                                                                   
   
  - N/A (no visible rendering change — only code snippet updates)                                                                
                                                                    
  What does this solve? What changed?

  - The EmailCodeFactor type is not exported from @clerk/expo or @clerk/nextjs/types public entrypoints, so code examples using
  (factor): factor is EmailCodeFactor => ... would fail with a TypeScript error when users copy-paste them into their apps.
  - Removed the EmailCodeFactor import and type predicate from all non-legacy code examples, replacing with a simple (factor) =>
  factor.strategy === 'email_code' — which works identically at runtime and doesn't require any type import.
  - Legacy examples are unchanged since they import from @clerk/shared/types (a valid transitive dependency) and need the type
  narrowing to access .emailAddressId.
  - Addresses review feedback from @manovotny on the dashboard Expo quickstart.

  Deadline

  - ASAP — this affects all core-3 custom flow code examples.

  Other resources

  - Dashboard PR review comment from @manovotny identifying the issue
