### PR TITLE
Improve the Supabase integration guide

### DIFF
--- a/docs/guides/development/integrations/databases/supabase.mdx
+++ b/docs/guides/development/integrations/databases/supabase.mdx
@@ -125,7 +125,7 @@ This guide will have you create a new table in your [Supabase project](https://s
         const [loading, setLoading] = useState(true)
         const [name, setName] = useState('')
         // The `useUser()` hook is used to ensure that Clerk has loaded data about the signed in user
-        const { user } = useUser()
+        const { isLoaded, user } = useUser()
         // The `useSession()` hook is used to get the Clerk session object
         // The session object is used to get the Clerk session token
         const { session } = useSession()
@@ -146,6 +146,10 @@ This guide will have you create a new table in your [Supabase project](https://s
         // This `useEffect` will wait for the User object to be loaded before requesting
         // the tasks for the signed in user
         useEffect(() => {
+          if (!isLoaded) {
+            return
+          }
+
           if (!user) {
             setTasks([])
             setName('')
@@ -162,7 +166,7 @@ This guide will have you create a new table in your [Supabase project](https://s
           }
 
           loadTasks()
-        }, [user])
+        }, [isLoaded, user])
 
         async function createTask(e: React.FormEvent<HTMLFormElement>) {
           e.preventDefault()
@@ -190,16 +194,17 @@ This guide will have you create a new table in your [Supabase project](https://s
 
             {loading && <p>Loading...</p>}
 
-            {!user && !loading && <p>Sign in to view your tasks.</p>}
+            {isLoaded && !user && !loading && <p>Sign in to view your tasks.</p>}
 
-            {user &&
+            {isLoaded &&
+              user &&
               !loading &&
               tasks.length > 0 &&
               tasks.map((task: any) => <p key={task.id}>{task.name}</p>)}
 
-            {user && !loading && tasks.length === 0 && <p>No tasks found</p>}
+            {isLoaded && user && !loading && tasks.length === 0 && <p>No tasks found</p>}
 
-            {user && (
+            {isLoaded && user && (
               <form onSubmit={createTask}>
                 <input
                   autoFocus

--- a/docs/guides/development/integrations/databases/supabase.mdx
+++ b/docs/guides/development/integrations/databases/supabase.mdx
@@ -46,7 +46,7 @@ This guide will have you create a new table in your [Supabase project](https://s
   1. In the Clerk Dashboard, navigate to the [Supabase integration setup](https://dashboard.clerk.com/setup/supabase).
   1. Choose your configuration options, and then select **Activate Supabase integration**. This will reveal the **Clerk domain** for your Clerk instance.
   1. Save the **Clerk domain**.
-  1. In the Supabase Dashboard, navigate to [**Authentication > Sign In / Up**](https://supabase.com/dashboard/project/_/auth/third-party).
+  1. In the Supabase Dashboard, navigate to [**Authentication > Sign In / Providers**](https://supabase.com/dashboard/project/_/auth/third-party).
   1. Select **Add provider** and select **Clerk** from the list of providers.
   1. Paste the **Clerk domain** you copied from the Clerk Dashboard.
 
@@ -97,8 +97,9 @@ This guide will have you create a new table in your [Supabase project](https://s
   ## Set up your environment variables
 
   1. In the Supabase dashboard, navigate to [**Project Settings > Data API**](https://supabase.com/dashboard/project/_/settings/api).
-  1. Add the **Project URL** to your `.env` file as `SUPABASE_URL`.
-  1. In the **Project API keys** section, copy the **Publishable key** (formerly the `anon` `public` key) and add it to your `.env` file as `SUPABASE_KEY`.
+  1. Copy the **API URL** and add it to your `.env` file as `SUPABASE_URL`. Ensure that you remove the trailing `/rest/v1` if it's included in the URL. **Only use the base project URL (e.g., [https://your-project-ref.supabase.co](https://your-project-ref.supabase.co)).**
+  1. Navigate to [**Project Settings > API Keys**](https://supabase.com/dashboard/project/_/settings/api-keys).
+  1. In the **Publishable and secret API keys** section, copy the **Publishable key** (formerly the `anon` `public` key) and add it to your `.env` file as `SUPABASE_KEY`.
 
   <If sdk="nextjs">
     > [!IMPORTANT]
@@ -107,7 +108,7 @@ This guide will have you create a new table in your [Supabase project](https://s
 
   ## Fetch Supabase data in your code
 
-  In your app's `page.tsx`, paste the following code. This example shows the list of tasks for the user and allows the user to add new tasks. The `createClerkSupabaseClient()` function uses [Supabase's `createClient()` method](https://supabase.com/docs/reference/objects/initializing) to initialize a new Supabase client with access to Clerk's session token.
+  In your app's `page.tsx`, paste the following code. This example shows the list of tasks for the user and allows the user to add new tasks. The `createClerkSupabaseClient()` function uses [Supabase's `createClient()` method](https://supabase.com/docs/reference/javascript/initializing) to initialize a new Supabase client with access to Clerk's session token.
 
   <Tabs items={["Client-side rendering", "Server-side rendering"]}>
     <Tab>
@@ -142,16 +143,19 @@ This guide will have you create a new table in your [Supabase project](https://s
           )
         }
 
-        // Create a `client` object for accessing Supabase data using the Clerk token
-        const client = createClerkSupabaseClient()
-
         // This `useEffect` will wait for the User object to be loaded before requesting
         // the tasks for the signed in user
         useEffect(() => {
-          if (!user) return
+          if (!user) {
+            setTasks([])
+            setName('')
+            setLoading(false)
+            return
+          }
 
           async function loadTasks() {
             setLoading(true)
+            const client = createClerkSupabaseClient()
             const { data, error } = await client.from('tasks').select()
             if (!error) setTasks(data)
             setLoading(false)
@@ -162,11 +166,22 @@ This guide will have you create a new table in your [Supabase project](https://s
 
         async function createTask(e: React.FormEvent<HTMLFormElement>) {
           e.preventDefault()
-          // Insert task into the "tasks" database
-          await client.from('tasks').insert({
-            name,
-          })
-          window.location.reload()
+          const trimmedName = name.trim()
+          if (!trimmedName) return
+
+          const client = createClerkSupabaseClient()
+          const { data, error } = await client
+            .from('tasks')
+            .insert({
+              name: trimmedName,
+            })
+            .select()
+            .single()
+
+          if (!error && data) {
+            setTasks((currentTasks) => [...currentTasks, data])
+            setName('')
+          }
         }
 
         return (
@@ -175,21 +190,28 @@ This guide will have you create a new table in your [Supabase project](https://s
 
             {loading && <p>Loading...</p>}
 
-            {!loading && tasks.length > 0 && tasks.map((task: any) => <p key={task.id}>{task.name}</p>)}
+            {!user && !loading && <p>Sign in to view your tasks.</p>}
 
-            {!loading && tasks.length === 0 && <p>No tasks found</p>}
+            {user &&
+              !loading &&
+              tasks.length > 0 &&
+              tasks.map((task: any) => <p key={task.id}>{task.name}</p>)}
 
-            <form onSubmit={createTask}>
-              <input
-                autoFocus
-                type="text"
-                name="name"
-                placeholder="Enter new task"
-                onChange={(e) => setName(e.target.value)}
-                value={name}
-              />
-              <button type="submit">Add</button>
-            </form>
+            {user && !loading && tasks.length === 0 && <p>No tasks found</p>}
+
+            {user && (
+              <form onSubmit={createTask}>
+                <input
+                  autoFocus
+                  type="text"
+                  name="name"
+                  placeholder="Enter new task"
+                  onChange={(e) => setName(e.target.value)}
+                  value={name}
+                />
+                <button type="submit">Add</button>
+              </form>
+            )}
           </div>
         )
       }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-supabase-integration-guide-improvements/guides/development/integrations/databases/supabase

### What does this solve? What changed?

Dived into this [Linear ticket](https://linear.app/clerk/issue/DOCS-11472/investigate-if-supabase-guide-is-working) and investigated whether or not the Supabase setup worked. After testing the flow, I noticed a few discrepancies that are fixed in this PR. 

**What changed**

- Updated the Supabase navigation path in the setup steps.
- Clarified that `SUPABASE_URL` should use the base project URL.
- Improved the client-side example by:
    - replacing `window.location.reload()` with local state updates
    - trimming task names before insert
    - returning the inserted row with `.select().single()`
    - handling signed-out state more cleanly
    - using `isLoaded` to avoid treating auth-loading as signed-out

In terms of the code changes, the previous example worked, but it was a bit rough around the edges and could briefly show signed-out UI before Clerk had finished loading auth state.


In terms of the code changes, the previous example worked, but it was a bit rough around the edges from both a UX and implementation perspective. It relied on `window.location.reload()` after creating a task instead of updating local state, didn’t guard against whitespace-only input, and treated a falsy user as immediately signed out even while Clerk might still be resolving auth state. 

### Deadline

No rush. 

### Other resources

[Linear](https://linear.app/clerk/issue/DOCS-11472/investigate-if-supabase-guide-is-working)
