### PR TITLE
Remove js-backend from custom flows frontmatter

### DIFF
--- a/docs/guides/development/custom-flows/authentication/google-one-tap.mdx
+++ b/docs/guides/development/custom-flows/authentication/google-one-tap.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build a custom Google One Tap authentication flow
 description: Learn how to build a custom Google One Tap authentication flow using the Clerk API.
-sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, expo, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start, js-backend
+sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, expo, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---
 
 {/* DOCS NOTE: Not currently supported by iOS and Android */}

--- a/docs/guides/development/custom-flows/authentication/waitlist.mdx
+++ b/docs/guides/development/custom-flows/authentication/waitlist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build a custom waitlist form
 description: Learn how to use the Clerk API to build a custom waitlist form using Clerk's useWaitlist() hook.
-sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, expo, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start, js-backend
+sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, expo, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---
 
 {/* DOCS NOTE: Not currently supported by iOS and Android */}

--- a/docs/guides/development/custom-flows/error-handling.mdx
+++ b/docs/guides/development/custom-flows/error-handling.mdx
@@ -1,7 +1,7 @@
 ---
 title: Error handling
 description: Provide your users with useful information about the errors being returned from sign-up and sign-in requests.
-sdk: nextjs, react, react-router, expo, tanstack-react-start, expressjs, astro, chrome-extension, js-frontend, js-backend, fastify, go, nuxt, vue, ruby
+sdk: nextjs, react, react-router, expo, tanstack-react-start, expressjs, astro, chrome-extension, js-frontend, fastify, go, nuxt, vue, ruby
 ---
 
 The `useSignIn()`, `useSignUp()`, and `useWaitlist()` hooks return a global [`Errors`](/docs/reference/types/errors) object that contains the errors that occurred during the last API request. Use this object to display errors to the user in your custom UI. These errors contain a `code`, `message`, `longMessage` and `meta` property. These properties can be used to provide your users with useful information about the errors being returned from sign-up and sign-in requests.


### PR DESCRIPTION
## Summary
- `js-backend` was removed from `VALID_SDKS` in #3254 but remained in the `sdk:` frontmatter of three custom-flows docs, breaking `pnpm build` on `main`
- Removes `js-backend` from: `google-one-tap.mdx`, `waitlist.mdx`, and `error-handling.mdx`

## Test plan
- [x] `pnpm build` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)