### PR TITLE
Add docs for new API keys hook

### DIFF
--- a/docs/_partials/hooks/hook-list.mdx
+++ b/docs/_partials/hooks/hook-list.mdx
@@ -17,3 +17,4 @@
 - [`useSubscription()`](/docs/reference/hooks/use-subscription)
 - [`usePaymentAttempts()`](/docs/reference/hooks/use-payment-attempts)
 - [`useStatements()`](/docs/reference/hooks/use-statements)
+- [`useAPIKeys()`](/docs/reference/hooks/use-api-keys)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3116,6 +3116,10 @@
                           "tag": "(Beta)"
                         },
                         {
+                          "title": "`useAPIKeys()`",
+                          "href": "/docs/reference/hooks/use-api-keys"
+                        },
+                        {
                           "title": "Legacy APIs",
                           "items": [
                             [

--- a/docs/reference/hooks/use-api-keys.mdx
+++ b/docs/reference/hooks/use-api-keys.mdx
@@ -14,7 +14,7 @@ The `useAPIKeys()` hook provides access to the API keys associated with a user o
   - `subject`
   - `string`
 
-  The ID of the user or organization to fetch API keys for. If not provided, defaults to the [active organization](/docs/organizations/overview#active-organization) if available, otherwise defaults to the current user.
+  The ID of the user or organization to fetch API keys for. If not provided, defaults to the [Active Organization](!active-organization) if available, otherwise defaults to the current user.
 
   ---
 

--- a/docs/reference/hooks/use-api-keys.mdx
+++ b/docs/reference/hooks/use-api-keys.mdx
@@ -99,7 +99,7 @@ The following example demonstrates how to fetch and display a user's API keys.
               <br />
               Revoked: {apiKey.revoked ? 'Yes' : 'No'}
               <br />
-              Created: {new Date(apiKey.createdAt).toLocaleDateString()}
+              Created: {apiKey.createdAt.toLocaleDateString()}
             </li>
           ))}
         </ul>
@@ -143,7 +143,7 @@ The following example demonstrates how to fetch and display a user's API keys.
               <br />
               Revoked: {apiKey.revoked ? 'Yes' : 'No'}
               <br />
-              Created: {new Date(apiKey.createdAt).toLocaleDateString()}
+              Created: {apiKey.createdAt.toLocaleDateString()}
             </li>
           ))}
         </ul>
@@ -257,6 +257,7 @@ The following example demonstrates how to use the `query` parameter to search AP
   export default function SearchAPIKeys() {
     const [search, setSearch] = useState('')
 
+    // Consider debouncing `search` in production to avoid firing a request on every keystroke
     const { data, isLoading } = useAPIKeys({
       query: search,
       pageSize: 10,
@@ -298,6 +299,7 @@ The following example demonstrates how to use the `query` parameter to search AP
   export default function SearchAPIKeys() {
     const [search, setSearch] = useState('')
 
+    // Consider debouncing `search` in production to avoid firing a request on every keystroke
     const { data, isLoading } = useAPIKeys({
       query: search,
       pageSize: 10,

--- a/docs/reference/hooks/use-api-keys.mdx
+++ b/docs/reference/hooks/use-api-keys.mdx
@@ -73,7 +73,7 @@ The following example demonstrates how to fetch and display a user's API keys.
   ```tsx {{ filename: 'app/api-keys/page.tsx' }}
   'use client'
 
-  import { useAPIKeys } from '@clerk/nextjs/experimental'
+  import { useAPIKeys } from '@clerk/nextjs'
 
   export default function APIKeysList() {
     const { data, isLoading, page, pageCount, fetchNext, fetchPrevious } = useAPIKeys({
@@ -117,7 +117,7 @@ The following example demonstrates how to fetch and display a user's API keys.
 
 <If sdk="react">
   ```tsx {{ filename: 'src/pages/api-keys/APIKeysList.tsx' }}
-  import { useAPIKeys } from '@clerk/react/experimental'
+  import { useAPIKeys } from '@clerk/react'
 
   export default function APIKeysList() {
     const { data, isLoading, page, pageCount, fetchNext, fetchPrevious } = useAPIKeys({
@@ -167,7 +167,7 @@ The following example demonstrates how to implement infinite scrolling with API 
   ```tsx {{ filename: 'app/api-keys/infinite/page.tsx' }}
   'use client'
 
-  import { useAPIKeys } from '@clerk/nextjs/experimental'
+  import { useAPIKeys } from '@clerk/nextjs'
 
   export default function InfiniteAPIKeys() {
     const { data, isLoading, hasNextPage, fetchNext } = useAPIKeys({
@@ -206,7 +206,7 @@ The following example demonstrates how to implement infinite scrolling with API 
 
 <If sdk="react">
   ```tsx {{ filename: 'src/pages/api-keys/InfiniteAPIKeys.tsx' }}
-  import { useAPIKeys } from '@clerk/react/experimental'
+  import { useAPIKeys } from '@clerk/react'
 
   export default function InfiniteAPIKeys() {
     const { data, isLoading, hasNextPage, fetchNext } = useAPIKeys({
@@ -251,7 +251,7 @@ The following example demonstrates how to use the `query` parameter to search AP
   ```tsx {{ filename: 'app/api-keys/search/page.tsx' }}
   'use client'
 
-  import { useAPIKeys } from '@clerk/nextjs/experimental'
+  import { useAPIKeys } from '@clerk/nextjs'
   import { useState } from 'react'
 
   export default function SearchAPIKeys() {
@@ -292,7 +292,7 @@ The following example demonstrates how to use the `query` parameter to search AP
 
 <If sdk="react">
   ```tsx {{ filename: 'src/pages/api-keys/SearchAPIKeys.tsx' }}
-  import { useAPIKeys } from '@clerk/react/experimental'
+  import { useAPIKeys } from '@clerk/react'
   import { useState } from 'react'
 
   export default function SearchAPIKeys() {

--- a/docs/reference/hooks/use-api-keys.mdx
+++ b/docs/reference/hooks/use-api-keys.mdx
@@ -1,0 +1,332 @@
+---
+title: '`useAPIKeys()`'
+description: Access and manage API keys in your React application with Clerk's useAPIKeys() hook.
+sdk: nextjs, react
+---
+
+The `useAPIKeys()` hook provides access to the API keys associated with a user or organization. It returns a paginated list of [`APIKeyResource`](/docs/reference/types/api-key-resource) objects and includes methods for managing pagination.
+
+## Parameters
+
+`useAPIKeys()` accepts a single optional object with the following properties:
+
+<Properties>
+  - `subject`
+  - `string`
+
+  The ID of the user or organization to fetch API keys for. If not provided, defaults to the [active organization](/docs/organizations/overview#active-organization) if available, otherwise defaults to the current user.
+
+  ---
+
+  - `query`
+  - `string`
+
+  A search query to filter API keys by name.
+
+  ---
+
+  - `enabled`
+  - `boolean`
+
+  If `true`, a request will be triggered when the hook is mounted. Defaults to `true`.
+
+  ---
+
+  - `infinite`
+  - `boolean`
+
+  If `true`, newly fetched data will be appended to the existing list rather than replacing it. Useful for implementing infinite scroll functionality. Defaults to `false`.
+
+  ---
+
+  - `initialPage`
+  - `number`
+
+  A number that specifies which page to fetch. For example, if `initialPage` is set to 10, it will skip the first 9 pages and fetch the 10th page. Defaults to `1`.
+
+  ---
+
+  - `pageSize`
+  - `number`
+
+  A number that specifies the maximum number of results to return per page. Defaults to `10`.
+
+  ---
+
+  - `keepPreviousData`
+  - `boolean`
+
+  If `true`, the previous data will be kept in the cache until new data is fetched. Defaults to `false`.
+</Properties>
+
+## Returns
+
+<Include src="_partials/hooks/paginated-resources" />
+
+## Examples
+
+### Basic usage
+
+The following example demonstrates how to fetch and display a user's API keys.
+
+<If sdk="nextjs">
+  ```tsx {{ filename: 'app/api-keys/page.tsx' }}
+  'use client'
+
+  import { useAPIKeys } from '@clerk/nextjs/experimental'
+
+  export default function APIKeysList() {
+    const { data, isLoading, page, pageCount, fetchNext, fetchPrevious } = useAPIKeys({
+      pageSize: 10,
+    })
+
+    if (isLoading) {
+      return <div>Loading...</div>
+    }
+
+    if (!data || data.length === 0) {
+      return <div>No API keys found.</div>
+    }
+
+    return (
+      <div>
+        <ul>
+          {data.map((apiKey) => (
+            <li key={apiKey.id}>
+              <strong>{apiKey.name}</strong>
+              <br />
+              Subject: {apiKey.subject}
+              <br />
+              Revoked: {apiKey.revoked ? 'Yes' : 'No'}
+              <br />
+              Created: {new Date(apiKey.createdAt).toLocaleDateString()}
+            </li>
+          ))}
+        </ul>
+
+        <div>
+          Page {page} of {pageCount}
+        </div>
+        <button onClick={() => fetchPrevious()}>Previous</button>
+        <button onClick={() => fetchNext()}>Next</button>
+      </div>
+    )
+  }
+  ```
+</If>
+
+<If sdk="react">
+  ```tsx {{ filename: 'src/pages/api-keys/APIKeysList.tsx' }}
+  import { useAPIKeys } from '@clerk/react/experimental'
+
+  export default function APIKeysList() {
+    const { data, isLoading, page, pageCount, fetchNext, fetchPrevious } = useAPIKeys({
+      pageSize: 10,
+    })
+
+    if (isLoading) {
+      return <div>Loading...</div>
+    }
+
+    if (!data || data.length === 0) {
+      return <div>No API keys found.</div>
+    }
+
+    return (
+      <div>
+        <ul>
+          {data.map((apiKey) => (
+            <li key={apiKey.id}>
+              <strong>{apiKey.name}</strong>
+              <br />
+              Subject: {apiKey.subject}
+              <br />
+              Revoked: {apiKey.revoked ? 'Yes' : 'No'}
+              <br />
+              Created: {new Date(apiKey.createdAt).toLocaleDateString()}
+            </li>
+          ))}
+        </ul>
+
+        <div>
+          Page {page} of {pageCount}
+        </div>
+        <button onClick={() => fetchPrevious()}>Previous</button>
+        <button onClick={() => fetchNext()}>Next</button>
+      </div>
+    )
+  }
+  ```
+</If>
+
+### Infinite pagination
+
+The following example demonstrates how to implement infinite scrolling with API keys.
+
+<If sdk="nextjs">
+  ```tsx {{ filename: 'app/api-keys/infinite/page.tsx' }}
+  'use client'
+
+  import { useAPIKeys } from '@clerk/nextjs/experimental'
+
+  export default function InfiniteAPIKeys() {
+    const { data, isLoading, hasNextPage, fetchNext } = useAPIKeys({
+      infinite: true,
+      pageSize: 20,
+    })
+
+    if (isLoading) {
+      return <div>Loading...</div>
+    }
+
+    if (!data || data.length === 0) {
+      return <div>No API keys found.</div>
+    }
+
+    return (
+      <div>
+        <ul>
+          {data.map((apiKey) => (
+            <li key={apiKey.id}>
+              <strong>{apiKey.name}</strong>
+              <br />
+              Subject: {apiKey.subject}
+              <br />
+              Revoked: {apiKey.revoked ? 'Yes' : 'No'}
+            </li>
+          ))}
+        </ul>
+
+        {hasNextPage && <button onClick={() => fetchNext()}>Load more API keys</button>}
+      </div>
+    )
+  }
+  ```
+</If>
+
+<If sdk="react">
+  ```tsx {{ filename: 'src/pages/api-keys/InfiniteAPIKeys.tsx' }}
+  import { useAPIKeys } from '@clerk/react/experimental'
+
+  export default function InfiniteAPIKeys() {
+    const { data, isLoading, hasNextPage, fetchNext } = useAPIKeys({
+      infinite: true,
+      pageSize: 20,
+    })
+
+    if (isLoading) {
+      return <div>Loading...</div>
+    }
+
+    if (!data || data.length === 0) {
+      return <div>No API keys found.</div>
+    }
+
+    return (
+      <div>
+        <ul>
+          {data.map((apiKey) => (
+            <li key={apiKey.id}>
+              <strong>{apiKey.name}</strong>
+              <br />
+              Subject: {apiKey.subject}
+              <br />
+              Revoked: {apiKey.revoked ? 'Yes' : 'No'}
+            </li>
+          ))}
+        </ul>
+
+        {hasNextPage && <button onClick={() => fetchNext()}>Load more API keys</button>}
+      </div>
+    )
+  }
+  ```
+</If>
+
+### With search query
+
+The following example demonstrates how to use the `query` parameter to search API keys by name.
+
+<If sdk="nextjs">
+  ```tsx {{ filename: 'app/api-keys/search/page.tsx' }}
+  'use client'
+
+  import { useAPIKeys } from '@clerk/nextjs/experimental'
+  import { useState } from 'react'
+
+  export default function SearchAPIKeys() {
+    const [search, setSearch] = useState('')
+
+    const { data, isLoading } = useAPIKeys({
+      query: search,
+      pageSize: 10,
+    })
+
+    return (
+      <div>
+        <input
+          type="text"
+          placeholder="Search API keys..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        {isLoading ? (
+          <div>Loading...</div>
+        ) : !data || data.length === 0 ? (
+          <div>No API keys found.</div>
+        ) : (
+          <ul>
+            {data.map((apiKey) => (
+              <li key={apiKey.id}>
+                <strong>{apiKey.name}</strong> - {apiKey.subject}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  }
+  ```
+</If>
+
+<If sdk="react">
+  ```tsx {{ filename: 'src/pages/api-keys/SearchAPIKeys.tsx' }}
+  import { useAPIKeys } from '@clerk/react/experimental'
+  import { useState } from 'react'
+
+  export default function SearchAPIKeys() {
+    const [search, setSearch] = useState('')
+
+    const { data, isLoading } = useAPIKeys({
+      query: search,
+      pageSize: 10,
+    })
+
+    return (
+      <div>
+        <input
+          type="text"
+          placeholder="Search API keys..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        {isLoading ? (
+          <div>Loading...</div>
+        ) : !data || data.length === 0 ? (
+          <div>No API keys found.</div>
+        ) : (
+          <ul>
+            {data.map((apiKey) => (
+              <li key={apiKey.id}>
+                <strong>{apiKey.name}</strong> - {apiKey.subject}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  }
+  ```
+</If>


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/rob-use-api-keys/nextjs/reference/hooks/use-api-keys

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Adds a new `useAPIKeys()` hook doc as part of API keys GA on Monday (April 6). This enables custom flows for rendering API keys.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- by Monday, April 6

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
