### PR TITLE
fix formatting on m2m create-token docs

### DIFF
--- a/docs/reference/backend/m2m-tokens/create-token.mdx
+++ b/docs/reference/backend/m2m-tokens/create-token.mdx
@@ -25,6 +25,8 @@ function createToken(params?: CreateM2MTokenParams): Promise<M2MToken>
 
   The format of the token. Defaults to `'opaque'`. Set to `'jwt'` to create a [JSON Web Token](/docs/guides/how-clerk-works/tokens-and-signatures#json-web-tokens-jwts) that can be verified locally without a network request. For a detailed comparison of the two formats, see [Token formats](/docs/guides/development/machine-auth/token-formats).
 
+  ---
+
   - `secondsUntilExpiration?`
   - `number | null`
 


### PR DESCRIPTION
### 🔎 Previews:



### What does this solve? What changed?

Fixes formatting in the M2M `createToken` SDK reference

### Deadline

03/05 if possible

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
