### PR TITLE
docs: Add moduleResolution note for @clerk/shared/types import

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -555,6 +555,9 @@ The following deprecated APIs have been removed from all Clerk SDKs.
     ```
 
     The `@clerk/types` package will continue to re-export types from `@clerk/shared/types` for backward compatibility, but new types will only be added to `@clerk/shared/types`.
+
+    > [!NOTE]
+    > The `@clerk/shared/types` subpath import requires `"moduleResolution"` set to `"bundler"`, `"node16"`, or `"nodenext"` in your `tsconfig.json`. If your project uses `"moduleResolution": "node"`, you'll need to update it — otherwise TypeScript cannot resolve the import. If you're unable to change your `moduleResolution`, you can continue using `@clerk/types`, which re-exports everything from `@clerk/shared/types`.
   </AccordionPanel>
 </Accordion>
 


### PR DESCRIPTION
## What

Adds a note to the Core 3 upgrade guide about the TypeScript `moduleResolution` requirement when importing from `@clerk/shared/types`.

## Why

`@clerk/shared/types` is a subpath import that uses the `exports` field in `package.json`. This only works with `moduleResolution` set to `"bundler"`, `"node16"`, or `"nodenext"`. Users on the legacy `moduleResolution: "node"` setting will get a "Cannot find module '@clerk/shared/types' or its corresponding type declarations" error because TypeScript ignores the `exports` field entirely under that mode.

This wasn't an issue with `@clerk/types` because it was a top-level package import, which resolves via the `types` field in `package.json` — supported by all `moduleResolution` settings.

The note informs users of this requirement and provides a fallback (continuing to use `@clerk/types`) for those who can't change their `moduleResolution`.
