### PR TITLE
Remove outdated Expo passkey limitation note

### DIFF
--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -86,7 +86,6 @@ A passkey is a type of sign-in credential that requires one user action, but use
 
 - Passkeys are not currently available as an [MFA](#multi-factor-authentication) option.
 - Not all devices and browsers are compatible with passkeys. Passkeys are built on WebAuthn technology and you should check [the Browser Compatibility docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API#browser_compatibility) for an up-to-date list.
-- Passkey related APIs will not work with Expo.
 - Your users can have a max of 10 passkeys per account.
 
 #### Domain restrictions for passkeys


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- `/docs/guides/configure/auth-strategies/sign-up-sign-in-options#passkeys`

### What does this solve? What changed?

The passkey section in `sign-up-sign-in-options.mdx` listed "Passkey related APIs will not work with Expo." as a limitation, but the same page (and a dedicated guide at `/docs/reference/expo/passkeys`) documents how to set up passkeys in Expo via `@clerk/clerk-expo >=2.2.0` / `@clerk/expo`. A user flagged the contradiction.

The `@clerk/expo` package re-exports `passkeys` from `@clerk/expo-passkeys` (see `packages/expo/src/passkeys/index.ts` in `clerk/javascript`), so the limitation note is stale.

- Removed the "Passkey related APIs will not work with Expo." bullet from the Passkey limitations list.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush, but it's a user-reported contradiction so sooner is better.

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

- Related: [Expo passkeys guide](/docs/reference/expo/passkeys)