### PR TITLE
Block merges on blocked label

### DIFF
--- a/.github/workflows/check-do-not-merge.yml
+++ b/.github/workflows/check-do-not-merge.yml
@@ -1,4 +1,4 @@
-name: Check for 'do not merge' label
+name: Check for blocking labels
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ jobs:
     name: Allow Merge
     runs-on: ubuntu-latest
     env:
-      should_block: ${{ contains(github.event.*.labels.*.name, 'do not merge') }}
+      should_block: ${{ contains(github.event.*.labels.*.name, 'do not merge') || contains(github.event.*.labels.*.name, 'blocked') }}
     steps:
       - name: Check for label
         run: |


### PR DESCRIPTION
### What does this solve? What changed?

Discovered after a recent accidental merge to main that PRs with the **blocked** label were not prevented from being merged. Our workflow was only blocking PRs labeled **do not merge**.

This PR updates the workflow to also prevent PRs labeled **blocked** from being merged into `main`, following a discussion with @manovotny .