### PR TITLE
Update Clerk SDK references to @clerk/clerk-expo

### DIFF
--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -65,7 +65,7 @@ Use the following tabs to choose your preferred approach:
       - Clerk stores the active user's session token in memory by default. In Expo apps, the recommended way to store sensitive data, such as tokens, is by using `expo-secure-store` which encrypts the data before storing it.
 
       ```bash
-      npx expo install @clerk/expo expo-secure-store
+      npx expo install @clerk/clerk-expo expo-secure-store
       ```
 
       ## Set your Clerk API keys
@@ -92,7 +92,7 @@ Use the following tabs to choose your preferred approach:
       1. In the `(auth)` group, create a `_layout.tsx` file with the following code. The [`useAuth()`](/docs/reference/hooks/use-auth) hook is used to access the user's authentication state. If the user is already signed in, they will be redirected to the home page.
 
       ```tsx {{ filename: 'app/(auth)/_layout.tsx' }}
-      import { useAuth } from '@clerk/expo'
+      import { useAuth } from '@clerk/clerk-expo'
       import { Redirect, Stack } from 'expo-router'
 
       export default function AuthRoutesLayout() {
@@ -131,7 +131,7 @@ Use the following tabs to choose your preferred approach:
       1. In the `(home)` group, create a `_layout.tsx` file with the following code.
 
       ```tsx {{ filename: 'app/(home)/_layout.tsx' }}
-      import { useAuth } from '@clerk/expo'
+      import { useAuth } from '@clerk/clerk-expo'
       import { Redirect, Stack } from 'expo-router'
 
       export default function Layout() {
@@ -152,8 +152,8 @@ Use the following tabs to choose your preferred approach:
       Then, in the same folder, create an `index.tsx` file. If the user is signed in, it displays their email and a sign-out button. If they're not signed in, it displays sign-in and sign-up links.
 
       ```tsx {{ filename: 'app/(home)/index.tsx', collapsible: true }}
-      import { Show, useUser } from '@clerk/expo'
-      import { useClerk } from '@clerk/expo'
+      import { Show, useUser } from '@clerk/clerk-expo'
+      import { useClerk } from '@clerk/clerk-expo'
       import { Link } from 'expo-router'
       import { Text, View, Pressable, StyleSheet } from 'react-native'
 
@@ -264,7 +264,7 @@ Use the following tabs to choose your preferred approach:
       - `expo-dev-client` allows you to build and run your app in development mode.
 
       ```bash
-      npx expo install @clerk/expo expo-secure-store expo-auth-session expo-web-browser expo-dev-client
+      npx expo install @clerk/clerk-expo expo-secure-store expo-auth-session expo-web-browser expo-dev-client
       ```
 
       ## Set your Clerk API keys
@@ -277,12 +277,12 @@ Use the following tabs to choose your preferred approach:
 
       ## Verify `app.json` plugins
 
-      Run `npx expo install` to automatically add the required config plugins to your `app.json` file. Then verify that `@clerk/expo` and `expo-secure-store` appear in the `plugins` array:
+      Run `npx expo install` to automatically add the required config plugins to your `app.json` file. Then verify that `@clerk/clerk-expo` and `expo-secure-store` appear in the `plugins` array:
 
       ```json {{ filename: 'app.json' }}
       {
         "expo": {
-          "plugins": ["expo-secure-store", "@clerk/expo"]
+          "plugins": ["expo-secure-store", "@clerk/clerk-expo"]
         }
       }
       ```
@@ -300,8 +300,8 @@ Use the following tabs to choose your preferred approach:
       <Include src="_partials/expo/session-sync-callout" />
 
       ```tsx {{ filename: 'app/index.tsx', collapsible: true }}
-      import { useAuth, useUser, useClerk, useUserProfileModal } from '@clerk/expo'
-      import { AuthView, UserButton } from '@clerk/expo/native'
+      import { useAuth, useUser, useClerk, useUserProfileModal } from '@clerk/clerk-expo'
+      import { AuthView, UserButton } from '@clerk/clerk-expo/native'
       import { Text, View, StyleSheet, Image, TouchableOpacity, ActivityIndicator } from 'react-native'
 
       export default function MainScreen() {


### PR DESCRIPTION
### 🔎 Previews:
<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->
- [Clerk Expo Quickstart](https://clerk.com/docs/expo/getting-started/quickstart)

### What does this solve? What changed?
The Expo Quickstart guide referenced `@clerk/expo` as the package name, which is incorrect. The correct package name is `@clerk/clerk-expo`.

Developers following the guide would install the wrong package, leading to failed imports and a broken setup.

This PR updates all instances of `@clerk/expo` to `@clerk/clerk-expo` in the Expo Quickstart guide.

Fixes https://github.com/clerk/clerk-docs/issues/3282

### Deadline
No rush.

### Other resources
- https://github.com/clerk/clerk-docs/issues/3282