### PR TITLE
Add new create props to sign-in/up future

### DIFF
--- a/docs/guides/development/custom-flows/organizations/accept-organization-invitations.mdx
+++ b/docs/guides/development/custom-flows/organizations/accept-organization-invitations.mdx
@@ -23,14 +23,14 @@ The `__clerk_ticket` query parameter contains the ticket token, which is essenti
 
 The `__clerk_status` query parameter is the outcome of the ticket verification and will contain one of three values:
 
-- `sign_in` indicates the user already exists in your application. You should create a sign-in flow using the invitation token by extracting the token from the URL and passing it to the [`signIn.create()`](/docs/reference/objects/sign-in#create) method.
-- `sign_up` indicates the user doesn't already exist in your application. You should create a sign-up flow using the invitation token by extracting the token from the URL and passing it to the [`signUp.create()`](/docs/reference/objects/sign-up#create) method.
+- `sign_in` indicates the user already exists in your application. You should create a sign-in flow using the invitation token by extracting the token from the URL and passing it to the [`signIn.ticket()`](/docs/reference/objects/sign-in-future#ticket) method.
+- `sign_up` indicates the user doesn't already exist in your application. You should create a sign-up flow using the invitation token by extracting the token from the URL and passing it to the [`signUp.create()`](/docs/reference/objects/sign-up-future#create) method.
 - `complete` indicates the user already exists in your application, and was signed in. The flow has been completed and no further actions are required.
 
 The following example demonstrates how to handle both sign-up and sign-in flows using the invitation token:
 
 1. It extracts the token from the URL.
-1. It passes the token to either [`signUp.create()`](/docs/reference/objects/sign-up#create) or [`signIn.create()`](/docs/reference/objects/sign-in#create), depending on the `__clerk_status`.
+1. It passes the token to either [`signUp.create()`](/docs/reference/objects/sign-up-future#create) or [`signIn.ticket()`](/docs/reference/objects/sign-in-future#ticket), depending on the `__clerk_status`.
 1. It demonstrates how to collect additional fields during sign-up, such as first and last names. You can modify or remove these fields as needed for your application. If you do not have **First and last name** enabled for your instance [in the Clerk Dashboard](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=user-profile), remove these fields or `signUp.create()` will throw an error.
 
 <If notSdk={["expo", "ios", "android"]}>
@@ -46,8 +46,8 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
   import { useSearchParams } from 'next/navigation'
 
   export default function Page() {
-    const { isLoaded, signUp, setActive: setActiveSignUp } = useSignUp()
-    const { signIn, setActive: setActiveSignIn } = useSignIn()
+    const { signUp, errors: signUpErrors } = useSignUp()
+    const { signIn, errors: signInErrors } = useSignIn()
     const { organization } = useOrganization()
     const [firstName, setFirstName] = React.useState('')
     const [lastName, setLastName] = React.useState('')
@@ -64,33 +64,45 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
 
     // Handle sign-in
     React.useEffect(() => {
-      if (!signIn || !setActiveSignIn || !token || organization || accountStatus !== 'sign_in') {
+      if (!token || organization || accountStatus !== 'sign_in') {
         return
       }
 
       const createSignIn = async () => {
-        try {
-          // Create a new `SignIn` with the supplied invitation token.
-          // Make sure you're also passing the ticket strategy.
-          const signInAttempt = await signIn.create({
-            strategy: 'ticket',
-            ticket: token as string,
-          })
-
-          // If the sign-in was successful, set the session to active
-          if (signInAttempt.status === 'complete') {
-            await setActiveSignIn({
-              session: signInAttempt.createdSessionId,
-            })
-          } else {
-            // If the sign-in attempt is not complete, check why.
-            // User may need to complete further steps.
-            console.error(JSON.stringify(signInAttempt, null, 2))
-          }
-        } catch (err) {
+        // Create a new `SignIn` with the supplied invitation token.
+        // Make sure you're also passing the ticket strategy.
+        const { error } = await signIn.ticket({ ticket: token })
+        if (error) {
           // See https://clerk.com/docs/guides/development/custom-flows/error-handling
           // for more info on error handling
           console.error('Error:', JSON.stringify(err, null, 2))
+          return
+        }
+
+        // If the sign-in was successful, set the session to active
+        if (signIn.status === 'complete') {
+          await signIn.finalize({
+            navigate: ({ session, decorateUrl }) => {
+              // Handle session tasks
+              // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+              if (session?.currentTask) {
+                console.log(session?.currentTask)
+                return
+              }
+
+              // If no session tasks, navigate the signed-in user to the home page
+              const url = decorateUrl('/')
+              if (url.startsWith('http')) {
+                window.location.href = url
+              } else {
+                router.push(url)
+              }
+            },
+          })
+        } else {
+          // If the sign-in attempt is not complete, check why.
+          // User may need to complete further steps.
+          console.error(JSON.stringify(signIn, null, 2))
         }
       }
 
@@ -101,35 +113,51 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
     const handleSignUp = async (e: React.FormEvent) => {
       e.preventDefault()
 
-      if (!isLoaded) return
-
-      try {
-        // Create a new sign-up with the supplied invitation token.
-        // Make sure you're also passing the ticket strategy.
-        // After the below call, the user's email address will be
-        // automatically verified because of the invitation token.
-        // You can also collect additional fields that your application requires,
-        // such as firstName and lastName.
-        const signUpAttempt = await signUp.create({
-          strategy: 'ticket',
-          ticket: token,
-          firstName,
-          lastName,
-          password,
-        })
-
-        // If the sign-up was successful, set the session to active
-        if (signUpAttempt.status === 'complete') {
-          await setActiveSignUp({ session: signUpAttempt.createdSessionId })
-        } else {
-          // If the sign-in attempt is not complete, check why.
-          // User may need to complete further steps.
-          console.error(JSON.stringify(signUpAttempt, null, 2))
-        }
-      } catch (err) {
+      // Create a new sign-up with the supplied invitation token.
+      // Make sure you're also passing the ticket strategy.
+      // After the below call, the user's email address will be
+      // automatically verified because of the invitation token.
+      // You can also collect additional fields that your application requires,
+      // such as firstName, lastName, and password.
+      const { error } = await signUp.create({
+        strategy: 'ticket',
+        ticket: token,
+        firstName,
+        lastName,
+        password,
+      })
+      if (error) {
         // See https://clerk.com/docs/guides/development/custom-flows/error-handling
         // for more info on error handling
         console.error(JSON.stringify(err, null, 2))
+        return
+      }
+
+      // If the sign-up was successful, set the session to active
+      if (signUp.status === 'complete') {
+        await signUp.finalize({
+          // Redirect the user to the home page after signing up
+          navigate: ({ session, decorateUrl }) => {
+            // Handle session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            if (session?.currentTask) {
+              console.log(session?.currentTask)
+              return
+            }
+
+            // If no session tasks, navigate the signed-in user to the home page
+            const url = decorateUrl('/')
+            if (url.startsWith('http')) {
+              window.location.href = url
+            } else {
+              router.push(url as Href)
+            }
+          },
+        })
+      } else {
+        // If the sign-in attempt is not complete, check why.
+        // User may need to complete further steps.
+        console.error(JSON.stringify(signUp, null, 2))
       }
     }
 
@@ -223,28 +251,40 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
       }
 
       const createSignIn = async () => {
-        try {
-          // Create a new `SignIn` with the supplied invitation token.
-          // Make sure you're also passing the ticket strategy.
-          const signInAttempt = await signIn.create({
-            strategy: 'ticket',
-            ticket: token as string,
-          })
-
-          // If the sign-in was successful, set the session to active
-          if (signInAttempt.status === 'complete') {
-            await setActiveSignIn({
-              session: signInAttempt.createdSessionId,
-            })
-          } else {
-            // If the sign-in attempt is not complete, check why.
-            // User may need to complete further steps.
-            console.error(JSON.stringify(signInAttempt, null, 2))
-          }
-        } catch (err) {
+        // Create a new `SignIn` with the supplied invitation token.
+        // Make sure you're also passing the ticket strategy.
+        const { error } = await signIn.ticket({ ticket: token })
+        if (error) {
           // See https://clerk.com/docs/guides/development/custom-flows/error-handling
           // for more info on error handling
           console.error('Error:', JSON.stringify(err, null, 2))
+          return
+        }
+
+        // If the sign-in was successful, set the session to active
+        if (signIn.status === 'complete') {
+          await signIn.finalize({
+            navigate: ({ session, decorateUrl }) => {
+              // Handle session tasks
+              // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+              if (session?.currentTask) {
+                console.log(session?.currentTask)
+                return
+              }
+
+              // If no session tasks, navigate the signed-in user to the home page
+              const url = decorateUrl('/')
+              if (url.startsWith('http')) {
+                window.location.href = url
+              } else {
+                router.push(url)
+              }
+            },
+          })
+        } else {
+          // If the sign-in attempt is not complete, check why.
+          // User may need to complete further steps.
+          console.error(JSON.stringify(signIn, null, 2))
         }
       }
 
@@ -253,35 +293,51 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
 
     // Handle submission of the sign-up form
     const handleSignUp = async () => {
-      if (!isLoaded) return
-
-      try {
-        // Create a new sign-up with the supplied invitation token.
-        // Make sure you're also passing the ticket strategy.
-        // After the below call, the user's email address will be
-        // automatically verified because of the invitation token.
-        // You can also collect additional fields that your application requires,
-        // such as firstName and lastName.
-        const signUpAttempt = await signUp.create({
-          strategy: 'ticket',
-          ticket: token,
-          firstName,
-          lastName,
-          password,
-        })
-
-        // If the sign-up was successful, set the session to active
-        if (signUpAttempt.status === 'complete') {
-          await setActiveSignUp({ session: signUpAttempt.createdSessionId })
-        } else {
-          // If the sign-in attempt is not complete, check why.
-          // User may need to complete further steps.
-          console.error(JSON.stringify(signUpAttempt, null, 2))
-        }
-      } catch (err) {
+      // Create a new sign-up with the supplied invitation token.
+      // Make sure you're also passing the ticket strategy.
+      // After the below call, the user's email address will be
+      // automatically verified because of the invitation token.
+      // You can also collect additional fields that your application requires,
+      // such as firstName, lastName, and password.
+      const { error } = await signUp.create({
+        strategy: 'ticket',
+        ticket: token,
+        firstName,
+        lastName,
+        password,
+      })
+      if (error) {
         // See https://clerk.com/docs/guides/development/custom-flows/error-handling
         // for more info on error handling
         console.error(JSON.stringify(err, null, 2))
+        return
+      }
+
+      // If the sign-up was successful, set the session to active
+      if (signUp.status === 'complete') {
+        await signUp.finalize({
+          // Redirect the user to the home page after signing up
+          navigate: ({ session, decorateUrl }) => {
+            // Handle session tasks
+            // See https://clerk.com/docs/guides/development/custom-flows/authentication/session-tasks
+            if (session?.currentTask) {
+              console.log(session?.currentTask)
+              return
+            }
+
+            // If no session tasks, navigate the signed-in user to the home page
+            const url = decorateUrl('/')
+            if (url.startsWith('http')) {
+              window.location.href = url
+            } else {
+              router.push(url as Href)
+            }
+          },
+        })
+      } else {
+        // If the sign-in attempt is not complete, check why.
+        // User may need to complete further steps.
+        console.error(JSON.stringify(signUp, null, 2))
       }
     }
 

--- a/docs/guides/development/custom-flows/organizations/accept-organization-invitations.mdx
+++ b/docs/guides/development/custom-flows/organizations/accept-organization-invitations.mdx
@@ -31,7 +31,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
 
 1. It extracts the token from the URL.
 1. It passes the token to either [`signUp.create()`](/docs/reference/objects/sign-up-future#create) or [`signIn.ticket()`](/docs/reference/objects/sign-in-future#ticket), depending on the `__clerk_status`.
-1. It demonstrates how to collect additional fields during sign-up, such as first and last names. You can modify or remove these fields as needed for your application. If you do not have **First and last name** enabled for your instance [in the Clerk Dashboard](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=user-profile), remove these fields or `signUp.create()` will throw an error.
+1. It demonstrates how to collect additional fields during sign-up, such as first and last names. You can modify or remove these fields as needed for your application. If you do not have **First and last name** enabled for your instance [in the Clerk Dashboard](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=user-profile), remove these fields or `signUp.create()` will return an error.
 
 <If notSdk={["expo", "ios", "android"]}>
   <If notSdk="nextjs">
@@ -43,12 +43,13 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
 
   import * as React from 'react'
   import { useOrganization, useSignIn, useSignUp } from '@clerk/nextjs'
-  import { useSearchParams } from 'next/navigation'
+  import { useRouter, useSearchParams } from 'next/navigation'
 
   export default function Page() {
-    const { signUp, errors: signUpErrors } = useSignUp()
-    const { signIn, errors: signInErrors } = useSignIn()
+    const { signUp } = useSignUp()
+    const { signIn } = useSignIn()
     const { organization } = useOrganization()
+    const router = useRouter()
     const [firstName, setFirstName] = React.useState('')
     const [lastName, setLastName] = React.useState('')
     const [password, setPassword] = React.useState('')
@@ -75,7 +76,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
         if (error) {
           // See https://clerk.com/docs/guides/development/custom-flows/error-handling
           // for more info on error handling
-          console.error('Error:', JSON.stringify(err, null, 2))
+          console.error('Error:', JSON.stringify(error, null, 2))
           return
         }
 
@@ -107,7 +108,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
       }
 
       createSignIn()
-    }, [signIn])
+    }, [signIn, token, organization, accountStatus])
 
     // Handle submission of the sign-up form
     const handleSignUp = async (e: React.FormEvent) => {
@@ -129,7 +130,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
       if (error) {
         // See https://clerk.com/docs/guides/development/custom-flows/error-handling
         // for more info on error handling
-        console.error(JSON.stringify(err, null, 2))
+        console.error(JSON.stringify(error, null, 2))
         return
       }
 
@@ -150,12 +151,12 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
             if (url.startsWith('http')) {
               window.location.href = url
             } else {
-              router.push(url as Href)
+              router.push(url)
             }
           },
         })
       } else {
-        // If the sign-in attempt is not complete, check why.
+        // Check why the sign-up is not complete.
         // User may need to complete further steps.
         console.error(JSON.stringify(signUp, null, 2))
       }
@@ -218,14 +219,15 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
   import { ThemedText } from '@/components/themed-text'
   import { ThemedView } from '@/components/themed-view'
   import { useOrganization, useSignIn, useSignUp } from '@clerk/expo'
-  import { useLocalSearchParams } from 'expo-router'
+  import { type Href, useLocalSearchParams, useRouter } from 'expo-router'
   import * as React from 'react'
   import { ActivityIndicator, Pressable, StyleSheet, TextInput } from 'react-native'
 
   export default function Page() {
-    const { isLoaded, signUp, setActive: setActiveSignUp } = useSignUp()
-    const { signIn, setActive: setActiveSignIn } = useSignIn()
+    const { signUp } = useSignUp()
+    const { signIn } = useSignIn()
     const { organization, isLoaded: orgIsLoaded } = useOrganization()
+    const router = useRouter()
     const [firstName, setFirstName] = React.useState('')
     const [lastName, setLastName] = React.useState('')
     const [password, setPassword] = React.useState('')
@@ -246,7 +248,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
 
     // Handle sign-in
     React.useEffect(() => {
-      if (!signIn || !setActiveSignIn || !token || organization || accountStatus !== 'sign_in') {
+      if (!token || organization || accountStatus !== 'sign_in') {
         return
       }
 
@@ -257,7 +259,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
         if (error) {
           // See https://clerk.com/docs/guides/development/custom-flows/error-handling
           // for more info on error handling
-          console.error('Error:', JSON.stringify(err, null, 2))
+          console.error('Error:', JSON.stringify(error, null, 2))
           return
         }
 
@@ -289,7 +291,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
       }
 
       createSignIn()
-    }, [signIn, token, organization, accountStatus, setActiveSignIn])
+    }, [signIn, token, organization, accountStatus])
 
     // Handle submission of the sign-up form
     const handleSignUp = async () => {
@@ -309,7 +311,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
       if (error) {
         // See https://clerk.com/docs/guides/development/custom-flows/error-handling
         // for more info on error handling
-        console.error(JSON.stringify(err, null, 2))
+        console.error(JSON.stringify(error, null, 2))
         return
       }
 
@@ -335,7 +337,7 @@ The following example demonstrates how to handle both sign-up and sign-in flows 
           },
         })
       } else {
-        // If the sign-in attempt is not complete, check why.
+        // Check why the sign-up is not complete.
         // User may need to complete further steps.
         console.error(JSON.stringify(signUp, null, 2))
       }

--- a/docs/reference/objects/sign-in-future.mdx
+++ b/docs/reference/objects/sign-in-future.mdx
@@ -131,6 +131,13 @@ function create(params: SignInFutureCreateParams): Promise<{ error: ClerkError |
 
   ---
 
+  - `password?`
+  - `string`
+
+  The user's password. Only supported if [password](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#password) is enabled.
+
+  ---
+
   - `redirectUrl?`
   - `string`
 
@@ -139,7 +146,7 @@ function create(params: SignInFutureCreateParams): Promise<{ error: ClerkError |
   ---
 
   - `strategy?`
-  - <code>[OAuthStrategy](/docs/reference/types/sso#o-auth-strategy) | "enterprise\_sso" | "passkey"</code>
+  - <code>[OAuthStrategy](/docs/reference/types/sso#o-auth-strategy) | "enterprise\_sso" | "passkey" | "ticket"</code>
 
   The first factor verification strategy to use in the sign-in flow. Depends on the `identifier` value. Each authentication identifier supports different verification strategies.
 

--- a/docs/reference/objects/sign-in-future.mdx
+++ b/docs/reference/objects/sign-in-future.mdx
@@ -145,6 +145,13 @@ function create(params: SignInFutureCreateParams): Promise<{ error: ClerkError |
 
   ---
 
+  - `signUpIfMissing?`
+  - `boolean`
+
+  When set to `true`, if a user does not exist, the sign-up will prepare a transfer to sign up a new account. If bot sign-up protection is enabled, captcha will also be required on sign in.
+
+  ---
+
   - `strategy?`
   - <code>[OAuthStrategy](/docs/reference/types/sso#o-auth-strategy) | "enterprise\_sso" | "passkey" | "ticket"</code>
 

--- a/docs/reference/objects/sign-up-future.mdx
+++ b/docs/reference/objects/sign-up-future.mdx
@@ -187,6 +187,18 @@ function create(params: SignUpFutureCreateParams): Promise<{ error: ClerkError |
 #### `SignUpFutureCreateParams`
 
 <Properties>
+  - `strategy?`
+  - `'oauth_<provider>' | 'enterprise_sso' | 'ticket' | 'google_one_tap'`
+
+  The strategy to use for the sign-up flow. The following strategies are supported:
+
+  - `'oauth_<provider>'`: The user will be authenticated with their [social connection account](/docs/guides/configure/auth-strategies/social-connections/overview). See a list of [supported values for `<provider>`](/docs/reference/types/sso).
+  - `'enterprise_sso'`: The user will be authenticated either through SAML or OIDC depending on the configuration of their [enterprise SSO account](/docs/guides/configure/auth-strategies/enterprise-connections/overview).
+  - `'ticket'`: The user will be authenticated via the ticket _or token_ generated from the Backend API.
+  - `'google_one_tap'`: The user will be authenticated with the Google One Tap UI. It's recommended to use [`authenticateWithGoogleOneTap()`](/docs/reference/components/authentication/google-one-tap#authenticate-with-google-one-tap) instead, as it will also set the user's current session as active for you.
+
+  ---
+
   - `emailAddress?`
   - `string`
 
@@ -254,6 +266,13 @@ function create(params: SignUpFutureCreateParams): Promise<{ error: ClerkError |
   - `string`
 
   The user's username. Only supported if [username](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#username) is enabled in the instance settings.
+
+  ---
+
+  - `password?`
+  - `string`
+
+  The user's password. Only supported if [password](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#password) is enabled.
 
   ---
 

--- a/docs/reference/objects/sign-up-future.mdx
+++ b/docs/reference/objects/sign-up-future.mdx
@@ -8,7 +8,7 @@ The `SignUpFuture` object holds the state of the current sign-up attempt and pro
 
 ## Example
 
-See the [custom flow guides](/docs/guides/development/custom-flows/overview) for comprehensive examples of using the `SignInFuture` object to build custom user interfaces with the Clerk API.
+See the [custom flow guides](/docs/guides/development/custom-flows/overview) for comprehensive examples of using the `SignUpFuture` object to build custom user interfaces with the Clerk API.
 
 ## Properties
 
@@ -187,18 +187,6 @@ function create(params: SignUpFutureCreateParams): Promise<{ error: ClerkError |
 #### `SignUpFutureCreateParams`
 
 <Properties>
-  - `strategy?`
-  - `'oauth_<provider>' | 'enterprise_sso' | 'ticket' | 'google_one_tap'`
-
-  The strategy to use for the sign-up flow. The following strategies are supported:
-
-  - `'oauth_<provider>'`: The user will be authenticated with their [social connection account](/docs/guides/configure/auth-strategies/social-connections/overview). See a list of [supported values for `<provider>`](/docs/reference/types/sso).
-  - `'enterprise_sso'`: The user will be authenticated either through SAML or OIDC depending on the configuration of their [enterprise SSO account](/docs/guides/configure/auth-strategies/enterprise-connections/overview).
-  - `'ticket'`: The user will be authenticated via the ticket _or token_ generated from the Backend API.
-  - `'google_one_tap'`: The user will be authenticated with the Google One Tap UI. It's recommended to use [`authenticateWithGoogleOneTap()`](/docs/reference/components/authentication/google-one-tap#authenticate-with-google-one-tap) instead, as it will also set the user's current session as active for you.
-
-  ---
-
   - `emailAddress?`
   - `string`
 
@@ -234,10 +222,31 @@ function create(params: SignUpFutureCreateParams): Promise<{ error: ClerkError |
 
   ---
 
+  - `password?`
+  - `string`
+
+  The user's password. Only supported if [password](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#password) is enabled.
+
+  ---
+
   - `phoneNumber?`
   - `string`
 
   The user's phone number in [E.164 format](https://en.wikipedia.org/wiki/E.164). Only supported if [phone number](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#phone) is enabled. Keep in mind that the phone number requires an extra verification process.
+
+  ---
+
+  - `strategy?`
+  - <code>[OAuthStrategy](/docs/reference/types/sso#o-auth-strategy) | 'enterprise\_sso' | 'ticket' | 'google\_one\_tap' | 'oauth\_token\_apple' | 'phone\_code'</code>
+
+  The strategy to use for the sign-up flow. The following strategies are supported:
+
+  - `'oauth_<provider>'`: The user will be authenticated with their [social connection account](/docs/guides/configure/auth-strategies/social-connections/overview). See a list of [supported values for `<provider>`](/docs/reference/types/sso).
+  - `'enterprise_sso'`: The user will be authenticated either through SAML or OIDC depending on the configuration of their [enterprise SSO account](/docs/guides/configure/auth-strategies/enterprise-connections/overview).
+  - `'ticket'`: The user will be authenticated via the ticket _or token_ generated from the Backend API.
+  - `'google_one_tap'`: The user will be authenticated with the Google One Tap UI. It's recommended to use [`authenticateWithGoogleOneTap()`](/docs/reference/components/authentication/google-one-tap#authenticate-with-google-one-tap) instead, as it will also set the user's current session as active for you.
+  - `'oauth_token_apple'`: The user will be authenticated using a native [Sign in with Apple](/docs/guides/configure/auth-strategies/sign-in-with-apple) identity token.
+  - `'phone_code'`: The user will receive a one-time code via SMS to verify their phone number.
 
   ---
 
@@ -266,13 +275,6 @@ function create(params: SignUpFutureCreateParams): Promise<{ error: ClerkError |
   - `string`
 
   The user's username. Only supported if [username](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#username) is enabled in the instance settings.
-
-  ---
-
-  - `password?`
-  - `string`
-
-  The user's password. Only supported if [password](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#password) is enabled.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/dsfix-future-tickets/nextjs/reference/objects/sign-in-future
- https://clerk.com/docs/pr/dsfix-future-tickets/nextjs/reference/objects/sign-up-future
- https://clerk.com/docs/pr/dsfix-future-tickets/guides/development/custom-flows/organizations/accept-organization-invitations

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- This PR updates the types for `signUp.create()` and `signIn.create()` to reflect new parameters added in a recent SDK release.
- This PR also updates the docs for accepting organization invitations to reflect the new Core 3 APIs (this was missed in our initial Core 3 docs work).

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush!

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
