### PR TITLE
fix: update JavaScript quickstart for clerk-js v6

### DIFF
--- a/docs/getting-started/quickstart.js-frontend.mdx
+++ b/docs/getting-started/quickstart.js-frontend.mdx
@@ -81,7 +81,7 @@ Use the following tabs to choose your preferred method.
         throw new Error('Add your VITE_CLERK_PUBLISHABLE_KEY to the .env file')
       }
 
-      // Derives the Frontend API domain from the publishable key
+      // Derive the Frontend API domain from the publishable key
       const clerkDomain = atob(publishableKey.split('_')[2]).slice(0, -1)
 
       // Loads the Clerk UI bundle
@@ -91,7 +91,7 @@ Use the following tabs to choose your preferred method.
         script.async = true
         script.crossOrigin = 'anonymous'
         script.onload = resolve
-        script.onerror = reject
+        script.onerror = () => reject(new Error('Failed to load @clerk/ui bundle'))
         document.head.appendChild(script)
       })
 
@@ -121,7 +121,7 @@ Use the following tabs to choose your preferred method.
         throw new Error('Add your VITE_CLERK_PUBLISHABLE_KEY to the .env file')
       }
 
-      // Derives the Frontend API domain from the publishable key
+      // Derive the Frontend API domain from the publishable key
       const clerkDomain = atob(publishableKey.split('_')[2]).slice(0, -1)
 
       // Loads the Clerk UI bundle
@@ -131,7 +131,7 @@ Use the following tabs to choose your preferred method.
         script.async = true
         script.crossOrigin = 'anonymous'
         script.onload = resolve
-        script.onerror = reject
+        script.onerror = () => reject(new Error('Failed to load @clerk/ui bundle'))
         document.head.appendChild(script)
       })
 
@@ -193,14 +193,14 @@ Use the following tabs to choose your preferred method.
       <!-- Rest of your HTML file -->
 
       <script
-        async
+        defer
         crossorigin="anonymous"
         src="https://{{fapi_url}}/npm/@clerk/ui@1/dist/ui.browser.js"
         type="text/javascript"
       ></script>
 
       <script
-        async
+        defer
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
         src="https://{{fapi_url}}/npm/@clerk/clerk-js@6/dist/clerk.browser.js"
@@ -239,14 +239,14 @@ Use the following tabs to choose your preferred method.
       <div id="app"></div>
 
       <script
-        async
+        defer
         crossorigin="anonymous"
         src="https://{{fapi_url}}/npm/@clerk/ui@1/dist/ui.browser.js"
         type="text/javascript"
       ></script>
 
       <script
-        async
+        defer
         crossorigin="anonymous"
         data-clerk-publishable-key="{{pub_key}}"
         src="https://{{fapi_url}}/npm/@clerk/clerk-js@6/dist/clerk.browser.js"


### PR DESCRIPTION
## Order of deployment

1. [Dashboard PR](https://github.com/clerk/dashboard/pull/8779)
2. [This PR](https://github.com/clerk/clerk-docs/pull/3177)

## Summary
- Adds `@clerk/ui@1` UI bundle loading to both the NPM module and `<script>` tag approaches
- Updates CDN references from `@clerk/clerk-js@5` to `@clerk/clerk-js@6`
- Passes `ui: { ClerkUI: window.__internal_ClerkUICtor }` to `clerk.load()` in all code examples
- Adds `VITE_CLERK_FRONTEND_API_URL` env var and uses it to load the UI bundle (consistent with `{{fapi_url}}` in the `<script>` tag approach)

## Context
The JavaScript quickstart guide was missing the required UI bundle loading step for `@clerk/clerk-js` v6. Without this, users following the guide would not see any prebuilt components rendered. The guide also referenced `@clerk/clerk-js@5` in CDN URLs and derived the frontend API domain from the publishable key instead of using an env var.

Verified against the reference repo: https://github.com/jacekradko/clerk-javascript-quickstart

## Test plan
- [ ] Verify the NPM module code examples work end-to-end with a fresh Vite project
- [ ] Verify the `<script>` tag examples work end-to-end in a plain HTML file
- [ ] Confirm prebuilt components (SignIn, UserButton) render correctly
