### PR TITLE
fix: update feedback links to resolved URLs

### DIFF
--- a/docs/guides/configure/auth-strategies/social-connections/overview.mdx
+++ b/docs/guides/configure/auth-strategies/social-connections/overview.mdx
@@ -592,4 +592,4 @@ Clerk provides a wide range of social providers to ease your user's sign-up and 
   - ![Xero logo](/docs/images/logos/auth_providers/xero.svg)
 </Cards>
 
-Don't see the provider you're looking for? You can [configure a custom OIDC-compatible provider](/docs/guides/configure/auth-strategies/social-connections/custom-provider) or [request a new one](https://feedback.clerk.com/roadmap/f9045ac8-0c8e-4f30-b84f-8d551b0767b9?_gl=1*1ywoqdy*_gcl_au*OTUwODgxMjg2LjE3MTI1OTEwNzMuMTczNjk0NTcxMC4xNzE1MTk4MTEyLjE3MTUxOTgxMTI.).
+Don't see the provider you're looking for? You can [configure a custom OIDC-compatible provider](/docs/guides/configure/auth-strategies/social-connections/custom-provider) or [request a new one](https://feedback.clerk.com/roadmap).

--- a/docs/guides/development/managing-environments.mdx
+++ b/docs/guides/development/managing-environments.mdx
@@ -36,7 +36,7 @@ When deploying to production, you must first activate your `Production` environm
 
 ## Staging environments
 
-Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Currently, Clerk only offers **Development** and **Production** instances. Official support for **Staging** instances is still on the [roadmap](https://feedback.clerk.com/roadmap/de417dd1-fa2e-4997-868f-4c9248027e7d). However, you can set up a "staging environment" by creating a separate Clerk application with a separate domain.
+Staging environments enable you to internally test and demo changes to your application or website before deploying them to production. Currently, Clerk only offers **Development** and **Production** instances. Official support for **Staging** instances is still on the [roadmap](https://feedback.clerk.com/roadmap?id=de417dd1-fa2e-4997-868f-4c9248027e7d). However, you can set up a "staging environment" by creating a separate Clerk application with a separate domain.
 
 Creating a separate Clerk application will prevent you from using live production environment data in your staging environment.
 

--- a/docs/guides/how-clerk-works/multi-tenant-architecture.mdx
+++ b/docs/guides/how-clerk-works/multi-tenant-architecture.mdx
@@ -63,7 +63,7 @@ The Organization's ID should be stored in your database alongside each resource 
 ## Platforms
 
 > [!NOTE]
-> Today, Clerk does not currently support the Platforms scenario. We are working on [Clerk for Platforms](https://feedback.clerk.com/roadmap/3b40265e-d8ae-41b0-a4b3-9c947d460218) to enable developers building platforms to offer their users Clerk's full range of features and customizability.
+> Today, Clerk does not currently support the Platforms scenario. We are working on [Clerk for Platforms](https://feedback.clerk.com/roadmap?id=3b40265e-d8ae-41b0-a4b3-9c947d460218) to enable developers building platforms to offer their users Clerk's full range of features and customizability.
 
 In the Platforms scenario, businesses can create multiple, isolated applications with their own user pools, branding, security policies, and limits. Some examples in this scenario are e-commerce platforms like Shopify, e-learning platforms, and mortgage lending platforms.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-instinctive-butternut/guides/configure/auth-strategies/social-connections/overview
- https://clerk.com/docs/pr/manovotny-instinctive-butternut/guides/development/managing-environments
- https://clerk.com/docs/pr/manovotny-instinctive-butternut/guides/how-clerk-works/multi-tenant-architecture

### What does this solve? What changed?

- [Oh Dear](https://ohdear.app/monitors/68124/check/broken-links/report/60795354962) reported a broken/dead feedback link. The link itself works, but it redirects one or more times before resolving, which Oh Dear flags as broken.
- Updated all `feedback.clerk.com` links across the docs to use their fully redirected/resolved URLs to prevent future false positives:
  - Removed tracking query parameters (`_gl`) from the social connections overview feedback link and simplified the path
  - Updated roadmap links in managing environments and multi-tenant architecture from `/roadmap/<id>` path format to `/roadmap?id=<id>` query parameter format (which is the final resolved URL after redirects)

### Deadline

- No rush

### Other resources

- Oh Dear report: https://ohdear.app/monitors/68124/check/broken-links/report/60795354962
- Slack thread: https://clerkinc.slack.com/archives/C07JVHA2UTZ/p1772584833932319

🤖 Generated with [Claude Code](https://claude.com/claude-code)