### PR TITLE
Fix prettier formatting in webhooks debugging page

### DIFF
--- a/docs/guides/development/webhooks/debugging.mdx
+++ b/docs/guides/development/webhooks/debugging.mdx
@@ -12,7 +12,7 @@ When you or a user of your application performs certain actions, a webhook can b
 Your localhost isn't reachable from the internet, so your app can't receive webhook requests directly. You have two options:
 
 - Expose your computer's local server using a **tunneling tool**, such as [ngrok](https://ngrok.com/docs/integrations/webhooks/clerk-webhooks), [localtunnel](https://github.com/localtunnel/localtunnel), [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), or [Pinggy](https://pinggy.io/).
-![Using webhooks in development](/docs/images/integrations/webhooks/webhooks_diagram.png)
+  ![Using webhooks in development](/docs/images/integrations/webhooks/webhooks_diagram.png)
 - Use a **hosted inspection service** like [Beeceptor](https://beeceptor.com/webhook-integration/), which captures requests at a public endpoint and displays them in a web UI, with optional forwarding to your local app.
 
 Debugging webhook-related issues can be tricky, so the following sections address common issues and how to resolve them.


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/guides/development/webhooks/debugging

### What does this solve? What changed?

#3297 didn't run tests/lints until after merge — a delay because an external contributor. Formatting was not correct.

Ran `pnpm lint` and fixed the one Prettier formatting error it surfaced — a nested image line under a bullet in `docs/guides/development/webhooks/debugging.mdx` was missing its two-space indent, which broke the list nesting.

- Re-indented the `![Using webhooks in development]` image so it renders as part of the tunneling-tool bullet.

### Deadline

- Sooner rather than later. The lint error will trigger on all PRs.