### PR TITLE
Document Account Portal fallback behavior for SignInButton/SignUpButton mode prop

### DIFF
--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -305,7 +305,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   > Both `mode` values can silently fall back to the [Account Portal](/docs/guides/account-portal/overview) when `<ClerkProvider>` is missing the `signInUrl` and/or `signUpUrl` props (or the equivalent [environment variables](/docs/guides/development/clerk-environment-variables#sign-in-and-sign-up-redirects)):
   >
   > - `mode="redirect"` navigates the user to `signInUrl`. If `signInUrl` is not configured, Clerk redirects to the Account Portal sign-in page instead.
-  > - `mode="modal"` opens the sign-in modal in your app, but if a user starts an SSO/OAuth flow and needs to be transferred to sign-up (for example, a new user, or `withSignUp` is `true`), Clerk navigates to `signUpUrl`. If `signUpUrl` is not configured, the user is redirected to the Account Portal sign-up page mid-flow.
+  > - `mode="modal"` opens the sign-in modal in your app, but if a user starts an SSO/OAuth flow and needs to be transferred to sign-up (for example, a new user, or [`withSignUp`](/docs/reference/components/authentication/sign-in#properties) is `true`), Clerk navigates to `signUpUrl`. If `signUpUrl` is not configured, the user is redirected to the Account Portal sign-up page mid-flow.
   >
   > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal) and these URLs are not configured on `<ClerkProvider>`, the fallback target returns a 404 and the authentication flow breaks. Always set `signInUrl` and `signUpUrl` (or use a [dedicated sign-in page](/docs/guides/development/custom-sign-in-or-up-page)) when the Account Portal is disabled.
 

--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -301,6 +301,14 @@ You can create a custom button by wrapping your own button, or button text, in t
 
   Determines what happens when a user clicks on the `<SignInButton>`. Setting this to `'redirect'` will redirect the user to the sign-in route. Setting this to `'modal'` will open a modal on the current route. Defaults to `'redirect'`.
 
+  > [!WARNING]
+  > Both `mode` values can silently fall back to the [Account Portal](/docs/guides/account-portal/overview) when `<ClerkProvider>` is missing the `signInUrl` and/or `signUpUrl` props (or the equivalent [environment variables](/docs/guides/development/clerk-environment-variables#sign-in-and-sign-up-redirects)):
+  >
+  > - `mode="redirect"` navigates the user to `signInUrl`. If `signInUrl` is not configured, Clerk redirects to the Account Portal sign-in page instead.
+  > - `mode="modal"` opens the sign-in modal in your app, but if a user starts an SSO/OAuth flow and needs to be transferred to sign-up (for example, a new user, or `withSignUp` is `true`), Clerk navigates to `signUpUrl`. If `signUpUrl` is not configured, the user is redirected to the Account Portal sign-up page mid-flow.
+  >
+  > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal) and these URLs are not configured on `<ClerkProvider>`, the fallback target returns a 404 and the authentication flow breaks. Always set `signInUrl` and `signUpUrl` (or use a [dedicated sign-in page](/docs/guides/development/custom-sign-in-or-up-page)) when the Account Portal is disabled.
+
   ---
 
   - `children?`

--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -305,9 +305,9 @@ You can create a custom button by wrapping your own button, or button text, in t
   > Both `mode` values can silently fall back to the [Account Portal](/docs/guides/account-portal/overview) when `<ClerkProvider>` is missing the `signInUrl` and/or `signUpUrl` props (or the equivalent [environment variables](/docs/guides/development/clerk-environment-variables#sign-in-and-sign-up-redirects)):
   >
   > - `mode="redirect"` navigates the user to `signInUrl`. If `signInUrl` is not configured, Clerk redirects to the Account Portal sign-in page instead.
-  > - `mode="modal"` opens the sign-in modal in your app, but if a user starts an SSO/OAuth flow and needs to be transferred to sign-up (for example, a new user, or [`withSignUp`](/docs/reference/components/authentication/sign-in#properties) is `true`), Clerk navigates to `signUpUrl`. If `signUpUrl` is not configured, the user is redirected to the Account Portal sign-up page mid-flow.
+  > - `mode="modal"` opens the sign-in modal in your app, but if a user starts an SSO/OAuth flow and needs to be transferred to sign-up (for example, a new user, or [`withSignUp`](/docs/reference/components/authentication/sign-in#properties) is `true`), Clerk navigates to `signUpUrl`. If `signUpUrl` is not configured but `signInUrl` is set to a relative path (combined sign-in-or-up flow), the transfer resolves to `signInUrl#/create` instead. If neither is configured, the user is redirected to the Account Portal sign-up page mid-flow.
   >
-  > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal) and these URLs are not configured on `<ClerkProvider>`, the fallback target returns a 404 and the authentication flow breaks. Always set `signInUrl` and `signUpUrl` (or use a [dedicated sign-in page](/docs/guides/development/custom-sign-in-or-up-page)) when the Account Portal is disabled.
+  > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal), either set both `signInUrl` and `signUpUrl` on `<ClerkProvider>`, or use a [combined sign-in-or-up page](/docs/guides/development/custom-sign-in-or-up-page) (set `signInUrl` to a relative path and leave `signUpUrl` unset). Otherwise the fallback target returns a 404 and the authentication flow breaks.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-up-button.mdx
+++ b/docs/reference/components/unstyled/sign-up-button.mdx
@@ -299,7 +299,15 @@ You can create a custom button by wrapping your own button, or button text, in t
   - `mode?`
   - `'redirect' | 'modal'`
 
-  Determines what happens when a user clicks on the `<SignUpButton>`. Setting this to `'redirect'` will redirect the user to the sign-up route. Setting this to `'modal'` will open a modal on the current route. Defaults to `'redirect'`
+  Determines what happens when a user clicks on the `<SignUpButton>`. Setting this to `'redirect'` will redirect the user to the sign-up route. Setting this to `'modal'` will open a modal on the current route. Defaults to `'redirect'`.
+
+  > [!WARNING]
+  > Both `mode` values can silently fall back to the [Account Portal](/docs/guides/account-portal/overview) when `<ClerkProvider>` is missing the `signUpUrl` and/or `signInUrl` props (or the equivalent [environment variables](/docs/guides/development/clerk-environment-variables#sign-in-and-sign-up-redirects)):
+  >
+  > - `mode="redirect"` navigates the user to `signUpUrl`. If `signUpUrl` is not configured, Clerk redirects to the Account Portal sign-up page instead.
+  > - `mode="modal"` opens the sign-up modal in your app, but if a user starts an SSO/OAuth flow and the identity already exists (so the user must be transferred to sign-in), Clerk navigates to `signInUrl`. If `signInUrl` is not configured, the user is redirected to the Account Portal sign-in page mid-flow.
+  >
+  > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal) and these URLs are not configured on `<ClerkProvider>`, the fallback target returns a 404 and the authentication flow breaks. Always set `signUpUrl` and `signInUrl` (or use a [dedicated sign-up page](/docs/guides/development/custom-sign-in-or-up-page)) when the Account Portal is disabled.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-up-button.mdx
+++ b/docs/reference/components/unstyled/sign-up-button.mdx
@@ -304,10 +304,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   > [!WARNING]
   > Both `mode` values can silently fall back to the [Account Portal](/docs/guides/account-portal/overview) when `<ClerkProvider>` is missing the `signUpUrl` and/or `signInUrl` props (or the equivalent [environment variables](/docs/guides/development/clerk-environment-variables#sign-in-and-sign-up-redirects)):
   >
-  > - `mode="redirect"` navigates the user to `signUpUrl`. If `signUpUrl` is not configured, Clerk redirects to the Account Portal sign-up page instead.
+  > - `mode="redirect"` navigates the user to `signUpUrl`. If `signUpUrl` is not configured but `signInUrl` is set to a relative path, Clerk treats your app as a [combined sign-in-or-up page](/docs/guides/development/custom-sign-in-or-up-page) and navigates to `signInUrl#/create`. If neither is configured, Clerk redirects to the Account Portal sign-up page instead.
   > - `mode="modal"` opens the sign-up modal in your app, but if a user starts an SSO/OAuth flow and the identity already exists (so the user must be transferred to sign-in), Clerk navigates to `signInUrl`. If `signInUrl` is not configured, the user is redirected to the Account Portal sign-in page mid-flow.
   >
-  > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal) and these URLs are not configured on `<ClerkProvider>`, the fallback target returns a 404 and the authentication flow breaks. Always set `signUpUrl` and `signInUrl` (or use a [dedicated sign-up page](/docs/guides/development/custom-sign-in-or-up-page)) when the Account Portal is disabled.
+  > If the [Account Portal is disabled](/docs/guides/account-portal/disable-account-portal), either set both `signInUrl` and `signUpUrl` on `<ClerkProvider>`, or use a [combined sign-in-or-up page](/docs/guides/development/custom-sign-in-or-up-page) (set `signInUrl` to a relative path and leave `signUpUrl` unset). Otherwise the fallback target returns a 404 and the authentication flow breaks.
 
   ---
 


### PR DESCRIPTION
See
- https://clerk.com/docs/pr/cursor-sign-up-in-mode-prop-docs/react/reference/components/unstyled/sign-in-button#properties
- https://clerk.com/docs/pr/cursor-sign-up-in-mode-prop-docs/react/reference/components/unstyled/sign-up-button#properties

## Summary

Adds a `> [!WARNING]` callout to the `mode` prop documentation for `<SignInButton>` and `<SignUpButton>` (the unstyled components) explaining how each mode silently falls back to the Account Portal when `<ClerkProvider>` is missing `signInUrl`/`signUpUrl`, and that the flow breaks entirely if the Account Portal is disabled. The callout also documents the **combined sign-in-or-up** path: when `signUpUrl` is unset and `signInUrl` is a relative path, Clerk routes to `signInUrl#/create` instead of falling through to the Account Portal.

The behavior was verified against the source in `clerk/javascript`:

- `mode="redirect"` calls `clerk.redirectToSignIn`/`redirectToSignUp`, which resolves the target via `options.signInUrl || displayConfig.signInUrl` (and same for sign-up). `displayConfig.signInUrl`/`signUpUrl` come from FAPI and default to the Account Portal URL.
- The combined sign-in-or-up flow is detected by `#isCombinedSignInOrUpFlow` at [packages/clerk-js/src/core/clerk.ts:597](https://github.com/clerk/javascript/blob/main/packages/clerk-js/src/core/clerk.ts#L597), with use sites at [L3392](https://github.com/clerk/javascript/blob/main/packages/clerk-js/src/core/clerk.ts#L3392) and [L3401](https://github.com/clerk/javascript/blob/main/packages/clerk-js/src/core/clerk.ts#L3401) — when active, the sign-up target becomes `signInUrl` with `hashPath: '/create'`.
- `mode="modal"` opens an in-app modal, but the SSO callback path (`_handleRedirectCallback`) and the modal context (`useSignInContext`/`useSignUpContext`) resolve the cross-flow URL the same way: `params.signUpUrl || displayConfig.signUpUrl` (and the inverse for sign-up), with the same combined-flow override mirrored in [packages/ui/src/contexts/components/SignIn.ts:122-126](https://github.com/clerk/javascript/blob/main/packages/ui/src/contexts/components/SignIn.ts#L122-L126) and [SignUp.ts:49-54](https://github.com/clerk/javascript/blob/main/packages/ui/src/contexts/components/SignUp.ts#L49-L54). So a new user starting an OAuth flow in `<SignInButton mode="modal">` gets bounced to the Account Portal sign-up URL when `signUpUrl` isn't configured (and likewise for `<SignUpButton mode="modal">` → `signInUrl` when the user already exists), unless the combined flow applies.
- When the Account Portal is disabled (`HasDisabledAccounts` on the domain), the FAPI auth middleware blocks requests to that subdomain, so the silent fallback returns a 404 and breaks the auth flow.

## Files changed

- `docs/reference/components/unstyled/sign-in-button.mdx`
- `docs/reference/components/unstyled/sign-up-button.mdx`

## Test plan

- [ ] Render the updated MDX locally and confirm the `> [!WARNING]` callout appears in the right place under the `mode` prop entry for both components.
- [ ] Confirm all internal links resolve: `/docs/guides/account-portal/overview`, `/docs/guides/account-portal/disable-account-portal`, `/docs/guides/development/clerk-environment-variables#sign-in-and-sign-up-redirects`, `/docs/guides/development/custom-sign-in-or-up-page`.


Made with [Cursor](https://cursor.com)