### PR TITLE
Replace `->` with `→` in plain markdown text

### DIFF
--- a/docs/guides/ai/mcp/clerk-mcp-server.mdx
+++ b/docs/guides/ai/mcp/clerk-mcp-server.mdx
@@ -109,7 +109,7 @@ To complete the integration, you'll need to connect your AI agent to Clerk's MCP
     ### Connecting Windsurf to Clerk's MCP server
 
     1. Press `Ctrl/Cmd + ,` to open Windsurf settings.
-    1. Scroll to **Cascade -> MCP Servers**.
+    1. Scroll to **Cascade → MCP Servers**.
     1. Select **Open MCP Marketplace**.
     1. Under **Installed MCPs**, select the gear icon in the top right corner of the section.
     1. Add the following configuration to the JSON file:

--- a/docs/guides/development/upgrading/upgrade-guides/core-2/backend.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-2/backend.mdx
@@ -50,7 +50,7 @@ clerkClient.authenticateRequest({ ...opts, request })
 clerkClient.authenticateRequest(request, { ...opts })
 ```
 
-### `clockSkewInSeconds` -> `clockSkewInMs`
+### `clockSkewInSeconds` → `clockSkewInMs`
 
 The `clockSkewInSeconds` option has been renamed to `clockSkewInMs` in order to accurately reflect that its value is expected to be in milliseconds rather than seconds. The value does not need to change here, only the name. This change affects the following imports:
 

--- a/docs/guides/development/upgrading/upgrade-guides/core-2/chrome-extension.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-2/chrome-extension.mdx
@@ -51,7 +51,7 @@ If you are having trouble with `npx`, it's also possible to install directly wit
 
 ## Breaking Changes
 
-### `tokenCache` -> `storageCache` as `<ClerkProvider>` props
+### `tokenCache` → `storageCache` as `<ClerkProvider>` props
 
 The `tokenCache` prop has been renamed to `storageCache` in order to accommodate the new [WebSSO feature](https://github.com/clerk/javascript/pull/2277). With the prop change from `tokenCache` to `storageCache`, the interface has been expanded to allow for more flexibility. The new interface is as follows:
 

--- a/docs/guides/how-clerk-works/overview.mdx
+++ b/docs/guides/how-clerk-works/overview.mdx
@@ -308,7 +308,7 @@ However, server-rendered applications present a unique challenge. Server-to-serv
 
 <Video src="/docs/images/how-clerk-works/handshake.mp4" width="1920" height="1080" autoPlay muted loop playsInline />
 
-This server -> browser -> FAPI request includes the client token, so FAPI is able to verify the user's auth state and issue a new session token securely. This handshake ensures secure token renewal while maintaining the benefits of server-side rendering.
+This server → browser → FAPI request includes the client token, so FAPI is able to verify the user's auth state and issue a new session token securely. This handshake ensures secure token renewal while maintaining the benefits of server-side rendering.
 
 > [!QUIZ]
 > Why does handshake do a redirect? Why can't it make a fetch request to FAPI and get a new token back that way? Not needing to redirect would be a better user experience.

--- a/docs/reference/backend/user/create-user.mdx
+++ b/docs/reference/backend/user/create-user.mdx
@@ -8,7 +8,7 @@ sdk: js-backend
 
 Creates a [`User`](/docs/reference/backend/types/backend-user).
 
-Your user management settings in the [Clerk Dashboard](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) determine how you should setup your user model. Anything **Required** in **Users & Authentication -> User & authentication** will need to be provided when creating a user. Trying to add a field that isn't enabled in **Users & Authentication -> User & authentication** will result in an error.
+Your user management settings in the [Clerk Dashboard](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) determine how you should setup your user model. Anything **Required** in **Users & Authentication → User & authentication** will need to be provided when creating a user. Trying to add a field that isn't enabled in **Users & Authentication → User & authentication** will result in an error.
 
 Any email address and phone number created using this method will be automatically marked as verified.
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk-docs-git-manovotny-awake-keeper-clerk-corp.vercel.app/docs/guides/how-clerk-works/overview
- https://clerk-docs-git-manovotny-awake-keeper-clerk-corp.vercel.app/docs/guides/ai/mcp/clerk-mcp-server
- https://clerk-docs-git-manovotny-awake-keeper-clerk-corp.vercel.app/docs/guides/development/upgrading/upgrade-guides/core-2/backend
- https://clerk-docs-git-manovotny-awake-keeper-clerk-corp.vercel.app/docs/guides/development/upgrading/upgrade-guides/core-2/chrome-extension
- https://clerk-docs-git-manovotny-awake-keeper-clerk-corp.vercel.app/docs/reference/backend/user/create-user

### What does this solve? What changed?

- The docs use `->` as an arrow in plain markdown text (e.g., "server -> browser -> FAPI", navigation paths like "Cascade -> MCP Servers", and rename headings like `` `clockSkewInSeconds` -> `clockSkewInMs` ``). The Unicode arrow `→` is a more polished, typographically correct alternative.
- Replaced all 6 instances of `->` in plain markdown text across 5 files with the Unicode arrow `→`. Occurrences inside code blocks (Kotlin lambdas, Swift closures, SQL, etc.) and HTML comments were intentionally left unchanged to avoid breaking code syntax.

### Deadline

- No rush

### Other resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)