### PR TITLE
feat(custom-flows): signUpIfMissing sign-in-or-up

### DIFF
--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -26,7 +26,7 @@ search:
 This guide demonstrates how to build a custom user interface that **allows users to sign up or sign in within a single flow**. There are two approaches:
 
 - [**Standard flow**](#standard-sign-in-or-up-flow): The sign-in attempt immediately tells you whether an account exists. If it doesn't exist yet, you start the sign-up flow. This is simple and gives users immediate feedback, but it reveals whether an account exists before any verification, making it susceptible to [user enumeration](/docs/guides/secure/user-enumeration-protection) attacks.
-- [**`signUpIfMissing` flow**](#sign-in-or-up-with-signupifmissing): The sign-in proceeds to verification regardless of whether an account exists. Only after verification does the backend reveal whether the account exists or needs to be created. This prevents user enumeration attacks.
+- [**`signUpIfMissing` flow**](#sign-in-or-up-with-sign-up-if-missing): The sign-in proceeds to verification regardless of whether an account exists. Only after verification does the backend reveal whether the account exists or needs to be created. This prevents user enumeration attacks.
 
 ## Standard sign-in-or-up flow
 
@@ -41,7 +41,7 @@ This guide demonstrates how to build a custom user interface that **allows users
 To blend a sign-up and sign-in flow into a single flow, you must **treat it as a sign-in flow**, but with the ability to sign up a new user if they don't have an account. You can do this by **checking for the `form_identifier_not_found` error** if the sign-in process fails, and then starting the sign-up process.
 
 > [!NOTE]
-> This approach reveals whether an account exists before verification. If you need to protect against user enumeration attacks, use the [`signUpIfMissing` flow](#sign-in-or-up-with-signupifmissing) instead.
+> This approach reveals whether an account exists before verification. If you need to protect against user enumeration attacks, use the [`signUpIfMissing` flow](#sign-in-or-up-with-sign-up-if-missing) instead.
 
 <If notSdk="expo">
   <If notSdk="nextjs">


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

Add documentation for `signUpIfMissing` sign-in-or-up custom flows. Frame these as an alternative to the standard approach, with tradeoffs including restrictions and a delay in providing feedback to end users on whether their account exists.

Three additional notes:
- ~~SDK releases are broken (?) at the moment so the underlying SDK changes have not yet been released, but it should be released very soon.~~ SDK released
- There is one piece of awkwardness when checking for the transfer, which I've commented on below. If it's worth making this easier with a helper in the SDK, we can definitely do that.
- In fact, in general this custom flow is particularly complex. If you have any suggestions on how the SDK could make this easier, that would be welcome.

### Deadline

It would be nice to be comfortable with sharing some form of this with Spark by end of week (March 13).
There's no rush on a broad release.

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
