### PR TITLE
Document invitation endpoint rate limits across guides and backend references

### DIFF
--- a/docs/guides/organizations/add-members/invitations.mdx
+++ b/docs/guides/organizations/add-members/invitations.mdx
@@ -37,6 +37,11 @@ To create an Organization invitation on the client-side, see the [dedicated guid
 
 To create Organization invitations on the server-side, use the [Backend API](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations){{ target: '_blank' }} either by using a cURL command or the [JS Backend SDK](/docs/js-backend/getting-started/quickstart). The JS Backend SDK is a wrapper around the Backend API that makes it easier to interact with the API.
 
+To invite multiple users in one request, use the [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) method.
+
+> [!CAUTION]
+> Organization invitation creation endpoints are [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests). `POST /v1/organizations/{organization_id}/invitations` allows **250 requests per hour** per application instance, and `POST /v1/organizations/{organization_id}/invitations/bulk` allows **50 requests per hour** per application instance. If you receive a `429`, respect the `Retry-After` header before retrying.
+
 Use the following tabs to see examples for each method.
 
 <Tabs items={["cURL", "JS Backend SDK"]}>

--- a/docs/guides/users/inviting.mdx
+++ b/docs/guides/users/inviting.mdx
@@ -24,6 +24,11 @@ To create an invitation in the Clerk Dashboard, navigate to the [**Invitations**
 
 To create an invitation programmatically, you can either [make a request directly to Clerk's Backend API](/docs/reference/backend/invitations/create-invitation#backend-api-bapi-endpoint) or use the [`createInvitation()`](/docs/reference/backend/invitations/create-invitation) method as shown in the following example.
 
+To invite multiple users in one request, use the [`createInvitationBulk()`](/docs/reference/backend/invitations/create-invitation-bulk) method.
+
+> [!CAUTION]
+> Invitation creation endpoints are [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests). `POST /v1/invitations` allows **100 requests per hour** per application instance, and `POST /v1/invitations/bulk` allows **25 requests per hour** per application instance. If you receive a `429`, respect the `Retry-After` header before retrying.
+
 <Include src="_partials/create-invitation" />
 
 See the [Backend API reference](/docs/reference/backend-api/tag/invitations/post/invitations){{ target: '_blank' }} for an example of the response.

--- a/docs/reference/backend/invitations/create-invitation-bulk.mdx
+++ b/docs/reference/backend/invitations/create-invitation-bulk.mdx
@@ -10,6 +10,10 @@ Creates multiple [`Invitation`](/docs/reference/backend/types/backend-invitation
 
 If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
 
+> [!CAUTION]
+>
+> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **25 requests per hour** per application instance.
+
 ```ts
 function createInvitationBulk(params: CreateBulkParams): Promise<Invitation[]>
 ```

--- a/docs/reference/backend/invitations/create-invitation.mdx
+++ b/docs/reference/backend/invitations/create-invitation.mdx
@@ -10,6 +10,10 @@ Creates a new [`Invitation`](/docs/reference/backend/types/backend-invitation) f
 
 If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
 
+> [!CAUTION]
+>
+> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **100 requests per hour** per application instance.
+
 ```ts
 function createInvitation(params: CreateParams): Promise<Invitation>
 ```

--- a/docs/reference/backend/organization/create-organization-invitation-bulk.mdx
+++ b/docs/reference/backend/organization/create-organization-invitation-bulk.mdx
@@ -8,6 +8,10 @@ sdk: js-backend
 
 Creates multiple [`OrganizationInvitation`](/docs/reference/backend/types/backend-organization-invitation)s in bulk for new users to join an Organization.
 
+> [!CAUTION]
+>
+> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **50 requests per hour** per application instance.
+
 ```ts
 function createOrganizationInvitationBulk(
   organizationId: string,

--- a/docs/reference/backend/organization/create-organization-invitation.mdx
+++ b/docs/reference/backend/organization/create-organization-invitation.mdx
@@ -8,6 +8,10 @@ sdk: js-backend
 
 Creates an [`OrganizationInvitation`](/docs/reference/backend/types/backend-organization-invitation) for new users to join an Organization.
 
+> [!CAUTION]
+>
+> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **250 requests per hour** per application instance.
+
 ```ts
 function createOrganizationInvitation(
   params: CreateOrganizationInvitationParams,


### PR DESCRIPTION
## Summary
- Added explicit guidance to use bulk invitation methods for both user invitations and organization invitations.
- Added caution callouts in guides documenting invitation creation rate limits and expected `429` handling via `Retry-After`.
- Added endpoint-specific rate limit cautions to backend reference pages for:
- `createInvitation()` (100 requests/hour)
- `createInvitationBulk()` (25 requests/hour)
- `createOrganizationInvitation()` (250 requests/hour)
- `createOrganizationInvitationBulk()` (50 requests/hour)
- Updated 6 docs files with clarification-only content changes (no API or code behavior changes).

## Testing
- Not run (documentation-only change).
- Verified diff coverage includes both guide pages and corresponding backend reference pages for user and organization invitation endpoints.
- Verified documented limits are consistent across guide and reference entries for each endpoint pair.