### PR TITLE
Update Playwright testing docs: recommend emailAddress sign-in, add sign-up form guide and troubleshooting

### DIFF
--- a/docs/guides/development/testing/playwright/overview.mdx
+++ b/docs/guides/development/testing/playwright/overview.mdx
@@ -6,7 +6,7 @@ description: Use Playwright to write end-to-end tests with Clerk.
 [Playwright](https://playwright.dev) is an open-source, end-to-end testing framework that automates web application testing across multiple browsers. This guide will help you set up your environment for creating authenticated tests with Clerk, assuming you have some familiarity with both Clerk and Playwright.
 
 > [!IMPORTANT]
-> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys, a test user with username and password, and have username and password authentication enabled in the Clerk Dashboard.
+> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys and have `email` and `password` authentication enabled in the Clerk Dashboard. A test user is created automatically during setup.
 
 <Steps>
   ## Install `@clerk/testing`
@@ -70,4 +70,7 @@ description: Use Playwright to write end-to-end tests with Clerk.
     // Add additional test logic here
   })
   ```
+
+  > [!TIP]
+  > The `<SignUp />` component renders form fields based on your instance configuration in the Clerk Dashboard, including in testing mode. If your instance requires additional fields like first and last name, username, or legal acceptance, those fields will appear in the sign-up form and must be filled in your test. See [Test the sign-up form](/docs/guides/development/testing/playwright/test-sign-up-flows) for a complete example.
 </Steps>

--- a/docs/guides/development/testing/playwright/overview.mdx
+++ b/docs/guides/development/testing/playwright/overview.mdx
@@ -74,3 +74,21 @@ description: Use Playwright to write end-to-end tests with Clerk.
   > [!TIP]
   > The `<SignUp />` component renders form fields based on your instance configuration in the Clerk Dashboard, including in testing mode. If your instance requires additional fields like first and last name, username, or legal acceptance, those fields will appear in the sign-up form and must be filled in your test. See [Test the sign-up form](/docs/guides/development/testing/playwright/test-sign-up-flows) for a complete example.
 </Steps>
+
+## Troubleshooting
+
+### Sign-up form fields missing (e.g., first and last name)
+
+If the `<SignUp />` component only renders email and password fields in your Playwright tests but shows all fields in a normal browser, check your Playwright config for the `--disable-web-security` Chrome launch argument.
+
+This flag strips the `Origin` header from cross-origin requests, which causes Clerk's API to reject the environment configuration request. Without the environment config, the component falls back to a minimal form.
+
+Remove `--disable-web-security` from your `launchOptions.args` to fix this.
+
+### `setupClerkTestingToken` error: "Clerk Frontend API URL is required"
+
+Make sure `clerkSetup()` is called in a [project-based setup](https://playwright.dev/docs/test-global-setup-teardown), not a function-based `globalSetup`.
+
+With a function-based `globalSetup`, the setup runs in a separate process and the environment variables set by `clerkSetup()` (`CLERK_FAPI` and `CLERK_TESTING_TOKEN`) don't propagate to your test workers.
+
+Use a project-based setup as shown in the [Configure Playwright with Clerk](#configure-playwright-with-clerk) section above, and declare it as a [dependency](https://playwright.dev/docs/test-projects#dependencies) for your test projects.

--- a/docs/guides/development/testing/playwright/overview.mdx
+++ b/docs/guides/development/testing/playwright/overview.mdx
@@ -6,7 +6,7 @@ description: Use Playwright to write end-to-end tests with Clerk.
 [Playwright](https://playwright.dev) is an open-source, end-to-end testing framework that automates web application testing across multiple browsers. This guide will help you set up your environment for creating authenticated tests with Clerk, assuming you have some familiarity with both Clerk and Playwright.
 
 > [!IMPORTANT]
-> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys and have `email` and `password` authentication enabled in the Clerk Dashboard. A test user is created automatically during setup.
+> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys and have **Email** and **Password** authentication enabled in the Clerk Dashboard. A test user is created automatically during setup.
 
 <Steps>
   ## Install `@clerk/testing`

--- a/docs/guides/development/testing/playwright/test-authenticated-flows.mdx
+++ b/docs/guides/development/testing/playwright/test-authenticated-flows.mdx
@@ -1,6 +1,6 @@
 ---
-title: Test authenticated flows
-description: Learn how to test authenticated flows with Playwright.
+title: Reuse auth state across tests
+description: Learn how to save and reuse authenticated state across Playwright tests.
 ---
 
 Playwright executes tests in isolated environments called browser contexts. Because each test case runs in a new browser context, the user session is not shared between test cases by default. However, tests can load existing authenticated state.
@@ -8,7 +8,7 @@ Playwright executes tests in isolated environments called browser contexts. Beca
 This guide demonstrates how to save the auth state globally and load it in your test cases, eliminating the need to authenticate in every test and speeding up test execution. Visit the [Playwright docs about authentication](https://playwright.dev/docs/auth) for more information.
 
 > [!IMPORTANT]
-> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys, a test user with username and password, and have username and password authentication enabled in the Clerk Dashboard.
+> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys and have `email` and `password` authentication enabled in the Clerk Dashboard. A test user is created automatically during setup.
 
 <Steps>
   ## Create a storage directory
@@ -28,7 +28,7 @@ This guide demonstrates how to save the auth state globally and load it in your 
 
   - Is executed before all projects.
   - Calls [`clerkSetup()`](/docs/guides/development/testing/playwright/overview#configure-playwright-with-clerk) to configure Playwright with Clerk.
-  - Calls `clerk.signIn()` to sign in a test user using credentials stored in environment variables. See the [reference](/docs/guides/development/testing/playwright/test-helpers#clerk-sign-in) for more information about the different parameters you can pass.
+  - Calls `clerk.signIn()` with the `emailAddress` parameter to sign in a test user. This approach uses a server-side token and works regardless of your instance's verification or MFA settings. See the [reference](/docs/guides/development/testing/playwright/test-helpers#clerk-sign-in) for more information about the different parameters you can pass.
   - Checks if the user can access a protected page to ensure the user is successfully authenticated.
   - Stores the auth state in the storage file.
 
@@ -36,6 +36,9 @@ This guide demonstrates how to save the auth state globally and load it in your 
   import { clerk, clerkSetup } from '@clerk/testing/playwright'
   import { test as setup } from '@playwright/test'
   import path from 'path'
+
+  // Setup must be run serially
+  setup.describe.configure({ mode: 'serial' })
 
   // Configure Playwright with Clerk
   setup('global setup', async ({}) => {
@@ -46,16 +49,12 @@ This guide demonstrates how to save the auth state globally and load it in your 
   const authFile = path.join(__dirname, '../playwright/.clerk/user.json')
 
   setup('authenticate and save state to storage', async ({ page }) => {
-    // Perform authentication steps.
-    // This example uses a Clerk helper to authenticate
+    // Sign in using the emailAddress parameter, which creates a
+    // server-side token and bypasses all verification steps
     await page.goto('/')
     await clerk.signIn({
       page,
-      signInParams: {
-        strategy: 'password',
-        identifier: process.env.E2E_CLERK_USER_USERNAME!,
-        password: process.env.E2E_CLERK_USER_PASSWORD!,
-      },
+      emailAddress: process.env.E2E_CLERK_USER_EMAIL!,
     })
     await page.goto('/protected')
     // Ensure the user has successfully accessed the protected page
@@ -65,6 +64,9 @@ This guide demonstrates how to save the auth state globally and load it in your 
     await page.context().storageState({ path: authFile })
   })
   ```
+
+  > [!TIP]
+  > Use a `+clerk_test` email address for your test user (e.g., `e2e+clerk_test@example.com`) so Clerk suppresses all email delivery, including verification codes and "new device" sign-in notifications. The [demo repo](https://github.com/clerk/clerk-playwright-nextjs) demonstrates auto-creating a test user with this pattern in global setup.
 
   ## Load the stored auth state in your tests
 

--- a/docs/guides/development/testing/playwright/test-authenticated-flows.mdx
+++ b/docs/guides/development/testing/playwright/test-authenticated-flows.mdx
@@ -8,7 +8,7 @@ Playwright executes tests in isolated environments called browser contexts. Beca
 This guide demonstrates how to save the auth state globally and load it in your test cases, eliminating the need to authenticate in every test and speeding up test execution. Visit the [Playwright docs about authentication](https://playwright.dev/docs/auth) for more information.
 
 > [!IMPORTANT]
-> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys and have `email` and `password` authentication enabled in the Clerk Dashboard. A test user is created automatically during setup.
+> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens). To run the tests, you'll need dev instance Clerk API keys and have **Email** and **Password** authentication enabled in the Clerk Dashboard. A test user is created automatically during setup.
 
 <Steps>
   ## Create a storage directory

--- a/docs/guides/development/testing/playwright/test-helpers.mdx
+++ b/docs/guides/development/testing/playwright/test-helpers.mdx
@@ -8,7 +8,10 @@ To use these commands, import the `clerk` object from the `@clerk/testing/playwr
 
 ### `clerk.signIn()`
 
-The `clerk.signIn()` function is used to sign in a user using Clerk. This helper only supports the following [first factor](!first-factor-verification) strategies: password, phone code, and email code. [Multi-factor authentication](!second-factor-verification) is not supported.
+The `clerk.signIn()` function is used to sign in a user using Clerk. There are two ways to use it:
+
+- **`emailAddress` parameter** (recommended): Signs in by creating a server-side token via the Backend API. This bypasses all verification steps, including email verification and multi-factor authentication. Requires `CLERK_SECRET_KEY` to be set.
+- **`signInParams` parameter**: Signs in client-side using the specified strategy (password, phone code, or email code). Only handles [first factor](!first-factor-verification) verification — [multi-factor authentication](!second-factor-verification) is not supported with this approach.
 
 Before calling `clerk.signIn()`, it is required to call `page.goto()` and navigate to an unprotected page that loads Clerk. For example, the index (`/`) page.
 
@@ -89,7 +92,26 @@ The `SetupClerkTestingTokenOptions` type is used to define the object that is pa
 
 #### Example
 
-The following example demonstrates how to use `clerk.signIn()` in a test to sign in a user.
+The following example demonstrates the recommended way to use `clerk.signIn()` with the `emailAddress` parameter. This approach works regardless of your instance's verification or MFA settings.
+
+```ts {{ filename: 'e2e/app.spec.ts' }}
+import { clerk } from '@clerk/testing/playwright'
+
+test('sign in', async ({ page }) => {
+  // Navigate to an unprotected page that loads Clerk
+  await page.goto('/')
+
+  await clerk.signIn({
+    page,
+    emailAddress: process.env.E2E_CLERK_USER_EMAIL,
+  })
+
+  // Navigate to a protected page
+  await page.goto('/protected')
+})
+```
+
+Alternatively, you can use the `signInParams` parameter to sign in using a specific strategy. This approach only handles first factor verification — if your instance has email verification or MFA enabled, use the `emailAddress` parameter instead.
 
 ```ts {{ filename: 'e2e/app.spec.ts' }}
 import { clerk } from '@clerk/testing/playwright'
@@ -104,24 +126,6 @@ test('sign in', async ({ page }) => {
   })
 
   // Navigate to a protected page
-  await page.goto('/protected')
-})
-```
-
-If you would prefer to sign a user in directly by email address, you can use the `emailAddress` parameter instead of the `signInParams` parameter.
-
-```ts {{ filename: 'e2e/app.spec.ts' }}
-import { clerk } from '@clerk/testing/playwright'
-
-test('sign in', async ({ page }) => {
-  // Navigate to an unprotected page that loads Clerk
-  await page.goto('/')
-
-  await clerk.signIn({
-    page,
-    emailAddress: process.env.TEST_USER_EMAIL,
-  })
-
   await page.goto('/protected')
 })
 ```

--- a/docs/guides/development/testing/playwright/test-sign-up-flows.mdx
+++ b/docs/guides/development/testing/playwright/test-sign-up-flows.mdx
@@ -42,9 +42,9 @@ test('sign up', async ({ page }) => {
     await usernameInput.fill('testuser' + Date.now())
   }
 
-  await page.locator('input[name=emailAddress]').fill(
-    `testuser+clerk_test_${Date.now()}@example.com`,
-  )
+  await page
+    .locator('input[name=emailAddress]')
+    .fill(`testuser+clerk_test_${Date.now()}@example.com`)
   await page.locator('input[name=password]').fill('your-test-password')
 
   // Check the legal checkbox if present
@@ -57,14 +57,11 @@ test('sign up', async ({ page }) => {
 
   // Wait for Clerk to prepare the email verification
   await page.waitForResponse(
-    (resp) =>
-      resp.url().includes('prepare_verification') && resp.status() === 200,
+    (resp) => resp.url().includes('prepare_verification') && resp.status() === 200,
   )
 
   // Enter test OTP code (424242 works with +clerk_test emails)
-  await page
-    .getByRole('textbox', { name: 'Enter verification code' })
-    .pressSequentially('424242')
+  await page.getByRole('textbox', { name: 'Enter verification code' }).pressSequentially('424242')
 
   await page.waitForURL('**/protected')
 })
@@ -75,7 +72,7 @@ test('sign up', async ({ page }) => {
 The following table lists the input selectors for fields that can appear in the `<SignUp />` component, depending on your instance configuration:
 
 | Field | Selector | Dashboard setting |
-| --- | --- | --- |
+| - | - | - |
 | First name | `input[name=firstName]` | User & authentication > User model > First and last name |
 | Last name | `input[name=lastName]` | User & authentication > User model > First and last name |
 | Username | `input[name=username]` | User & authentication > Username |

--- a/docs/guides/development/testing/playwright/test-sign-up-flows.mdx
+++ b/docs/guides/development/testing/playwright/test-sign-up-flows.mdx
@@ -1,0 +1,93 @@
+---
+title: Test the sign-up form
+description: Learn how to test the sign-up form with Playwright, including additional fields like first and last name.
+---
+
+The Clerk `<SignUp />` component renders form fields based on your instance configuration in the [Clerk Dashboard](https://dashboard.clerk.com), including in testing mode. If your instance requires additional fields — such as first and last name, username, or legal acceptance — those fields will appear in the sign-up form and must be filled in your test.
+
+This guide demonstrates how to write a sign-up test that handles these fields. It builds on the setup from the [overview](/docs/guides/development/testing/playwright/overview).
+
+> [!IMPORTANT]
+> See the [demo repo](https://github.com/clerk/clerk-playwright-nextjs) that demonstrates testing a Clerk-powered application using [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens).
+
+## Sign-up test with conditional fields
+
+The following example uses `isVisible()` checks so the test works regardless of which fields are enabled in your instance. This means the same test works whether your instance requires first and last name, username, both, or neither.
+
+```tsx {{ filename: 'e2e/app.spec.ts' }}
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+import { test } from '@playwright/test'
+
+test('sign up', async ({ page }) => {
+  await setupClerkTestingToken({ page })
+
+  await page.goto('/sign-up')
+  await page.waitForSelector('.cl-signUp-root', { state: 'attached' })
+
+  // Fill in first and last name if the fields are present.
+  // These fields appear when "First and last name" is enabled
+  // in the Clerk Dashboard under "User & authentication > User model".
+  const firstNameInput = page.locator('input[name=firstName]')
+  if (await firstNameInput.isVisible()) {
+    await firstNameInput.fill('Test')
+  }
+  const lastNameInput = page.locator('input[name=lastName]')
+  if (await lastNameInput.isVisible()) {
+    await lastNameInput.fill('User')
+  }
+
+  // Fill in the username if the field is present.
+  const usernameInput = page.locator('input[name=username]')
+  if (await usernameInput.isVisible()) {
+    await usernameInput.fill('testuser' + Date.now())
+  }
+
+  await page.locator('input[name=emailAddress]').fill(
+    `testuser+clerk_test_${Date.now()}@example.com`,
+  )
+  await page.locator('input[name=password]').fill('your-test-password')
+
+  // Check the legal checkbox if present
+  const legalCheckbox = page.locator('input[name=legalAccepted]')
+  if (await legalCheckbox.isVisible()) {
+    await legalCheckbox.check()
+  }
+
+  await page.getByRole('button', { name: 'Continue', exact: true }).click()
+
+  // Wait for Clerk to prepare the email verification
+  await page.waitForResponse(
+    (resp) =>
+      resp.url().includes('prepare_verification') && resp.status() === 200,
+  )
+
+  // Enter test OTP code (424242 works with +clerk_test emails)
+  await page
+    .getByRole('textbox', { name: 'Enter verification code' })
+    .pressSequentially('424242')
+
+  await page.waitForURL('**/protected')
+})
+```
+
+## Available sign-up field selectors
+
+The following table lists the input selectors for fields that can appear in the `<SignUp />` component, depending on your instance configuration:
+
+| Field | Selector | Dashboard setting |
+| --- | --- | --- |
+| First name | `input[name=firstName]` | User & authentication > User model > First and last name |
+| Last name | `input[name=lastName]` | User & authentication > User model > First and last name |
+| Username | `input[name=username]` | User & authentication > Username |
+| Email address | `input[name=emailAddress]` | User & authentication > Email |
+| Password | `input[name=password]` | User & authentication > Password |
+| Phone number | `input[name=phoneNumber]` | User & authentication > Phone |
+| Legal acceptance | `input[name=legalAccepted]` | User & authentication > Legal acceptance |
+
+## Test email addresses and OTP codes
+
+To avoid sending real emails during tests, use the `+clerk_test` email pattern. Emails containing `+clerk_test` (e.g., `testuser+clerk_test_123@example.com`) can be verified with the test OTP code `424242`. This is only available in development instances. See [Testing Tokens](/docs/guides/development/testing/overview#testing-tokens) for more information.
+
+## Cleaning up test users
+
+Sign-up tests create users in your Clerk instance. To prevent test users from accumulating, use a [Playwright global teardown](https://playwright.dev/docs/test-global-setup-teardown) to delete users created during the test run. The [demo repo](https://github.com/clerk/clerk-playwright-nextjs) demonstrates this pattern using the Clerk Backend API to clean up after each run.

--- a/docs/guides/development/testing/playwright/test-sign-up-flows.mdx
+++ b/docs/guides/development/testing/playwright/test-sign-up-flows.mdx
@@ -47,6 +47,12 @@ test('sign up', async ({ page }) => {
     .fill(`testuser+clerk_test_${Date.now()}@example.com`)
   await page.locator('input[name=password]').fill('your-test-password')
 
+  // Fill in the phone number if the field is present.
+  const phoneInput = page.locator('input[name=phoneNumber]')
+  if (await phoneInput.isVisible()) {
+    await phoneInput.fill('+15555550100')
+  }
+
   // Check the legal checkbox if present
   const legalCheckbox = page.locator('input[name=legalAccepted]')
   if (await legalCheckbox.isVisible()) {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1485,8 +1485,12 @@
                                 "href": "/docs/guides/development/testing/playwright/test-helpers"
                               },
                               {
-                                "title": "Test authenticated flows",
+                                "title": "Reuse auth state across tests",
                                 "href": "/docs/guides/development/testing/playwright/test-authenticated-flows"
+                              },
+                              {
+                                "title": "Test the sign-up form",
+                                "href": "/docs/guides/development/testing/playwright/test-sign-up-flows"
                               }
                             ]
                           ]


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-malleable-crime/guides/development/testing/playwright/overview
- https://clerk.com/docs/pr/manovotny-malleable-crime/guides/development/testing/playwright/test-helpers
- https://clerk.com/docs/pr/manovotny-malleable-crime/guides/development/testing/playwright/test-authenticated-flows
- https://clerk.com/docs/pr/manovotny-malleable-crime/guides/development/testing/playwright/test-sign-up-flows

### What does this solve? What changed?

The [clerk-playwright-nextjs demo repo](https://github.com/clerk/clerk-playwright-nextjs/pull/10) overhauled its e2e test infrastructure. The old `clerk.signIn()` approach used `signInParams` with `strategy: 'password'`, which only completes first-factor verification — it breaks when email verification or MFA is enabled (the default). The docs recommended this broken pattern.

This PR updates the Playwright testing docs to match:

- **`test-helpers.mdx`**: Restructured `clerk.signIn()` docs to recommend `emailAddress` parameter (server-side token, bypasses all verification) as the primary approach, with `signInParams` as the alternative with a caveat about first-factor-only
- **`test-authenticated-flows.mdx`** (renamed to "Reuse auth state across tests"): Switched `global.setup.ts` example from `signInParams`/password to `emailAddress`, added `setup.describe.configure({ mode: 'serial' })`, added tip about `+clerk_test` emails suppressing notifications
- **`overview.mdx`**: Updated demo repo callout (test user is now auto-created, no manual creation needed), added tip about sign-up form fields linking to the new guide, added troubleshooting section covering `--disable-web-security` breaking sign-up fields and `setupClerkTestingToken` errors from function-based `globalSetup`
- **`test-sign-up-flows.mdx`** (new page, "Test the sign-up form"): Guide for testing the `<SignUp />` component with conditional fields, `+clerk_test`/`424242` OTP pattern, field selector reference table, and test user cleanup via global teardown
- **`manifest.json`**: Added new page to nav, updated renamed page title

### Deadline

- No rush — ships after https://github.com/clerk/clerk-playwright-nextjs/pull/10 merges

### Other resources

- Source PR: https://github.com/clerk/clerk-playwright-nextjs/pull/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)