### PR TITLE
(billing): clarify Stripe account linking requirements

### DIFF
--- a/docs/guides/billing/overview.mdx
+++ b/docs/guides/billing/overview.mdx
@@ -32,7 +32,8 @@ Clerk Billing allows your customers to purchase recurring Subscriptions to your 
 ### Can I use an existing Stripe account with Clerk Billing?
 
 Yes, you can use an existing Stripe account, as long as it isn't controlled by another platform.
-Accounts created under a platform's Connect setup must be disconnected from that platform before they can be linked to Clerk.
+
+Disconnect accounts created under a platform's Stripe Connect setup from that platform before linking them to Clerk.
 
 In general, if you created your Stripe account yourself via Stripe, it's independent; if it was created through another service, it may be platform-controlled.
 

--- a/docs/guides/billing/overview.mdx
+++ b/docs/guides/billing/overview.mdx
@@ -31,7 +31,10 @@ Clerk Billing allows your customers to purchase recurring Subscriptions to your 
 
 ### Can I use an existing Stripe account with Clerk Billing?
 
-Yes, you can. However, it must not already be linked to another platform.
+Yes, you can use an existing Stripe account, as long as it isn't controlled by another platform.
+Accounts created under a platform's Connect setup must be disconnected from that platform before they can be linked to Clerk.
+
+In general, if you created your Stripe account yourself via Stripe, it's independent; if it was created through another service, it may be platform-controlled.
 
 ### Can I see Subscriptions in my Stripe account?
 


### PR DESCRIPTION
### 🔎 Previews:

https://clerk-docs-git-mauricio-antunes-update-stripe-account-wi-ae58be.clerkstage.dev/

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

### What does this solve? What changed?

Customers were confused by the statement that existing Stripe accounts must not be linked to another platform, since in practice some accounts can still be connected to multiple apps.

This change clarifies that the restriction only applies to accounts that are controlled by another platform (e.g created via a platform's Connect setup), which cannot be connected via OAuth with read/write access

### Other resources
Slack thread: https://clerkinc.slack.com/archives/C08QHV76VA8/p1776201504373949