### PR TITLE
Add redirects for top docs 404s

### DIFF
--- a/redirects/dynamic/docs.jsonc
+++ b/redirects/dynamic/docs.jsonc
@@ -59,4 +59,9 @@
     "destination": "/docs/:sdk/reference/:path*",
     "permanent": true,
   },
+  {
+    "source": "/docs/remix/:path*",
+    "destination": "/docs/core-2/remix/:path*",
+    "permanent": true,
+  },
 ]

--- a/redirects/dynamic/docs.jsonc
+++ b/redirects/dynamic/docs.jsonc
@@ -59,9 +59,4 @@
     "destination": "/docs/:sdk/reference/:path*",
     "permanent": true,
   },
-  {
-    "source": "/docs/remix/:path*",
-    "destination": "/docs/core-2/remix/:path*",
-    "permanent": true,
-  },
 ]

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4030,5 +4030,353 @@
   {
     "source": "/docs/guides/development/spa-mode",
     "destination": "/docs/core-2/guides/development/spa-mode"
+  },
+  {
+    "source": "/docs/remix/getting-started/quickstart",
+    "destination": "/docs/core-2/remix/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/remix/guides/development/custom-sign-in-or-up-page",
+    "destination": "/docs/core-2/remix/guides/development/custom-sign-in-or-up-page"
+  },
+  {
+    "source": "/docs/remix/guides/development/custom-sign-up-page",
+    "destination": "/docs/core-2/remix/guides/development/custom-sign-up-page"
+  },
+  {
+    "source": "/docs/remix/guides/users/reading",
+    "destination": "/docs/core-2/remix/guides/users/reading"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-organization-list",
+    "destination": "/docs/core-2/remix/reference/hooks/use-organization-list"
+  },
+  {
+    "source": "/docs/remix/reference/components/user/user-button",
+    "destination": "/docs/core-2/remix/reference/components/user/user-button"
+  },
+  {
+    "source": "/docs/remix/reference/components/overview",
+    "destination": "/docs/core-2/remix/reference/components/overview"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication/sign-in",
+    "destination": "/docs/core-2/remix/reference/components/authentication/sign-in"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/overview",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/overview"
+  },
+  {
+    "source": "/docs/remix/reference/components/unstyled/sign-in-button",
+    "destination": "/docs/core-2/remix/reference/components/unstyled/sign-in-button"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/bring-your-own-css",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/bring-your-own-css"
+  },
+  {
+    "source": "/docs/remix/guides/billing/for-b2b",
+    "destination": "/docs/core-2/remix/guides/billing/for-b2b"
+  },
+  {
+    "source": "/docs/remix/reference/components/unstyled/sign-out-button",
+    "destination": "/docs/core-2/remix/reference/components/unstyled/sign-out-button"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/themes",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/themes"
+  },
+  {
+    "source": "/docs/remix/reference/components/user/user-profile",
+    "destination": "/docs/core-2/remix/reference/components/user/user-profile"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/authenticate-with-redirect-callback",
+    "destination": "/docs/core-2/remix/reference/components/control/authenticate-with-redirect-callback"
+  },
+  {
+    "source": "/docs/remix/reference/components/user/user-avatar",
+    "destination": "/docs/core-2/remix/reference/components/user/user-avatar"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication/task-choose-organization",
+    "destination": "/docs/core-2/remix/reference/components/authentication/task-choose-organization"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication/sign-up",
+    "destination": "/docs/core-2/remix/reference/components/authentication/sign-up"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/variables",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/variables"
+  },
+  {
+    "source": "/docs/remix/reference/components/unstyled/sign-up-button",
+    "destination": "/docs/core-2/remix/reference/components/unstyled/sign-up-button"
+  },
+  {
+    "source": "/docs/remix/guides/billing/for-b2c",
+    "destination": "/docs/core-2/remix/guides/billing/for-b2c"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-organization",
+    "destination": "/docs/core-2/remix/reference/hooks/use-organization"
+  },
+  {
+    "source": "/docs/remix/reference/components/organization/organization-profile",
+    "destination": "/docs/core-2/remix/reference/components/organization/organization-profile"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/clerk-failed",
+    "destination": "/docs/core-2/remix/reference/components/control/clerk-failed"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/clerk-loaded",
+    "destination": "/docs/core-2/remix/reference/components/control/clerk-loaded"
+  },
+  {
+    "source": "/docs/remix/reference/components/organization/create-organization",
+    "destination": "/docs/core-2/remix/reference/components/organization/create-organization"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/adding-items/user-button",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/adding-items/user-button"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/captcha",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/captcha"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication/waitlist",
+    "destination": "/docs/core-2/remix/reference/components/authentication/waitlist"
+  },
+  {
+    "source": "/docs/remix/guides/development/webhooks/billing",
+    "destination": "/docs/core-2/remix/guides/development/webhooks/billing"
+  },
+  {
+    "source": "/docs/remix/reference/components/billing/pricing-table",
+    "destination": "/docs/core-2/remix/reference/components/billing/pricing-table"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/redirect-to-create-organization",
+    "destination": "/docs/core-2/remix/reference/components/control/redirect-to-create-organization"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/redirect-to-sign-up",
+    "destination": "/docs/core-2/remix/reference/components/control/redirect-to-sign-up"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/adding-items/user-profile",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/adding-items/user-profile"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/redirect-to-user-profile",
+    "destination": "/docs/core-2/remix/reference/components/control/redirect-to-user-profile"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication/google-one-tap",
+    "destination": "/docs/core-2/remix/reference/components/authentication/google-one-tap"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication/task-reset-password",
+    "destination": "/docs/core-2/remix/reference/components/authentication/task-reset-password"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/redirect-to-sign-in",
+    "destination": "/docs/core-2/remix/reference/components/control/redirect-to-sign-in"
+  },
+  {
+    "source": "/docs/remix/reference/components/unstyled/sign-in-with-metamask",
+    "destination": "/docs/core-2/remix/reference/components/unstyled/sign-in-with-metamask"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/clerk-degraded",
+    "destination": "/docs/core-2/remix/reference/components/control/clerk-degraded"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/redirect-to-organization-profile",
+    "destination": "/docs/core-2/remix/reference/components/control/redirect-to-organization-profile"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/clerk-loading",
+    "destination": "/docs/core-2/remix/reference/components/control/clerk-loading"
+  },
+  {
+    "source": "/docs/remix/reference/components/organization/organization-list",
+    "destination": "/docs/core-2/remix/reference/components/organization/organization-list"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/adding-items/organization-profile",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/adding-items/organization-profile"
+  },
+  {
+    "source": "/docs/remix/reference/components/organization/organization-switcher",
+    "destination": "/docs/core-2/remix/reference/components/organization/organization-switcher"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/overview",
+    "destination": "/docs/core-2/remix/reference/hooks/overview"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-reverification",
+    "destination": "/docs/core-2/remix/reference/hooks/use-reverification"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/signed-out",
+    "destination": "/docs/core-2/remix/reference/components/control/signed-out"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/signed-in",
+    "destination": "/docs/core-2/remix/reference/components/control/signed-in"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/layout",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/layout"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/protect",
+    "destination": "/docs/core-2/remix/reference/components/control/protect"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/options",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/options"
+  },
+  {
+    "source": "/docs/remix/reference/components/control/show",
+    "destination": "/docs/core-2/remix/reference/components/control/show"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-clerk",
+    "destination": "/docs/core-2/remix/reference/hooks/use-clerk"
+  },
+  {
+    "source": "/docs/remix/reference/types/set-active-params",
+    "destination": "/docs/core-2/remix/reference/types/set-active-params"
+  },
+  {
+    "source": "/docs/remix/guides/billing",
+    "destination": "/docs/core-2/remix/guides/billing"
+  },
+  {
+    "source": "/docs/remix/guides/users",
+    "destination": "/docs/core-2/remix/guides/users"
+  },
+  {
+    "source": "/docs/remix/reference/components/organization",
+    "destination": "/docs/core-2/remix/reference/components/organization"
+  },
+  {
+    "source": "/docs/remix/reference/types/sign-in-resource",
+    "destination": "/docs/core-2/remix/reference/types/sign-in-resource"
+  },
+  {
+    "source": "/docs/remix/reference/hooks",
+    "destination": "/docs/core-2/remix/reference/hooks"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-auth",
+    "destination": "/docs/core-2/remix/reference/hooks/use-auth"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-session",
+    "destination": "/docs/core-2/remix/reference/hooks/use-session"
+  },
+  {
+    "source": "/docs/remix/components",
+    "destination": "/docs/core-2/remix/components"
+  },
+  {
+    "source": "/docs/remix/guides/development",
+    "destination": "/docs/core-2/remix/guides/development"
+  },
+  {
+    "source": "/docs/remix/guides/development/webhooks/overview",
+    "destination": "/docs/core-2/remix/guides/development/webhooks/overview"
+  },
+  {
+    "source": "/docs/remix/reference/components/authentication",
+    "destination": "/docs/core-2/remix/reference/components/authentication"
+  },
+  {
+    "source": "/docs/remix/reference/components/unstyled",
+    "destination": "/docs/core-2/remix/reference/components/unstyled"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop"
+  },
+  {
+    "source": "/docs/remix/reference/components/billing",
+    "destination": "/docs/core-2/remix/reference/components/billing"
+  },
+  {
+    "source": "/docs/remix/reference/components/clerk-provider",
+    "destination": "/docs/core-2/remix/reference/components/clerk-provider"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-session-list",
+    "destination": "/docs/core-2/remix/reference/hooks/use-session-list"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-sign-in",
+    "destination": "/docs/core-2/remix/reference/hooks/use-sign-in"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-sign-up",
+    "destination": "/docs/core-2/remix/reference/hooks/use-sign-up"
+  },
+  {
+    "source": "/docs/remix/reference/hooks/use-user",
+    "destination": "/docs/core-2/remix/reference/hooks/use-user"
+  },
+  {
+    "source": "/docs/remix/reference/types/create-organization-params",
+    "destination": "/docs/core-2/remix/reference/types/create-organization-params"
+  },
+  {
+    "source": "/docs/remix/components/billing",
+    "destination": "/docs/core-2/remix/components/billing"
+  },
+  {
+    "source": "/docs/remix/components/organization",
+    "destination": "/docs/core-2/remix/components/organization"
+  },
+  {
+    "source": "/docs/remix/components/unstyled",
+    "destination": "/docs/core-2/remix/components/unstyled"
+  },
+  {
+    "source": "/docs/remix/guides/customizing-clerk/appearance-prop/elements",
+    "destination": "/docs/core-2/remix/guides/customizing-clerk/appearance-prop/elements"
+  },
+  {
+    "source": "/docs/remix/guides/development/webhooks",
+    "destination": "/docs/core-2/remix/guides/development/webhooks"
+  },
+  {
+    "source": "/docs/remix/reference",
+    "destination": "/docs/core-2/remix/reference"
+  },
+  {
+    "source": "/docs/remix/reference/components",
+    "destination": "/docs/core-2/remix/reference/components"
+  },
+  {
+    "source": "/docs/remix/reference/components/control",
+    "destination": "/docs/core-2/remix/reference/components/control"
+  },
+  {
+    "source": "/docs/remix/reference/components/user",
+    "destination": "/docs/core-2/remix/reference/components/user"
+  },
+  {
+    "source": "/docs/reference/remix/add-remix-router",
+    "destination": "/docs/core-2/reference/remix/add-remix-router"
+  },
+  {
+    "source": "/docs/reference/remix/clerk-error-boundary",
+    "destination": "/docs/core-2/reference/remix/clerk-error-boundary"
   }
 ]

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2416,6 +2416,10 @@
     "destination": "/docs/reference/components/unstyled/sign-in-button"
   },
   {
+    "source": "/docs/components/sign-in-button",
+    "destination": "/docs/reference/components/unstyled/sign-in-button"
+  },
+  {
     "source": "/docs/customization/overview",
     "destination": "/docs/guides/customizing-clerk/overview"
   },
@@ -4024,23 +4028,7 @@
     "destination": "/docs/core-2/reference/remix/clerk-app"
   },
   {
-    "source": "/docs/remix/guides/users/reading",
-    "destination": "/docs/core-2/remix/guides/users/reading"
-  },
-  {
     "source": "/docs/guides/development/spa-mode",
     "destination": "/docs/core-2/guides/development/spa-mode"
-  },
-  {
-    "source": "/docs/remix/guides/development/custom-sign-in-or-up-page",
-    "destination": "/docs/core-2/remix/guides/development/custom-sign-in-or-up-page"
-  },
-  {
-    "source": "/docs/remix/guides/development/custom-sign-up-page",
-    "destination": "/docs/core-2/remix/guides/development/custom-sign-up-page"
-  },
-  {
-    "source": "/docs/remix/getting-started/quickstart",
-    "destination": "/docs/core-2/remix/getting-started/quickstart"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

- N/A (redirect-only changes)

### What does this solve? What changed?

Investigated the top 5 docs 404s from the last 7 days and added redirects for the 2 that warranted action. Also replaced the broken dynamic Remix catch-all with comprehensive static redirects based on 90-day traffic data.

#### Investigation methodology

- Searched the full Clerk GitHub org via `gh search code` for each URL to check for broken internal links
- Cross-referenced each URL against existing redirects in `redirects/static/docs.json` and `redirects/dynamic/docs.jsonc`
- Checked the actual file structure to identify correct current URLs
- Googled each exact URL to check for external references
- Validated with `lint:check-duplicate-redirects` — all checks pass

#### Analysis of all 5 URLs

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/remix/reference/components/user/user-button` | **Deprecated SDK** — Remix was deprecated and moved to Core 2 ([#3192](https://github.com/clerk/clerk-docs/pull/3192), [#3200](https://github.com/clerk/clerk-docs/pull/3200)), but no working redirect existed for `/docs/remix/*` paths. | ✅ Covered by new static redirects |
| 2 | `/docs/components/clerk-provider]` | **Malformed URL** — Trailing `]` from a broken markdown link somewhere external. Without the `]`, the existing redirect works fine. Searched both `clerk-docs` and `clerk` org — no malformed links found in our repos. | Skipped |
| 3 | `/docs/guides/configure/auth-strategies/multi-factor` | **AI-fabricated** — Plausible path based on real directory structure, but this page never existed. MFA config lives in `sign-up-sign-in-options#multi-factor-authentication`. No org or external references. | Skipped |
| 4 | `/docs/components/sign-in-button` | **Legit near-miss** — Old `/docs/components/` prefix has redirects for many components, but `sign-in-button` was missed. `/docs/components/unstyled/sign-in-button` and `/docs/component-reference/sign-in-button` redirect correctly, but this shorter path (without the `unstyled` segment) didn't. | ✅ Added redirect |
| 5 | `/docs/users/delete-user` | **AI-fabricated** — `/docs/users/` prefix never existed as a docs path. Real path is `/docs/reference/backend/user/delete-user`. No org or external references. | Skipped |

#### Changes

**Static redirect** (`redirects/static/docs.json`):
- `/docs/components/sign-in-button` → `/docs/reference/components/unstyled/sign-in-button`
- **87 new Remix static redirects** covering all `/docs/remix/*` and `/docs/reference/remix/*` paths from 90-day traffic data, mapped to their `/docs/core-2/` equivalents

**Dynamic redirect** (`redirects/dynamic/docs.jsonc`):
- Removed the `/docs/remix/:path*` catch-all — it didn't work because `clerk-docs-redirects.ts` strips the SDK key before matching dynamic patterns ([review comment](https://github.com/clerk/clerk-docs/pull/3269#issuecomment-4202648394))

**Note:** The 90-day traffic list is not a complete inventory of all possible Remix routes. If additional Remix 404s surface in future weekly reports, they can be added incrementally.

### Deadline

- No rush

### Other resources

- Previous 404 redirect PR: [#3262](https://github.com/clerk/clerk-docs/pull/3262)
- Remix deprecation PRs: [#3192](https://github.com/clerk/clerk-docs/pull/3192), [#3200](https://github.com/clerk/clerk-docs/pull/3200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)