### PR TITLE
Fix <If notSdk> false positives and skip partial scope checks

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -1241,9 +1241,7 @@ Testing with a simple page.`,
     expect(output).toContain(`warning sdk \"astro\" in <If /> is not a valid SDK`)
   })
 
-  // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
-  // Change back when `safeFail` is restored in validateIfComponents.ts
-  console.warn('⚠️  TEMPORARILY DISABLED: <If> SDK not in frontmatter test skipped')
+  // TODO: Re-enable after clerk/clerk-docs#3265 (mobile custom flows manifest) merges and safeFail is restored in validateIfComponents.ts
   test.skip('<If> SDK not in frontmatter fails the build', async () => {
     const { tempDir } = await createTempFiles([
       {
@@ -1282,9 +1280,7 @@ Testing with a simple page.`,
     )
   })
 
-  // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
-  // Change back when `safeFail` is restored in validateIfComponents.ts
-  console.warn('⚠️  TEMPORARILY DISABLED: <If> SDK not in manifest test skipped')
+  // TODO: Re-enable after clerk/clerk-docs#3265 (mobile custom flows manifest) merges and safeFail is restored in validateIfComponents.ts
   test.skip('<If> SDK not in manifest fails the build', async () => {
     const { tempDir } = await createTempFiles([
       {
@@ -1748,6 +1744,49 @@ sdk: nextjs, react
 
     expect(await readFile(pathJoin('./dist/nextjs/overview.mdx'))).toContain('This content is for Next.js users only.')
     expect(await readFile(pathJoin('./dist/react/overview.mdx'))).toContain('This content is for React users only.')
+  })
+
+  test('should not fail when <If notSdk /> excludes SDKs not in page scope', async () => {
+    const { tempDir, pathJoin } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              {
+                title: 'Overview',
+                href: '/docs/overview',
+                sdk: ['nextjs', 'react'],
+              },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/overview.mdx',
+        content: `---
+title: Overview
+sdk: nextjs, react
+---
+
+# Hello World
+
+<If notSdk={["ios", "android"]}>
+  This content is for non-mobile users.
+</If>`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['nextjs', 'react', 'ios', 'android'],
+      }),
+    )
+
+    expect(await readFile(pathJoin('./dist/nextjs/overview.mdx'))).toContain('This content is for non-mobile users.')
+    expect(await readFile(pathJoin('./dist/react/overview.mdx'))).toContain('This content is for non-mobile users.')
   })
 
   test('should handle <If /> components with both `sdk` and `notSdk` props', async () => {

--- a/scripts/lib/plugins/checkPartials.ts
+++ b/scripts/lib/plugins/checkPartials.ts
@@ -95,7 +95,7 @@ export const checkPartials =
       foundPartial?.(resolvedPartialPath)
 
       if (options.embed === true) {
-        return Object.assign(node, partial.node)
+        return Object.assign(node, partial.node, { data: { ...partial.node.data, fromPartial: true } })
       }
 
       return node

--- a/scripts/lib/plugins/validateIfComponents.ts
+++ b/scripts/lib/plugins/validateIfComponents.ts
@@ -1,5 +1,5 @@
 import { Node } from 'unist'
-import { visit as mdastVisit } from 'unist-util-visit'
+import { SKIP, visit as mdastVisit } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 import { type BuildConfig } from '../config'
 import { safeFail } from '../error-messages'
@@ -33,8 +33,11 @@ function extractSDKsFromIfComponent(
   }
 
   if (notSdk) {
-    const notAllowedSdks = extractSDKsFromIfProp(config)(node, vfile, notSdk, 'docs', filePath)
-    return notAllowedSdks
+    // Still validate that the SDK names are valid, but don't return them
+    // for scope checking — notSdk exclusions don't require the excluded
+    // SDKs to be in the page's scope.
+    extractSDKsFromIfProp(config)(node, vfile, notSdk, 'docs', filePath)
+    return undefined
   }
 
   if (sdk) {
@@ -57,6 +60,11 @@ export const validateIfComponents =
   () =>
   (tree: Node, vfile: VFile) => {
     mdastVisit(tree, (node) => {
+      // Skip nodes embedded from partials — their <If> components are validated
+      // in the context of each including page, but partials are shared across
+      // pages with different SDK scopes, so per-page checks produce false positives.
+      if ((node as any).data?.fromPartial) return SKIP
+
       const allowedSdks = extractSDKsFromIfComponent(
         config,
         node,
@@ -82,8 +90,7 @@ export const validateIfComponents =
           const available = doc.sdk.includes(sdk)
 
           if (available === false) {
-            // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
-            // Change back to `safeFail` when done.
+            // TODO: Re-enable after clerk/clerk-docs#3265 (mobile custom flows manifest) merges.
             console.warn(`⚠️  TEMPORARILY DISABLED: <If /> sdk "${sdk}" not in frontmatter for ${filePath}`)
           }
         })()
@@ -94,8 +101,7 @@ export const validateIfComponents =
           const available = availableSDKs.includes(sdk)
 
           if (available === false) {
-            // TODO: Temporarily disabled due to large-scale docs/SDK changes (Core 3, native mobile sidebar, and Development SDK-specificity.
-            // Change back to `safeFail` when done.
+            // TODO: Re-enable after clerk/clerk-docs#3265 (mobile custom flows manifest) merges.
             console.warn(`⚠️  TEMPORARILY DISABLED: <If /> sdk "${sdk}" not in manifest for ${doc.file.href}`)
           }
         })()


### PR DESCRIPTION
### 🔎 Previews:

- N/A (build script changes only)

### What does this solve? What changed?

The `<If>` component validator had two sources of false positives that caused us to disable it entirely with `⚠️ TEMPORARILY DISABLED` warnings:

**1. `notSdk` false positives** — The validator treated `notSdk` props identically to `sdk` props. When a page used `<If notSdk={["ios", "android"]}>` but wasn't scoped for ios/android, the validator flagged it. But `notSdk` means "show for everything EXCEPT these" — the excluded SDKs don't need to be in scope. Fixed by having `extractSDKsFromIfComponent` return `undefined` for `notSdk` (SDK names are still validated, just not scope-checked).

**2. Partial false positives** — Shared partials like `_partials/hooks/use-user.mdx` contain `<If sdk="react">`, `<If sdk="nextjs">`, etc. for multiple SDKs. When included on a page scoped to only one SDK, the validator flagged the others. Fixed by marking embedded partial nodes with `data.fromPartial` in `checkPartials.ts` and skipping scope checks for those subtrees in the validator.

**What's NOT re-enabled yet:** The `safeFail` calls remain as `console.warn` because ~79 remaining warnings are ios/android manifest issues that #3265 will resolve. After #3265 merges, only 4 files / 8 warnings remain (tested by merging #3265 locally):

| Issue | File | Count |
|-------|------|-------|
| Frontmatter missing ios/android | `embedded-email-links.mdx` | 2 |
| Manifest missing ios/android | `embedded-email-links.mdx` | 2 |
| Manifest missing ios/android | `sign-up-sign-in-options` | 2 |
| Manifest missing android | `social-connections/google` | 1 |
| Manifest missing android | `legacy/passkeys` | 1 |

Updated the TODO comments to reference #3265.

**Out of scope / follow-up:**
- **Dead `<If>` detection in partials** — This PR skips scope checks for `<If>` inside partials (to eliminate false positives), but doesn't yet detect truly dead content in partials (e.g., `<If sdk="X">` in a partial where no including page is scoped for X). That requires an aggregate check across all including pages — a separate feature.

**Changes:**
- `validateIfComponents.ts` — Return `undefined` for `notSdk` props (skip scope check), import `SKIP` and skip `fromPartial` subtrees
- `checkPartials.ts` — Mark embedded partial root nodes with `data.fromPartial`
- `build-docs.test.ts` — Add regression test for `notSdk` with out-of-scope SDKs, update TODO comments to reference #3265

### Deadline

- No rush

### Other resources

- #3265 — Add custom flows to mobile sidebar (resolves 79 of the 81 remaining warnings)
