### PR TITLE
fix: Updated offline support doc for Core 3 changes

### DIFF
--- a/docs/guides/development/offline-support.mdx
+++ b/docs/guides/development/offline-support.mdx
@@ -66,10 +66,11 @@ To enable offline support in your Expo app, follow these steps:
 
 When there is no internet connection, Clerk's [custom flows](!custom-flow) (e.g., `signIn.create()`) will throw a network error.
 
-To handle network errors in your Expo app, you can use the `isClerkRuntimeError()` function to check if the error is a Clerk-related error. Clerk-related errors are returned as an array of [`ClerkAPIError`](/docs/reference/types/clerk-api-error) objects. These errors contain a `code` property that you can use to identify the specific error. See the following example.
+To detect when a request failed because the device is offline, catch the error and check it with `ClerkOfflineError.is(error)`. `ClerkOfflineError` is exported from `@clerk/expo/errors` (and the corresponding `/errors` entry point of other Clerk SDKs). See the following example.
 
-```tsx {{ mark: [1, [22, 30]] }}
-import { useSignIn, isClerkRuntimeError } from '@clerk/expo'
+```tsx {{ mark: [[1, 2], [23, 31]] }}
+import { useSignIn } from '@clerk/expo'
+import { ClerkOfflineError } from '@clerk/expo/errors'
 import { Link, useRouter } from 'expo-router'
 import { Text, TextInput, Button, View } from 'react-native'
 import React from 'react'
@@ -93,7 +94,7 @@ export default function SignInPage() {
     } catch (err) {
       // See https://clerk.com/docs/guides/development/custom-flows/error-handling
       // for more info on error handling
-      if (isClerkRuntimeError(err) && err.code === 'network_error') {
+      if (ClerkOfflineError.is(err)) {
         console.error('Network error occurred!')
       }
 


### PR DESCRIPTION
### 🔎 Previews:


### What does this solve? What changed?

- https://clerk.com/docs/guides/development/offline-support was missed with the Core 3 updates.
- Changed error handler to `ClerkOfflineError` and corrected import paths

### Deadline

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
