### PR TITLE
Add note on wildcard format for domain 

### DIFF
--- a/docs/reference/backend/allowlist/create-allowlist-identifier.mdx
+++ b/docs/reference/backend/allowlist/create-allowlist-identifier.mdx
@@ -20,7 +20,7 @@ function createAllowlistIdentifier(
   - `identifier`
   - `string`
 
-  The identifier to be added in the allowlist. Can be an email address, a phone number in international [E.164](https://en.wikipedia.org/wiki/E.164) format, a domain, or a Web3 wallet address.
+  The identifier to be added in the allowlist. Can be an email address, a phone number in international [E.164](https://en.wikipedia.org/wiki/E.164) format, a domain in wildcard email format (e.g. `*@example.com`), or a Web3 wallet address.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-docs-11582/reference/backend/allowlist/create-allowlist-identifier

### What does this solve? What changed?

Linear context: https://linear.app/clerk/issue/DOCS-11582/clarify-domain-format-for-createallowlistidentifier-in-docs

The docs currently state that the identifier param **"Can be an email address, a phone number in international E.164 format, a domain, or a Web3 wallet address."** but when passing a plain domain (e.g. [example.com](http://example.com)) via the API, it throws an error saying it must be an email, phone number, or wallet address.

The correct format for adding a domain is the wildcard email format: `*@example.com`. This PR adds this distinction. 

### Deadline

Quick approval. 