### PR TITLE
Update brew install command to use clerk/stable/clerk tap

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -27,7 +27,7 @@ Install the CLI globally, or run it directly without installing using `npx clerk
   ```
 
   ```bash {{ filename: 'terminal', prompt: '$' }}
-  brew install clerk
+  brew install clerk/stable/clerk
   ```
 
   ```bash {{ filename: 'terminal', prompt: '$' }}


### PR DESCRIPTION
## Summary
- Update `brew install clerk` to `brew install clerk/stable/clerk` in the CLI install instructions

## Test plan
- [ ] Verify the updated command in `docs/cli.mdx` renders correctly