### PR TITLE
Add fields to signUp.update

### DIFF
--- a/docs/reference/objects/sign-up-future.mdx
+++ b/docs/reference/objects/sign-up-future.mdx
@@ -539,6 +539,13 @@ function update(params: SignUpFutureUpdateParams): Promise<{ error: ClerkError |
 #### `SignUpFutureUpdateParams`
 
 <Properties>
+  - `emailAddress?`
+  - `string`
+
+  The user's email address. Only supported if [Email address](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#email) is enabled. Keep in mind that the email address requires an extra verification process.
+
+  ---
+
   - `firstName?`
   - `string`
 
@@ -567,10 +574,24 @@ function update(params: SignUpFutureUpdateParams): Promise<{ error: ClerkError |
 
   ---
 
+  - `phoneNumber?`
+  - `string`
+
+  The user's phone number in [E.164 format](https://en.wikipedia.org/wiki/E.164). Only supported if [phone number](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#phone) is enabled. Keep in mind that the phone number requires an extra verification process.
+
+  ---
+
   - `unsafeMetadata?`
   - `SignUpUnsafeMetadata`
 
   Metadata that can be read and set from the frontend. Once the sign-up is complete, the value of this field will be automatically copied to the newly created user's unsafe metadata. One common use case for this attribute is to use it to implement custom fields that can be collected during sign-up and will automatically be attached to the created User object.
+
+  ---
+
+  - `username?`
+  - `string`
+
+  The user's username. Only supported if [username](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#username) is enabled in the instance settings.
 </Properties>
 
 ### `verifications`


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/dsfix-future-signup-update/react/reference/objects/sign-up-future#update

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- This PR adds the fields `emailAddress`, `phoneNumber`, and `username` to the `signUp.update()` documentation. This is in conjunction with https://github.com/clerk/javascript/pull/8320

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
