### PR TITLE
fix(expo): keep components/ in quickstart template cleanup

### DIFF
--- a/docs/_partials/expo/quickstart/remove-default-template-files.mdx
+++ b/docs/_partials/expo/quickstart/remove-default-template-files.mdx
@@ -1,7 +1,7 @@
-The default Expo template includes files that will conflict with the routes you'll create in this guide. Remove the conflicting files and unused `components/` directory:
+The default Expo template includes files that will conflict with the routes you'll create in this guide. Remove the conflicting files:
 
 ```bash
-rm -rf "app/(tabs)" app/modal.tsx app/+not-found.tsx components/
+rm -rf "app/(tabs)" app/modal.tsx app/+not-found.tsx
 ```
 
 The default template also includes `react-native-reanimated`, which can cause [known Android build issues](https://docs.expo.dev/versions/latest/sdk/reanimated/#known-issues). Since it's not needed for this guide, remove it to avoid build errors:


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/chris-expo-quickstart-keep-components-dir/expo/getting-started/quickstart

### What does this solve? What changed?

Following the Expo quickstart end-to-end produces a broken app. The "remove default template files" step instructs you to delete the `components/` directory, but the sign-in and sign-up snippets later in the same quickstart import `ThemedText` from `@/components/themed-text` and `ThemedView` from `@/components/themed-view`. After running the cleanup command, those imports fail to resolve and the app won't build.

The two partials drifted out of sync — likely an earlier version of the snippets used plain RN `Text`/`View`, the snippets were rewritten to use the themed components, but the deletion command was never updated. The directory is **not** unused — the docs' own snippets depend on it.

This PR drops `components/` from the `rm -rf` command in `_partials/expo/quickstart/remove-default-template-files.mdx` and updates the surrounding sentence so it no longer claims the directory is unused. The conflicting `app/(tabs)`, `app/modal.tsx`, and `app/+not-found.tsx` are still removed.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush, but it would be nice to land this soon - anyone following the quickstart today hits the broken state.

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

- Reported by Jordan Bott in Slack