### PR TITLE
Restore API keys step in Next.js and TanStack quickstarts

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -34,10 +34,10 @@ llm:
 
     Add the following keys to your `.env` file. These keys can always be retrieved from the [**API keys**](https://dashboard.clerk.com/~/api-keys) page in the Clerk Dashboard.
 
-   ```sh {{ filename: '.env' }}
-   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
-   CLERK_SECRET_KEY={{secret}}
-   ```
+    ```sh {{ filename: '.env' }}
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY={{pub_key}}
+    CLERK_SECRET_KEY={{secret}}
+    ```
   </SignedIn>
 
   ## Add `clerkMiddleware()` to your app

--- a/docs/getting-started/quickstart.tanstack-react-start.mdx
+++ b/docs/getting-started/quickstart.tanstack-react-start.mdx
@@ -203,7 +203,7 @@ sdk: tanstack-react-start
   <Include src="_partials/quickstarts/run-project-step" />
 
   <Include src="_partials/quickstarts/create-first-user-step" />
-  
+
   <SignedOut>
     > [!IMPORTANT]
     > To make configuration changes to your Clerk development instance, claim the Clerk keys that were generated for you by selecting **Configure your application** in the bottom right of your app. This will associate the application with your Clerk account.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-add-env-vars-flow-nextjs-quickstart/nextjs/getting-started/quickstart
- https://clerk.com/docs/pr/ss-add-env-vars-flow-nextjs-quickstart/tanstack-react-start/getting-started/quickstart

### What does this solve? What changed?

Slack context: https://clerkinc.slack.com/archives/C06FGDX7MRD/p1773472389462269.

Essentially, the quickstart step for copying environment variables in the Next.js and TanStack quickstarts had been removed for various reasons. But, after consideration and Colin's feedback, it is better to bring them back with the caveat of showing the env var step for logged in users.

Here is what this PR achieves:
- Restores the API keys step for logged in users only - logged out users won't see that step.
- Turn the keyless flow step into a callout to make it more visible and only display to logged out users. 

**These changes are applied to the Next.js and Tanstack quickstarts.**

What is shown for logged in users:

<img width="586" height="243" alt="Screenshot 2026-03-18 at 10 29 42 am" src="https://github.com/user-attachments/assets/16d2730a-86e6-4a40-a66a-86d767b84bf5" />

What is shown when you're not logged in (in the last step):

<img width="696" height="291" alt="Screenshot 2026-03-18 at 10 35 50 am" src="https://github.com/user-attachments/assets/68b8f146-360c-4ce7-944b-c775c36d7831" />


### Deadline

ASAP. 

### Other resources

Dashboard sibling PR to make the change on onboarding: https://github.com/clerk/dashboard/pull/8709. 
