### PR TITLE
Support multiple AI orchestration tools

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,4 @@
+{
+  "setup": ["./scripts/ai/setup.sh"],
+  "teardown": []
+}

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "setup": "pnpm i",
-    "run": "pnpm dev",
+    "setup": "./scripts/ai/setup.sh",
+    "run": "./scripts/ai/run.sh",
     "archive": ""
   }
 }

--- a/scripts/ai/run.sh
+++ b/scripts/ai/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pnpm dev

--- a/scripts/ai/setup.sh
+++ b/scripts/ai/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pnpm i


### PR DESCRIPTION
## Summary

- **Problem:** AI orchestration commands (`pnpm i`, `pnpm dev`) were inlined directly in `conductor.json`, coupling them to a single tool. As we adopt additional orchestration tools like [Superset](https://superset.sh), each tool needs its own config format but should run the same underlying commands.
- **Solution:** Extract setup and run commands into shared shell scripts (`scripts/ai/setup.sh` and `scripts/ai/run.sh`), then point both Conductor and Superset configs at them. This centralizes behavior so adding or updating commands only requires changing one place.
- Adds `.superset/config.json` for Superset workspace support
- Updates `conductor.json` to reference the shared scripts instead of inline commands

## Test plan

- [ ] Verify Conductor workspace setup and dev server start correctly using the shared scripts
- [ ] Verify Superset workspace setup runs correctly using the shared scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)