### PR TITLE
Block subaddresses feature blocks the Gmail dot trick

### DIFF
--- a/docs/guides/secure/restricting-access.mdx
+++ b/docs/guides/secure/restricting-access.mdx
@@ -116,7 +116,7 @@ For example, if you add `john.doe@clerk.dev` as a blocked email address, it mean
 
 ## Block email subaddresses
 
-**Block email subaddresses** allows you to block all email addresses that contain the characters `+`, `=` or `#` from signing up or being added to existing accounts. For example, an email address like `user+sub@clerk.com` will be blocked.
+**Block email subaddresses** allows you to block all email addresses that contain the characters `+`, `=` or `#` from signing up or being added to existing accounts. For example, an email address like `user+sub@clerk.com` will be blocked. It also blocks email addresses that contain dots in the local part of a Gmail address if the equivalent address without dots already has an account. For example, if `jsmith@gmail.com` already has an account, `j.smith@gmail.com` will be blocked.
 
 > [!NOTE]
 > Existing accounts with email subaddresses will not be affected by this restriction, and will still be allowed to sign in.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

https://clerk.com/docs/pr/aa-docs-11596/guides/secure/restricting-access#block-email-subaddresses

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

The linear ticket reads:
> We updated the block email subaddresses feature to also automatically block the "Gmail dot trick", like d.moerner@gmail.com is blocked if dmoerner@gmail.com has an account. We should update this page to say that: https://clerk.com/docs/guides/secure/restricting-access#block-email-subaddresses

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

https://linear.app/clerk/issue/DOCS-11596/block-subaddresses-also-blocks-the-gmail-dot-trick