### PR TITLE
Add guide for rotating Clerk API keys

### DIFF
--- a/docs/guides/secure/rotate-api-keys.mdx
+++ b/docs/guides/secure/rotate-api-keys.mdx
@@ -24,10 +24,15 @@ Clerk supports multiple active Secret Keys on the same instance, which lets you 
 1. In the sidenav, navigate to the [**API keys**](https://dashboard.clerk.com/~/api-keys) page.
 1. Under **Secret keys**, select **+ Add new key**. Give the new key a descriptive name (e.g., `rotated-2026-04-19`) and create it.
 1. Copy the new key value.
-1. Update the <If notSdk={["nuxt"]}>`CLERK_SECRET_KEY`</If><If sdk="nuxt">`NUXT_CLERK_SECRET_KEY`</If> environment variable everywhere it's set — your local `.env` file, your hosting provider (Vercel, Netlify, AWS, etc.), your CI/CD pipelines, and anywhere else the key is referenced.
+1. Update the `CLERK_SECRET_KEY` environment variable everywhere it's set — your local `.env` file, your hosting provider (Vercel, Netlify, AWS, etc.), your CI/CD pipelines, and anywhere else the key is referenced.
 1. Redeploy your app so the new key takes effect.
 1. Verify that your app works as expected with the new key. Exercise any flow that calls Clerk's Backend API — for example, server-side routes that use `clerkClient`, auth middleware, and admin scripts that create, update, or delete users.
 1. Return to the **API keys** page, find the old (compromised) key under **Secret keys**, and delete it.
+
+<If sdk="nuxt">
+  > [!IMPORTANT]
+  > Nuxt uses `NUXT_CLERK_SECRET_KEY` instead of `CLERK_SECRET_KEY`.
+</If>
 
 After you delete the old key, any request to Clerk's Backend API that still uses it will fail.
 

--- a/docs/guides/secure/rotate-api-keys.mdx
+++ b/docs/guides/secure/rotate-api-keys.mdx
@@ -1,0 +1,39 @@
+---
+title: Rotate your Clerk API keys
+description: Learn how to rotate your Clerk Secret Key to revoke access for a compromised key.
+---
+
+If one of your Clerk keys has been exposed — through a leaked `.env` file, a third-party security incident, or a departing team member — rotate the affected key to revoke its access. This page covers how to rotate your [Secret Key](!secret-key), and points to rotation instructions for other Clerk secrets.
+
+## Which keys to rotate
+
+Not every Clerk credential is a secret, and not all of them are rotated the same way:
+
+- **[Publishable Key](!publishable-key)** (`pk_live_*` / `pk_test_*`): Safe to expose on the frontend. You don't need to rotate it if it's committed to a repository or otherwise made public.
+- **[Secret Key](!secret-key)** (`sk_live_*` / `sk_test_*`): Must be kept private. If it's exposed, rotate it using the steps below.
+- **Webhook signing secret** (`whsec_*`): Rotated separately from Clerk's API keys. See the [webhooks guide](/docs/guides/development/webhooks/syncing) for details.
+
+## Rotate your Secret Key
+
+Clerk supports multiple active Secret Keys on the same instance, which lets you roll keys with zero downtime. The process is to add a new key, deploy your application with it, and then delete the old one.
+
+> [!WARNING]
+> Don't delete the old Secret Key until your application has been redeployed and verified with the new key. Removing a key that's still in use will break authentication in your app.
+
+1. At the top left of the Clerk Dashboard, select the app and environment (e.g., **Development** or **Production**) you want to rotate keys for.
+1. In the sidenav, navigate to the [**API keys**](https://dashboard.clerk.com/~/api-keys) page.
+1. Under **Secret keys**, select **+ Add new key**. Give the new key a descriptive name (e.g., `rotated-2026-04-19`) and create it.
+1. Copy the new key value.
+1. Update the <If notSdk={["nuxt"]}>`CLERK_SECRET_KEY`</If><If sdk="nuxt">`NUXT_CLERK_SECRET_KEY`</If> environment variable everywhere it's set — your local `.env` file, your hosting provider (Vercel, Netlify, AWS, etc.), your CI/CD pipelines, and anywhere else the key is referenced.
+1. Redeploy your app so the new key takes effect.
+1. Verify that your app works as expected with the new key. Exercise flows that call Clerk's Backend API, such as sign-in, user management, and webhook handlers.
+1. Return to the **API keys** page, find the old (compromised) key under **Secret keys**, and delete it.
+
+After you delete the old key, any request to Clerk's Backend API that still uses it will fail.
+
+## Rotate across environments and applications
+
+Each Clerk app and environment combination has its own set of API keys. If you need to rotate keys in more than one place, repeat the steps above for each one:
+
+- **Development and Production instances are independent.** Rotating your Production Secret Key doesn't affect your Development Secret Key, and vice versa. Use the app and environment selectors at the top left of the Clerk Dashboard to switch between them.
+- **Separate applications have separate keys.** If you maintain multiple Clerk applications, each has its own Secret Key and must be rotated independently.

--- a/docs/guides/secure/rotate-api-keys.mdx
+++ b/docs/guides/secure/rotate-api-keys.mdx
@@ -3,7 +3,7 @@ title: Rotate your Clerk API keys
 description: Learn how to rotate your Clerk Secret Key to revoke access for a compromised key.
 ---
 
-If one of your Clerk keys has been exposed — through a leaked `.env` file, a third-party security incident, or a departing team member — rotate the affected key to revoke its access. This page covers how to rotate your [Secret Key](!secret-key), and points to rotation instructions for other Clerk secrets.
+If one of your Clerk keys has been exposed — through a leaked `.env` file, a third-party security incident, or a departing team member — rotate the affected key to revoke its access. This page covers how to rotate your [Secret Key](!secret-key) and clarifies which other Clerk credentials do or don't need rotation.
 
 ## Which keys to rotate
 
@@ -11,7 +11,7 @@ Not every Clerk credential is a secret, and not all of them are rotated the same
 
 - **[Publishable Key](!publishable-key)** (`pk_live_*` / `pk_test_*`): Safe to expose on the frontend. You don't need to rotate it if it's committed to a repository or otherwise made public.
 - **[Secret Key](!secret-key)** (`sk_live_*` / `sk_test_*`): Must be kept private. If it's exposed, rotate it using the steps below.
-- **Webhook signing secret** (`whsec_*`): Rotated separately from Clerk's API keys. See the [webhooks guide](/docs/guides/development/webhooks/syncing) for details.
+- **Webhook signing secret** (`whsec_*`): Managed separately from Clerk's API keys on the [**Webhooks**](https://dashboard.clerk.com/~/webhooks) page in the Clerk Dashboard.
 
 ## Rotate your Secret Key
 
@@ -26,7 +26,7 @@ Clerk supports multiple active Secret Keys on the same instance, which lets you 
 1. Copy the new key value.
 1. Update the <If notSdk={["nuxt"]}>`CLERK_SECRET_KEY`</If><If sdk="nuxt">`NUXT_CLERK_SECRET_KEY`</If> environment variable everywhere it's set — your local `.env` file, your hosting provider (Vercel, Netlify, AWS, etc.), your CI/CD pipelines, and anywhere else the key is referenced.
 1. Redeploy your app so the new key takes effect.
-1. Verify that your app works as expected with the new key. Exercise flows that call Clerk's Backend API, such as sign-in, user management, and webhook handlers.
+1. Verify that your app works as expected with the new key. Exercise any flow that calls Clerk's Backend API — for example, server-side routes that use `clerkClient`, auth middleware, and admin scripts that create, update, or delete users.
 1. Return to the **API keys** page, find the old (compromised) key under **Secret keys**, and delete it.
 
 After you delete the old key, any request to Clerk's Backend API that still uses it will fail.

--- a/docs/guides/secure/rotate-api-keys.mdx
+++ b/docs/guides/secure/rotate-api-keys.mdx
@@ -3,7 +3,7 @@ title: Rotate your Clerk API keys
 description: Learn how to rotate your Clerk Secret Key to revoke access for a compromised key.
 ---
 
-If one of your Clerk keys has been exposed — through a leaked `.env` file, a third-party security incident, or a departing team member — rotate the affected key to revoke its access. This page covers how to rotate your [Secret Key](!secret-key) and clarifies which other Clerk credentials do or don't need rotation.
+Common reasons to rotate a key include a leaked `.env` file, a security incident at a third-party service, or a departing team member. This page covers how to rotate your [Secret Key](!secret-key) and explains which other Clerk credentials do or don't need rotation.
 
 ## Which keys to rotate
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1189,6 +1189,10 @@
                     "href": "/docs/guides/development/geo-blocking"
                   },
                   {
+                    "title": "Rotate your Clerk API keys",
+                    "href": "/docs/guides/secure/rotate-api-keys"
+                  },
+                  {
                     "title": "Legal compliance",
                     "href": "/docs/guides/secure/legal-compliance"
                   }


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-brindle-longship/guides/secure/rotate-api-keys

### What does this solve? What changed?

In response to the [Vercel April 2026 security incident](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident), Clerk customers hosted on Vercel may need to rotate their Secret Keys. Clerk's docs previously had no dedicated guide on how to do this.

This PR adds an evergreen, incident-agnostic guide covering:

- Which Clerk credentials are secrets and which aren't (Publishable Key vs. Secret Key).
- The correct dual-key rotation flow: add a new Secret Key → redeploy → delete the old key.
- How the flow applies across multiple app/environment combinations.
- A pointer to webhook signing secret rotation (separate mechanism).

The new page lives at `docs/guides/secure/rotate-api-keys.mdx` and is added to the **Secure** section of the sidenav, between **Web security** and **Legal compliance**. The `CLERK_SECRET_KEY` reference uses the existing `<If sdk="nuxt">` pattern so Nuxt users see `NUXT_CLERK_SECRET_KEY`.

### Deadline

- Soon — responding to the Vercel April 2026 security incident.

### Other resources

- [Vercel April 2026 security incident bulletin](https://vercel.com/kb/bulletin/vercel-april-2026-security-incident)
