### PR TITLE
Fix 404s across docs 

### DIFF
--- a/docs/getting-started/quickstart/overview.mdx
+++ b/docs/getting-started/quickstart/overview.mdx
@@ -50,7 +50,7 @@ description: See the getting started guides and tutorials.
 
   ---
 
-  - [Chrome Extension (JavaScript)](/docs/chrome-extension/getting-started/quickstart/chrome-extension-js)
+  - [Chrome Extension (JavaScript)](/docs/getting-started/quickstart/chrome-extension-js)
   - Use the Chrome Extension SDK with plain TypeScript to authenticate users in your Chrome extension.
   - <Icon name="chrome" />
 

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2200,6 +2200,10 @@
     "destination": "/docs/guides/organizations/control-access/roles-and-permissions"
   },
   {
+    "source": "/docs/guides/organizations/roles-permissions",
+    "destination": "/docs/guides/organizations/control-access/roles-and-permissions"
+  },
+  {
     "source": "/docs/guides/organizations/roles-and-permissions",
     "destination": "/docs/guides/organizations/control-access/roles-and-permissions"
   },
@@ -3990,5 +3994,9 @@
   {
     "source": "/docs/reference/javascript/types/web3-wallet",
     "destination": "/docs/reference/types/web3-wallet"
+  },
+  {
+    "source": "/docs/reference/android/overview",
+    "destination": "/docs/android/reference/native-mobile/overview"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-fix-docs-404s/getting-started/quickstart/chrome-extension-js
- https://clerk.com/docs/pr/ss-fix-docs-404s/reference/android/overview 

### What does this solve? What changed?

Context here: https://clerkinc.slack.com/archives/C01QFRQNHSN/p1774275797741269.

Fixing 404s spotted:
- Fixing `/docs/chrome-extension/getting-started/quickstart/chrome-extension-js` -> /`docs/getting-started/quickstart/chrome-extension-js`
- Added a redirect for `/docs/reference/android/overview`

### Deadline

ASAP.

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
