### PR TITLE
Emphasize email requirement in Directory docs

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -40,7 +40,7 @@ Directory Sync is configured per enterprise connection. To set it up:
 Once Directory Sync is enabled in Clerk, configure your IdP to point to Clerk's SCIM endpoint.
 
 > [!IMPORTANT]
-> Clerk requires an `email` attribute to be sent for every user. Even if your `userName` attribute contains an email address, your IdP must also be configured to send the email in the SCIM `email` attribute — Clerk will not fall back to `userName` for email. Users whose SCIM payloads omit `email` will fail to provision.
+> Clerk requires an `email` attribute to be sent for every user. Even if your `userName` attribute contains an email address, you must also configure your IdP to send the email in the SCIM `email` attribute — Clerk will not fall back to `userName` for email. Users whose SCIM payloads omit `email` will fail to provision.
 
 ### Okta
 
@@ -51,7 +51,7 @@ Once Directory Sync is enabled in Clerk, configure your IdP to point to Clerk's 
 1. Enter the **Bearer token** from Clerk into the **API Token** field.
 1. Select **Test API Credentials** to verify the connection, then select **Save**.
 1. Under **To App**, enable the operations you want Okta to push to Clerk: **Create Users**, **Update User Attributes**, and **Deactivate Users**. Select **Save**.
-1. Under **Attribute Mappings**, confirm that `email` (`user.email`) is mapped and being sent to Clerk. If `userName` is the user's email, you still need a separate mapping to `email` — Clerk requires both.
+1. Under **Attribute Mappings**, confirm that `email` (`user.email`) is mapped and sent to Clerk. If `userName` is the user's email, you still need a separate mapping to `email` — Clerk requires both.
 1. To sync groups for [role mapping](#role-mapping), switch to the **Push Groups** tab on the app's Provisioning section and enable **Push Groups**. Select the groups you want to push to Clerk and select **Save**.
 
 ### Microsoft Entra ID

--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -40,7 +40,7 @@ Directory Sync is configured per enterprise connection. To set it up:
 Once Directory Sync is enabled in Clerk, configure your IdP to point to Clerk's SCIM endpoint.
 
 > [!IMPORTANT]
-> Clerk requires an `email` attribute to be sent for every user. Even if your `userName` attribute contains an email address, you must also configure your IdP to send the email in the SCIM `email` attribute — Clerk will not fall back to `userName` for email. Users whose SCIM payloads omit `email` will fail to provision.
+> Clerk requires an email (contained in the `emails` attribute) to be sent for every user. Even if your `userName` attribute contains an email address, you must also configure your IdP to send the email in the SCIM `emails` attribute — Clerk will not fall back to `userName` for email. Users whose SCIM payloads omit an email will fail to provision.
 
 ### Okta
 

--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -39,6 +39,9 @@ Directory Sync is configured per enterprise connection. To set it up:
 
 Once Directory Sync is enabled in Clerk, configure your IdP to point to Clerk's SCIM endpoint.
 
+> [!IMPORTANT]
+> Clerk requires an `email` attribute to be sent for every user. Even if your `userName` attribute contains an email address, your IdP must also be configured to send the email in the SCIM `email` attribute — Clerk will not fall back to `userName` for email. Users whose SCIM payloads omit `email` will fail to provision.
+
 ### Okta
 
 1. In the Okta admin dashboard, navigate to your enterprise app's **Provisioning** tab.
@@ -48,6 +51,7 @@ Once Directory Sync is enabled in Clerk, configure your IdP to point to Clerk's 
 1. Enter the **Bearer token** from Clerk into the **API Token** field.
 1. Select **Test API Credentials** to verify the connection, then select **Save**.
 1. Under **To App**, enable the operations you want Okta to push to Clerk: **Create Users**, **Update User Attributes**, and **Deactivate Users**. Select **Save**.
+1. Under **Attribute Mappings**, confirm that `email` (`user.email`) is mapped and being sent to Clerk. If `userName` is the user's email, you still need a separate mapping to `email` — Clerk requires both.
 1. To sync groups for [role mapping](#role-mapping), switch to the **Push Groups** tab on the app's Provisioning section and enable **Push Groups**. Select the groups you want to push to Clerk and select **Save**.
 
 ### Microsoft Entra ID


### PR DESCRIPTION
We continue to regularly see SCIM provisioning failures due to lack of an email field in the payload. This doc update calls out the requirement explicitly.