### PR TITLE
Remove `flatNavSidebar` flag

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,1 +1,1 @@
-{ "flatNavSidebar": true }
+{}


### PR DESCRIPTION
## Summary

- Removes the `flatNavSidebar` flag from `flags.json`, which has been enabled for 1.5 months
- The flag gated whether the `flatNav` manifest property was respected for SDK-specific flat navigation (e.g., iOS, Android)
- The corresponding flag check has been removed from the `clerk/clerk` repo, making this flag definition unused

## Important

**This PR must be merged AFTER the https://github.com/clerk/clerk/pull/2256 PR that removes the flag check.** If merged first, the flag removal would have no effect (the flag is no longer read), but the correct ordering ensures a clean rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)