### PR TITLE
Add CLI overview page

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -45,6 +45,8 @@ clerk init
 
 This command auto-detects your framework, installs the appropriate Clerk SDK, and applies framework-specific setup such as auth pages, middleware, and providers. If you're authenticated with `clerk auth login`, it also links your project to a Clerk application and pulls your environment variables automatically.
 
+You can also use `clerk init --starter` to bootstrap a brand new project from a starter template, or run `clerk init` without an account to get started immediately with temporary development keys.
+
 ## What you can do
 
 - **Set up authentication** — `clerk init` detects your framework, installs the SDK, and scaffolds your project with Clerk's authentication setup.
@@ -52,6 +54,7 @@ This command auto-detects your framework, installs the appropriate Clerk SDK, an
 - **Configure your instance** — `clerk config pull` and `clerk config patch` let you manage your Clerk instance's auth settings as code.
 - **Access the Clerk API** — `clerk api` is an authenticated client for Clerk's [Backend API](/docs/reference/backend/overview). Run `clerk api ls` to explore available endpoints.
 - **Run diagnostics** — `clerk doctor` validates your project's Clerk integration and flags common issues.
+- **Manage applications** — `clerk apps list` and `clerk apps create` let you view and create Clerk applications from the terminal.
 - **Open the Dashboard** — `clerk open` launches the [Clerk Dashboard](https://dashboard.clerk.com) in your browser from the terminal.
 - **Update the CLI** — `clerk update` updates the CLI to the latest version.
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,0 +1,87 @@
+---
+title: Clerk CLI
+description: Learn how to use the Clerk CLI to set up authentication, manage configuration, and integrate with AI agents.
+---
+
+The Clerk CLI is a command-line tool for setting up and managing [Clerk](https://clerk.com) authentication in your projects. It works for both humans and AI agents, and supports 10+ frameworks.
+
+## Installation
+
+Install the CLI globally, or run it directly without installing using `npx` or `bunx`.
+
+<Tabs items={["npm (recommended)", "Homebrew", "npx", "bunx"]}>
+  <Tab>
+    ```bash {{ filename: 'terminal' }}
+    npm install -g clerk
+    ```
+  </Tab>
+
+  <Tab>
+    ```bash {{ filename: 'terminal' }}
+    brew install clerk/stable/clerk
+    ```
+  </Tab>
+
+  <Tab>
+    ```bash {{ filename: 'terminal' }}
+    npx clerk
+    ```
+  </Tab>
+
+  <Tab>
+    ```bash {{ filename: 'terminal' }}
+    bunx clerk
+    ```
+  </Tab>
+</Tabs>
+
+## Get started
+
+Run `clerk init` in your project directory to get started:
+
+```bash {{ filename: 'terminal' }}
+clerk init
+```
+
+This command auto-detects your framework, installs the appropriate Clerk SDK, and applies framework-specific setup such as auth pages, middleware, and providers. If you're authenticated with `clerk auth login`, it also links your project to a Clerk application and pulls your environment variables automatically.
+
+## What you can do
+
+- **Set up authentication** — `clerk init` detects your framework, installs the SDK, and scaffolds your project with Clerk's authentication setup.
+- **Manage environment variables** — `clerk env pull` pulls your Clerk API keys into your project's env file.
+- **Configure your instance** — `clerk config pull` and `clerk config patch` let you manage your Clerk instance's auth settings as code.
+- **Access the Clerk API** — `clerk api` is an authenticated client for Clerk's [Backend API](/docs/reference/backend/overview). Run `clerk api ls` to explore available endpoints.
+- **Run diagnostics** — `clerk doctor` validates your project's Clerk integration and flags common issues.
+- **Open the Dashboard** — `clerk open` launches the [Clerk Dashboard](https://dashboard.clerk.com) in your browser from the terminal.
+
+Run `clerk --help` for a full list of commands.
+
+## AI agent integration
+
+The CLI is designed to work seamlessly with AI coding agents:
+
+- **Automatic agent detection** — The CLI auto-detects agent vs. human mode. Non-TTY environments default to agent mode, or you can set it explicitly with `--mode agent`.
+- **Agent-friendly setup** — `clerk init --prompt` outputs framework-specific integration instructions for your AI agent and exits without modifying the project.
+- **Clerk Skills** — Install [Clerk Skills](/docs/guides/ai/skills) separately to give your AI agent deeper knowledge about Clerk's SDKs and patterns.
+
+## Frequently asked questions (FAQ)
+
+### What can't the CLI do?
+
+The CLI handles project setup, configuration, and API access. For user management, analytics, and other advanced features, use the [Clerk Dashboard](https://dashboard.clerk.com) directly.
+
+### Which frameworks are supported?
+
+The CLI supports frameworks such as Next.js, React, Vue, Nuxt, Astro, React Router, TanStack Start, and more. Some frameworks like Expo, Express, and Fastify are supported for SDK installation but don't yet include full scaffolding. Run `clerk init --help` for the current list.
+
+### Is it open source?
+
+Yes. The CLI is open source and available on [GitHub](https://github.com/clerk/cli).
+
+### How do I report a bug?
+
+Open an issue on the [GitHub repo](https://github.com/clerk/cli/issues) or [contact support](https://clerk.com/contact/support).
+
+### How do I request a feature?
+
+Submit feature requests on Clerk's [public roadmap](https://feedback.clerk.com/roadmap).

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -3,13 +3,13 @@ title: Clerk CLI
 description: Learn how to use the Clerk CLI to set up authentication, manage configuration, and integrate with AI agents.
 ---
 
-The Clerk CLI is a command-line tool for setting up and managing [Clerk](https://clerk.com) authentication in your projects. It works for both humans and AI agents, and supports 10+ frameworks.
+The Clerk CLI is a command-line tool for you and your agents to set up and manage [Clerk](https://clerk.com) authentication directly from the terminal. It supports 10+ frameworks.
 
 ## Installation
 
 Install the CLI globally, or run it directly without installing using `npx` or `bunx`.
 
-<Tabs items={["npm (recommended)", "Homebrew", "npx", "bunx"]}>
+<Tabs items={["npm (recommended)", "pnpm", "bun", "Homebrew", "npx", "bunx"]}>
   <Tab>
     ```bash {{ filename: 'terminal' }}
     npm install -g clerk
@@ -18,7 +18,19 @@ Install the CLI globally, or run it directly without installing using `npx` or `
 
   <Tab>
     ```bash {{ filename: 'terminal' }}
-    brew install clerk/stable/clerk
+    pnpm install -g clerk
+    ```
+  </Tab>
+
+  <Tab>
+    ```bash {{ filename: 'terminal' }}
+    bun add -g clerk
+    ```
+  </Tab>
+
+  <Tab>
+    ```bash {{ filename: 'terminal' }}
+    brew install clerk
     ```
   </Tab>
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -7,9 +7,9 @@ The Clerk CLI is a command-line tool for you and your agents to set up and manag
 
 ## Installation
 
-Install the CLI globally, or run it directly without installing using `npx` or `bunx`.
+Install the CLI globally, or run it directly without installing using `npx clerk` or `bunx clerk`.
 
-<CodeBlockTabs options={["npm (recommended)", "pnpm", "bun", "Homebrew", "npx", "bunx"]}>
+<CodeBlockTabs type="installer" options={["npm", "pnpm", "bun", "Homebrew"]}>
   ```bash {{ filename: 'terminal' }}
   npm install -g clerk
   ```
@@ -24,14 +24,6 @@ Install the CLI globally, or run it directly without installing using `npx` or `
 
   ```bash {{ filename: 'terminal' }}
   brew install clerk
-  ```
-
-  ```bash {{ filename: 'terminal' }}
-  npx clerk
-  ```
-
-  ```bash {{ filename: 'terminal' }}
-  bunx clerk
   ```
 </CodeBlockTabs>
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -9,43 +9,31 @@ The Clerk CLI is a command-line tool for you and your agents to set up and manag
 
 Install the CLI globally, or run it directly without installing using `npx` or `bunx`.
 
-<Tabs items={["npm (recommended)", "pnpm", "bun", "Homebrew", "npx", "bunx"]}>
-  <Tab>
-    ```bash {{ filename: 'terminal' }}
-    npm install -g clerk
-    ```
-  </Tab>
+<CodeBlockTabs options={["npm (recommended)", "pnpm", "bun", "Homebrew", "npx", "bunx"]}>
+  ```bash {{ filename: 'terminal' }}
+  npm install -g clerk
+  ```
 
-  <Tab>
-    ```bash {{ filename: 'terminal' }}
-    pnpm install -g clerk
-    ```
-  </Tab>
+  ```bash {{ filename: 'terminal' }}
+  pnpm install -g clerk
+  ```
 
-  <Tab>
-    ```bash {{ filename: 'terminal' }}
-    bun add -g clerk
-    ```
-  </Tab>
+  ```bash {{ filename: 'terminal' }}
+  bun add -g clerk
+  ```
 
-  <Tab>
-    ```bash {{ filename: 'terminal' }}
-    brew install clerk
-    ```
-  </Tab>
+  ```bash {{ filename: 'terminal' }}
+  brew install clerk
+  ```
 
-  <Tab>
-    ```bash {{ filename: 'terminal' }}
-    npx clerk
-    ```
-  </Tab>
+  ```bash {{ filename: 'terminal' }}
+  npx clerk
+  ```
 
-  <Tab>
-    ```bash {{ filename: 'terminal' }}
-    bunx clerk
-    ```
-  </Tab>
-</Tabs>
+  ```bash {{ filename: 'terminal' }}
+  bunx clerk
+  ```
+</CodeBlockTabs>
 
 ## Get started
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -9,13 +9,17 @@ The Clerk CLI is a command-line tool for you and your agents to set up and manag
 
 Install the CLI globally, or run it directly without installing using `npx clerk` or `bunx clerk`.
 
-<CodeBlockTabs type="installer" options={["npm", "pnpm", "bun", "Homebrew"]}>
+<CodeBlockTabs type="installer" options={["npm", "pnpm", "yarn", "bun", "Homebrew"]}>
   ```bash {{ filename: 'terminal', prompt: '$' }}
   npm install -g clerk
   ```
 
   ```bash {{ filename: 'terminal', prompt: '$' }}
   pnpm install -g clerk
+  ```
+
+  ```bash {{ filename: 'terminal', prompt: '$' }}
+  yarn global add clerk
   ```
 
   ```bash {{ filename: 'terminal', prompt: '$' }}

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -62,7 +62,7 @@ The CLI is designed to work seamlessly with AI coding agents:
 
 - **Automatic agent detection** — The CLI auto-detects agent vs. human mode. Non-TTY environments default to agent mode, or you can set it explicitly with `--mode agent`.
 - **Agent-friendly setup** — `clerk init --prompt` outputs framework-specific integration instructions for your AI agent and exits without modifying the project.
-- **Clerk Skills** — Install [Clerk Skills](/docs/guides/ai/skills) separately to give your AI agent deeper knowledge about Clerk's SDKs and patterns.
+- **Clerk Skills** — `clerk init` offers to install [Clerk Skills](/docs/guides/ai/skills), giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -31,7 +31,7 @@ Install the CLI globally, or run it directly without installing using `npx clerk
   ```
 
   ```bash {{ filename: 'terminal', prompt: '$' }}
-  curl -fsSL https://cli.clerk.com/install | bash
+  curl -fsSL https://clerk.com/install | bash
   ```
 </CodeBlockTabs>
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -9,7 +9,7 @@ The Clerk CLI is a command-line tool for you and your agents to set up and manag
 
 Install the CLI globally, or run it directly without installing using `npx clerk` or `bunx clerk`.
 
-<CodeBlockTabs type="installer" options={["npm", "pnpm", "yarn", "bun", "Homebrew"]}>
+<CodeBlockTabs type="installer" options={["npm", "pnpm", "yarn", "bun", "Homebrew", "curl"]}>
   ```bash {{ filename: 'terminal', prompt: '$' }}
   npm install -g clerk
   ```
@@ -28,6 +28,10 @@ Install the CLI globally, or run it directly without installing using `npx clerk
 
   ```bash {{ filename: 'terminal', prompt: '$' }}
   brew install clerk
+  ```
+
+  ```bash {{ filename: 'terminal', prompt: '$' }}
+  curl -fsSL https://cli.clerk.com/install | bash
   ```
 </CodeBlockTabs>
 
@@ -49,6 +53,7 @@ This command auto-detects your framework, installs the appropriate Clerk SDK, an
 - **Access the Clerk API** — `clerk api` is an authenticated client for Clerk's [Backend API](/docs/reference/backend/overview). Run `clerk api ls` to explore available endpoints.
 - **Run diagnostics** — `clerk doctor` validates your project's Clerk integration and flags common issues.
 - **Open the Dashboard** — `clerk open` launches the [Clerk Dashboard](https://dashboard.clerk.com) in your browser from the terminal.
+- **Update the CLI** — `clerk update` updates the CLI to the latest version.
 
 Run `clerk --help` for a full list of commands.
 
@@ -58,7 +63,7 @@ The CLI is designed to work seamlessly with AI coding agents:
 
 - **Automatic agent detection** — The CLI auto-detects agent vs. human mode. Non-TTY environments default to agent mode, or you can set it explicitly with `--mode agent`.
 - **Agent-friendly setup** — `clerk init --prompt` outputs framework-specific integration instructions for your AI agent and exits without modifying the project.
-- **Clerk Skills** — `clerk init` offers to install [Clerk Skills](/docs/guides/ai/skills), giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
+- **Clerk Skills** — Run `clerk skill install` or accept the prompt during `clerk init` to install [Clerk Skills](/docs/guides/ai/skills), giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -10,19 +10,19 @@ The Clerk CLI is a command-line tool for you and your agents to set up and manag
 Install the CLI globally, or run it directly without installing using `npx clerk` or `bunx clerk`.
 
 <CodeBlockTabs type="installer" options={["npm", "pnpm", "bun", "Homebrew"]}>
-  ```bash {{ filename: 'terminal' }}
+  ```bash {{ filename: 'terminal', prompt: '$' }}
   npm install -g clerk
   ```
 
-  ```bash {{ filename: 'terminal' }}
+  ```bash {{ filename: 'terminal', prompt: '$' }}
   pnpm install -g clerk
   ```
 
-  ```bash {{ filename: 'terminal' }}
+  ```bash {{ filename: 'terminal', prompt: '$' }}
   bun add -g clerk
   ```
 
-  ```bash {{ filename: 'terminal' }}
+  ```bash {{ filename: 'terminal', prompt: '$' }}
   brew install clerk
   ```
 </CodeBlockTabs>
@@ -31,7 +31,7 @@ Install the CLI globally, or run it directly without installing using `npx clerk
 
 Run `clerk init` in your project directory to get started:
 
-```bash {{ filename: 'terminal' }}
+```bash {{ filename: 'terminal', prompt: '$' }}
 clerk init
 ```
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1238,6 +1238,12 @@
           ],
           [
             {
+              "title": "CLI",
+              "href": "/docs/cli"
+            }
+          ],
+          [
+            {
               "title": "Development",
               "items": [
                 [


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-manovotnydocs-11681-create-mini-49fd22/cli

### What does this solve? What changed?

Adds a minimal CLI docs page to support the upcoming GA launch (Friday, April 17). The CLI team agreed docs should signal existence without duplicating `--help`.

**Changes:**
- New `docs/cli.mdx` overview page with:
  - Install tabs (npm, pnpm, yarn, bun, Homebrew) matching the changelog's `CodeBlockTabs` pattern
  - `clerk init` quick start
  - Capabilities overview (init, env pull, config, api, doctor, open)
  - AI agent integration section (agent mode, `--prompt`, Skills)
  - FAQ (limitations, frameworks, open source, bugs, feature requests)
- Added top-level "CLI" sidebar entry in `manifest.json` (placed between "AI" and "Development")

### Deadline

Friday, April 17 (CLI GA launch)

### Other resources

- Linear: [DOCS-11681](https://linear.app/clerk/issue/DOCS-11681/create-minimal-cli-docs)
- CLI repo: https://github.com/clerk/cli
- CLI landing page: https://github.com/clerk/clerk/pull/2403
- CLI changelog: https://github.com/clerk/clerk/pull/2427
- [Slack thread](https://clerkinc.slack.com/archives/C0944EQCUKY/p1776116997578939)
