### PR TITLE
Add redirects for top docs 404s

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4402,5 +4402,9 @@
   {
     "source": "/docs/android/reference/native-mobile/production",
     "destination": "/docs/guides/development/deployment/production"
+  },
+  {
+    "source": "/docs/reference/react/use-auth",
+    "destination": "/docs/reference/hooks/use-auth"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-fair-globeflower/reference/react/use-auth

### What does this solve? What changed?

Investigated the top 5 docs 404s from the last 7 days and added a redirect for the 1 that warranted action.

#### Investigation methodology

- Searched the full Clerk GitHub org via `gh search code` for each URL to check for broken internal links
- Cross-referenced each URL against existing redirects in `redirects/static/docs.json` and `redirects/dynamic/docs.jsonc`
- Checked the actual file structure to identify correct current URLs
- Validated with `lint:check-duplicate-redirects` — all checks pass

#### Analysis of all 5 URLs

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/reference/react/use-auth` | **Legit near-miss** — Structural gap: `/docs/reference/react/{use-user,use-sign-in,use-organization,use-organizations}` all redirect to their `/docs/reference/hooks/*` equivalents, but `use-auth` was missed. | ✅ Added redirect |
| 2 | `/docs/authentication/enterprise-sso` | **AI-fabricated** — This URL was never a real docs path. Historical enterprise SSO pages lived under `/docs/authentication/saml/*` (already redirected). No references in clerk org. | Skipped |
| 3 | `/docs/authentication/mfa` | **AI-fabricated** — Never a real path. The correct historical URL `/docs/authentication/multi-factor-authentication` already redirects to `sign-up-sign-in-options#multi-factor-authentication`. No references in clerk org. | Skipped |
| 4 | `/docs/guides/ai/mcp` | **Already covered** — Redirect added in [#3284](https://github.com/clerk/clerk-docs/pull/3284) (2026-04-13). The 7-day 404 window overlaps with the period before that PR merged. | Skipped |
| 5 | `/docs/guides/dashboard/dns-domains/proxy-fapi*` | **Malformed URL** — Trailing `*` is either a tool artifact or external markdown malformation. The file exists at the clean path and is correctly linked in our docs and manifest. No broken links in clerk org. | Skipped |

#### Changes

**Static redirect** (`redirects/static/docs.json`):
- `/docs/reference/react/use-auth` → `/docs/reference/hooks/use-auth`

### Deadline

- No rush

### Other resources

- Previous 404 redirect PRs: [#3284](https://github.com/clerk/clerk-docs/pull/3284), [#3269](https://github.com/clerk/clerk-docs/pull/3269), [#3262](https://github.com/clerk/clerk-docs/pull/3262)
