### PR TITLE
Fix application invitation custom flow

### DIFF
--- a/docs/guides/development/custom-flows/authentication/application-invitations.mdx
+++ b/docs/guides/development/custom-flows/authentication/application-invitations.mdx
@@ -33,13 +33,13 @@ Once the user visits the invitation link and is redirected to the specified URL,
 For example, if the redirect URL was `https://www.example.com/accept-invitation`, the URL that the user would be redirected to would be `https://www.example.com/accept-invitation?__clerk_ticket=.....`.
 
 <If notSdk={["ios", "android"]}>
-  <If notSdk="nextjs">
-    <Include src="_partials/sdk-examples-not-available-callout" />
-  </If>
-
   To create a sign-up flow using that invitation token, you need to call the [`signUp.ticket()`](/docs/reference/javascript/sign-up-future#ticket) method, as shown in the following example. The following example also demonstrates how to collect additional user information for the sign-up; you can either remove these fields or adjust them to fit your application.
 
   <If notSdk="expo">
+    <If notSdk="nextjs">
+      <Include src="_partials/sdk-examples-not-available-callout" />
+    </If>
+
     ```tsx {{ filename: 'app/sign-up/accept-invitation/page.tsx', collapsible: true }}
     'use client'
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

As stated in the linear ticket, a user informed us that collecting the `ticket` from the URL search params was not included in the custom flow logic. It got accidentally lost in the [Core 3 PR](https://github.com/clerk/clerk-docs/commit/423b9a930db022e9a30679938486af7415258deb) when the custom flow was updated to use the new `useSignUp()` API. 

This PR adds that logic back!

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

ASAP - to fix broken code!

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

https://linear.app/clerk/issue/DOCS-11587/missing-clerk-ticket-url-param-extraction-in-application-invitations