### PR TITLE
Add RedwoodJS deprecation warning to v2-to-v3 upgrade guide

### DIFF
--- a/docs/guides/development/upgrading/upgrading-from-v2-to-v3.mdx
+++ b/docs/guides/development/upgrading/upgrading-from-v2-to-v3.mdx
@@ -3,6 +3,9 @@ title: Upgrading from v2 to v3
 description: Learn how to upgrade from version 2 to version 3 of the Clerk JavaScript libraries.
 ---
 
+> [!WARNING]
+> As of April 4, 2025, RedwoodJS is no longer actively developed. [Learn more](https://community.redwoodjs.com/t/the-future-of-redwood-launches-today/7938).
+
 On March 24, 2022, Clerk launched version 3 of its full suite of JavaScript libraries, including our SDKs for React, Next.js, Remix, and Redwood. This guide helps you with upgrading to the next major version of your SDK.
 
 ## Why upgrade?


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-manovotnydocs-11165-remove-redw-f18ca8/guides/development/upgrading/upgrading-from-v2-to-v3

### What does this solve? What changed?

On April 4, 2025, RedwoodJS was retired as a fullstack JS framework — split into RedwoodSDK (Cloudflare Workers) and Redwood GraphQL (maintenance-only). The original framework that Clerk's community SDK integration supported is no longer actively developed.

Most Redwood references were removed in #2799, but the v2-to-v3 upgrade guide still mentions Redwood. Rather than removing those historically accurate references, this adds a `[!WARNING]` callout at the top of the guide linking to the [official announcement](https://community.redwoodjs.com/t/the-future-of-redwood-launches-today/7938).

### Deadline

- No rush

### Other resources

- [RedwoodJS community announcement](https://community.redwoodjs.com/t/the-future-of-redwood-launches-today/7938)
- [RedwoodJS → RedwoodSDK blog post](https://rwsdk.com/blog/redwoodjs-to-redwoodsdk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)