### PR TITLE
Fix false positive in code block URL validation

### DIFF
--- a/scripts/lib/plugins/validateLinks.ts
+++ b/scripts/lib/plugins/validateLinks.ts
@@ -125,8 +125,13 @@ function validateCodeBlockUrls(
   const lines = codeValue.split('\n')
 
   for (const line of lines) {
-    // Only check lines that look like comments
-    const isComment = line.includes('//') || line.includes('#') || line.includes('/*') || line.includes('*/')
+    // Only check lines that look like comments (exclude # inside URLs by stripping clerk.com URLs first)
+    const lineWithoutUrls = line.replace(CLERK_DOCS_URL_PATTERN, '')
+    const isComment =
+      lineWithoutUrls.includes('//') ||
+      lineWithoutUrls.includes('#') ||
+      lineWithoutUrls.includes('/*') ||
+      lineWithoutUrls.includes('*/')
     if (!isComment) continue
 
     // Find all clerk.com/docs URLs


### PR DESCRIPTION
### 🔎 Previews:

- N/A (build script change only)

### What does this solve? What changed?

- PR #3020 introduced code block URL validation that checks `clerk.com/docs` URLs inside code blocks. The comment detection logic uses `line.includes('#')` to identify comment lines, but this also matches `#` characters inside URL hash fragments (e.g., `authentication-flows#saml`).
- This caused a false positive in the `API Errors Generation` test: the `api_errors.json` file contains a `longMessage` with a valid URL (`https://clerk.com/docs/guides/configure/auth-strategies/enterprise-connections/authentication-flows#saml`) that gets embedded in a JSON code block. The `#saml` fragment triggered the comment check, causing the validator to treat the line as a comment and then flag the URL as pointing to a missing doc (since the test uses a minimal temp directory).
- The fix strips `clerk.com/docs` URLs from the line **before** checking for comment markers, so `#` in URL fragments no longer triggers false comment detection. The URLs are still validated in the subsequent `matchAll` pass on the original line.

### Deadline

- No rush

### Other resources

- Related PRs: #3020, #3197

🤖 Generated with [Claude Code](https://claude.com/claude-code)