### PR TITLE
Add Nuxt guide for custom sign-in-or-up page

### DIFF
--- a/docs/guides/development/custom-sign-in-or-up-page.nuxt.mdx
+++ b/docs/guides/development/custom-sign-in-or-up-page.nuxt.mdx
@@ -14,7 +14,7 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
 <Steps>
   ## Build a sign-in-or-up page
 
-  The following example demonstrates how to render the `<SignIn />` component on a dedicated page using a [Nuxt catch-all route](https://nuxt.com/docs/guide/directory-structure/pages#catch-all-route).
+  The following example demonstrates how to render the `<SignIn />` component on a dedicated page using a [Nuxt catch-all route](https://nuxt.com/docs/directory-structure/app/pages#catch-all-route).
 
   ```vue {{ filename: 'app/pages/sign-in/[...slug].vue' }}
   <template>

--- a/docs/guides/development/custom-sign-up-page.nuxt.mdx
+++ b/docs/guides/development/custom-sign-up-page.nuxt.mdx
@@ -14,7 +14,7 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
 <Steps>
   ## Build a sign-up page
 
-  The following example demonstrates how to render the `<SignUp />` component on a dedicated sign-up page using a [Nuxt catch-all route](https://nuxt.com/docs/guide/directory-structure/pages#catch-all-route).
+  The following example demonstrates how to render the `<SignUp />` component on a dedicated sign-up page using a [Nuxt catch-all route](https://nuxt.com/docs/directory-structure/app/pages#catch-all-route).
 
   ```vue {{ filename: 'app/pages/sign-up/[...slug].vue' }}
   <template>


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/rob-nuxt-sign-in-or-up/nuxt/guides/development/custom-sign-in-or-up-page
- https://clerk.com/docs/pr/rob-nuxt-sign-in-or-up/nuxt/guides/development/custom-sign-up-page

### What does this solve? What changed?

- All of our full stack SDKs have examples for custom sign-in-or-up pages except Nuxt. This PR adds guides for custom sign-in-or-up pages in Nuxt.

### Deadline

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
