### PR TITLE
docs(expo): document native component theming

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1954,6 +1954,10 @@
                               {
                                 "title": "`<UserProfileView />`",
                                 "href": "/docs/reference/expo/native-components/user-profile-view"
+                              },
+                              {
+                                "title": "Theming",
+                                "href": "/docs/reference/expo/native-components/theming"
                               }
                             ]
                           ]

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -52,6 +52,13 @@ The plugin accepts the following options:
   - `string`
 
   Custom keychain service identifier. Required if you need extension targets (widgets, App Clips, Watch) to share the keychain with the main app.
+
+  ---
+
+  - `theme`
+  - `string`
+
+  Path to a JSON file that customizes the appearance of the native components on iOS and Android (colors, dark mode, border radius, font family). See the [Theming](/docs/reference/expo/native-components/theming) reference for the full schema.
 </Properties>
 
 #### Example

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -58,7 +58,7 @@ The plugin accepts the following options:
   - `theme`
   - `string`
 
-  Path to a JSON file that customizes the appearance of the native components on iOS and Android (colors, dark mode, border radius, font family). See the [Theming](/docs/reference/expo/native-components/theming) reference for the full schema.
+  Path to a JSON file that customizes the appearance of the native components on iOS and Android (colors, dark mode, border radius, and font family). See the [Theming](/docs/reference/expo/native-components/theming) reference for platform-specific details and the full schema.
 </Properties>
 
 #### Example

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -6,7 +6,7 @@ sdk: expo
 
 <Include src="_partials/expo/beta-callout" />
 
-You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserButton />`, and `<UserProfileView />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
+You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and the profile modal opened by `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android. The `<UserButton />` avatar itself is a React Native component and is not affected by the theme.
 
 ## Configure the plugin
 

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -91,10 +91,7 @@ Light mode color tokens. Each value must be a 6- or 8-digit hex string (8-digit 
 
 Same shape as `colors`, applied automatically when the device is in dark mode. Any tokens you omit fall back to the default dark theme.
 
-When `darkColors` is provided:
-
-- **iOS:** the plugin removes `UIUserInterfaceStyle` from `Info.plist` so the system can switch between light and dark mode automatically.
-- **Android:** the dark palette is registered on `Clerk.customTheme.darkColors`.
+When `darkColors` is provided, native components automatically use the dark palette when the device is in dark mode. To enable system dark mode in your app, set `"userInterfaceStyle": "automatic"` in your `app.json`. If you pin your app to `"light"` or `"dark"`, the native components will always use the corresponding palette.
 
 ### `design`
 
@@ -110,8 +107,10 @@ When `darkColors` is provided:
 
 The plugin runs during `expo prebuild`:
 
-- **iOS:** the parsed theme is embedded in `Info.plist` under the `ClerkTheme` key. At runtime, the iOS components read it and apply both the light and dark palettes via SwiftUI's environment.
+- **iOS:** the parsed theme is embedded in `Info.plist` under the `ClerkTheme` key. At runtime, the iOS components read it and apply the light or dark palette based on the current system appearance via SwiftUI's environment.
 - **Android:** the JSON is copied to `android/app/src/main/assets/clerk_theme.json`. At runtime the Android module parses it and assigns it to `Clerk.customTheme`.
+
+The plugin does not modify your app's `userInterfaceStyle` setting. To control whether your app follows the system appearance or is pinned to light/dark mode, set `"userInterfaceStyle"` in your `app.json`.
 
 Because the theme is applied at the native layer, it does not affect any web or JavaScript components.
 
@@ -120,4 +119,4 @@ Because the theme is applied at the native layer, it does not affect any web or 
 - **My theme changes aren't showing up.** Run `npx expo prebuild --clean` to regenerate the native projects. The theme is only read at prebuild time.
 - **`Clerk theme: invalid hex color for colors.primary`.** All color values must be hex strings with a leading `#` and 6 or 8 hex digits.
 - **`Clerk theme file not found`.** The `theme` path is resolved relative to your project root. Double-check the path in `app.json`.
-- **Dark mode isn't switching on iOS.** Make sure you're providing `darkColors`, and that you haven't manually re-added `UIUserInterfaceStyle` to your `Info.plist` after prebuild.
+- **Dark mode isn't switching on iOS.** Make sure you're providing `darkColors` and that `"userInterfaceStyle"` is set to `"automatic"` in your `app.json`.

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -120,3 +120,4 @@ Because the theme is applied at the native layer, it does not affect any web or 
 - **`Clerk theme: invalid hex color for colors.primary`.** All color values must be hex strings with a leading `#` and 6 or 8 hex digits.
 - **`Clerk theme file not found`.** The `theme` path is resolved relative to your project root. Double-check the path in `app.json`.
 - **Dark mode isn't switching on iOS.** Make sure you're providing `darkColors` and that `"userInterfaceStyle"` is set to `"automatic"` in your `app.json`.
+- **I removed the `theme` prop but the old theme is still applied.** Run `npx expo prebuild --clean` after removing the `theme` option. Incremental prebuilds don't clean up previously embedded theme data from `Info.plist` or `android/app/src/main/assets/clerk_theme.json`.

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -6,7 +6,10 @@ sdk: expo
 
 <Include src="_partials/expo/beta-callout" />
 
-You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and the profile modal opened by `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android. The `<UserButton />` avatar itself is a React Native component and is not affected by the theme.
+You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and the profile modal opened by `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
+
+> [!NOTE]
+> The `<UserButton />` avatar itself is a React Native component and is not affected by the theme.
 
 ## Configure the plugin
 
@@ -116,8 +119,22 @@ Because the theme is applied at the native layer, it only affects the native vie
 
 ## Troubleshooting
 
-- **My theme changes aren't showing up.** Run `npx expo prebuild --clean` to regenerate the native projects. The theme is only read at prebuild time.
-- **`Clerk theme: invalid hex color for colors.primary`.** All color values must be hex strings with a leading `#` and 6 or 8 hex digits.
-- **`Clerk theme file not found`.** The `theme` path is resolved relative to your project root. Double-check the path in `app.json`.
-- **Dark mode isn't switching on iOS.** Make sure you're providing `darkColors` and that `"userInterfaceStyle"` is set to `"automatic"` in your `app.json`.
-- **I removed the `theme` prop but the old theme is still applied.** Run `npx expo prebuild --clean` after removing the `theme` option. Incremental prebuilds don't clean up previously embedded theme data from `Info.plist` or `android/app/src/main/assets/clerk_theme.json`.
+### My theme changes aren't showing up
+
+Run `npx expo prebuild --clean` to regenerate the native projects. The theme is only read at prebuild time.
+
+### `Clerk theme: invalid hex color for colors.primary`
+
+All color values must be hex strings with a leading `#` and 6 or 8 hex digits.
+
+### `Clerk theme file not found`
+
+The `theme` path is resolved relative to your project root. Double-check the path in `app.json`.
+
+### Dark mode isn't switching on iOS
+
+Make sure you're providing `darkColors` and that `"userInterfaceStyle"` is set to `"automatic"` in your `app.json`.
+
+### I removed the `theme` prop but the old theme is still applied
+
+Run `npx expo prebuild --clean` after removing the `theme` option. Incremental prebuilds don't clean up previously embedded theme data from `Info.plist` or `android/app/src/main/assets/clerk_theme.json`.

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -112,7 +112,7 @@ The plugin runs during `expo prebuild`:
 
 The plugin does not modify your app's `userInterfaceStyle` setting. To control whether your app follows the system appearance or is pinned to light/dark mode, set `"userInterfaceStyle"` in your `app.json`.
 
-Because the theme is applied at the native layer, it does not affect any web or JavaScript components.
+Because the theme is applied at the native layer, it only affects the native views (`<AuthView />`, `<UserProfileView />`, and the profile modal opened by `<UserButton />`). It does not affect web components or React Native UI elements like the `<UserButton />` avatar itself.
 
 ## Troubleshooting
 

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -1,0 +1,123 @@
+---
+title: Theming Expo native components
+description: Customize the appearance of Clerk's native iOS and Android components with a JSON theme file.
+sdk: expo
+---
+
+<Include src="_partials/expo/beta-callout" />
+
+You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserButton />`, and `<UserProfileView />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
+
+## Configure the plugin
+
+Create a `clerk-theme.json` file in your project and reference it from the plugin in your `app.json`:
+
+```json {{ filename: 'app.json' }}
+{
+  "expo": {
+    "plugins": [
+      [
+        "@clerk/expo",
+        {
+          "theme": "./clerk-theme.json"
+        }
+      ]
+    ]
+  }
+}
+```
+
+Run `npx expo prebuild --clean` (or rerun `npx expo run:ios` / `npx expo run:android`) so the plugin picks up the theme. The JSON is validated during prebuild — invalid hex colors or value types will fail the build with a descriptive error.
+
+## Theme schema
+
+Every key is optional. Provide only what you want to override; everything else falls back to the default Clerk theme.
+
+```json {{ filename: 'clerk-theme.json' }}
+{
+  "colors": {
+    "primary": "#6C47FF",
+    "background": "#FFFFFF",
+    "input": "#F5F5F5",
+    "danger": "#EF4444",
+    "success": "#10B981",
+    "warning": "#F59E0B",
+    "foreground": "#0F172A",
+    "mutedForeground": "#64748B",
+    "primaryForeground": "#FFFFFF",
+    "inputForeground": "#0F172A",
+    "neutral": "#94A3B8",
+    "border": "#E2E8F0",
+    "ring": "#6C47FF",
+    "muted": "#F1F5F9",
+    "shadow": "#00000020"
+  },
+  "darkColors": {
+    "primary": "#8B6FFF",
+    "background": "#0B0B0F",
+    "foreground": "#FFFFFF",
+    "border": "#1F2937"
+  },
+  "design": {
+    "borderRadius": 12,
+    "fontFamily": "Inter"
+  }
+}
+```
+
+### `colors`
+
+Light mode color tokens. Each value must be a 6- or 8-digit hex string (8-digit includes an alpha channel, e.g. `#00000080`). Unknown keys are ignored with a warning.
+
+| Key | Description |
+| - | - |
+| `primary` | Primary action color (buttons, links, focus). |
+| `background` | Surface background. |
+| `input` | Input field background. |
+| `danger` | Destructive / error states. |
+| `success` | Success states. |
+| `warning` | Warning states. |
+| `foreground` | Primary text color on `background`. |
+| `mutedForeground` | Secondary / helper text. |
+| `primaryForeground` | Text color used on top of `primary` (e.g. button labels). |
+| `inputForeground` | Text color inside inputs. |
+| `neutral` | Neutral accent color. |
+| `border` | Borders and dividers. |
+| `ring` | Focus ring. |
+| `muted` | Muted surface (badges, subtle backgrounds). |
+| `shadow` | Shadow color. |
+
+### `darkColors`
+
+Same shape as `colors`, applied automatically when the device is in dark mode. Any tokens you omit fall back to the default dark theme.
+
+When `darkColors` is provided:
+
+- **iOS:** the plugin removes `UIUserInterfaceStyle` from `Info.plist` so the system can switch between light and dark mode automatically.
+- **Android:** the dark palette is registered on `Clerk.customTheme.darkColors`.
+
+### `design`
+
+| Key | Type | Platform | Description |
+| - | - | - | - |
+| `borderRadius` | `number` | iOS + Android | Corner radius applied across components, in points/dp. |
+| `fontFamily` | `string` | iOS only | Custom font family name. The font must be bundled with your iOS app and registered in `Info.plist` (`UIAppFonts`). |
+
+> [!NOTE]
+> Custom font families are currently iOS-only. Android uses the system font.
+
+## How it works
+
+The plugin runs during `expo prebuild`:
+
+- **iOS:** the parsed theme is embedded in `Info.plist` under the `ClerkTheme` key. At runtime, the iOS components read it and apply both the light and dark palettes via SwiftUI's environment.
+- **Android:** the JSON is copied to `android/app/src/main/assets/clerk_theme.json`. At runtime the Android module parses it and assigns it to `Clerk.customTheme`.
+
+Because the theme is applied at the native layer, it does not affect any web or JavaScript components.
+
+## Troubleshooting
+
+- **My theme changes aren't showing up.** Run `npx expo prebuild --clean` to regenerate the native projects. The theme is only read at prebuild time.
+- **`Clerk theme: invalid hex color for colors.primary`.** All color values must be hex strings with a leading `#` and 6 or 8 hex digits.
+- **`Clerk theme file not found`.** The `theme` path is resolved relative to your project root. Double-check the path in `app.json`.
+- **Dark mode isn't switching on iOS.** Make sure you're providing `darkColors`, and that you haven't manually re-added `UIUserInterfaceStyle` to your `Info.plist` after prebuild.


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/chris-native-components-theming/reference/expo/native-components/theming
- https://clerk.com/docs/pr/chris-native-components-theming/reference/expo/native-components/overview

### What does this solve? What changed?

- Adds a new **Theming** reference page (`docs/reference/expo/native-components/theming.mdx`) documenting the JSON-based theme system for Clerk's native Expo components (`<AuthView />`, `<UserButton />`, `<UserProfileView />`).
- Adds `theme` to the Expo plugin options table in the native components overview page.
- Adds the theming page to `manifest.json` under the native components nav section.

The theme JSON supports `colors` (15 semantic tokens), `darkColors` (automatic dark mode), `design.borderRadius`, and `design.fontFamily` (iOS only). Dark mode is controlled by the developer via Expo's `userInterfaceStyle` setting in `app.json` — the plugin does not modify it.

Source PR: https://github.com/clerk/javascript/pull/8243

### Deadline

- Ships with the theming feature in `@clerk/expo`. No rush beyond that.

### Other resources

- SDK PR: https://github.com/clerk/javascript/pull/8243
- Changelog PR: https://github.com/clerk/clerk/pull/new/chris/native-components-theming
- Quickstart PR: https://github.com/clerk/clerk-expo-quickstart/pull/new/chris/native-components-theming