### PR TITLE
Add CLI to iOS and Android sidebars

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -36,13 +36,6 @@ Install the CLI globally, or run it directly without installing using `npx clerk
 </CodeBlockTabs>
 
 <If
-  notSdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
->
-  > [!NOTE]
-  > `clerk init` doesn't currently support scaffolding for this SDK. You can still use the CLI for app and environment management.
-</If>
-
-<If
   sdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
 >
   ## Get started
@@ -59,6 +52,13 @@ Install the CLI globally, or run it directly without installing using `npx clerk
 </If>
 
 ## What you can do
+
+<If
+  notSdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
+>
+  > [!NOTE]
+  > `clerk init` doesn't currently support scaffolding for this SDK. You can still use the CLI for app and environment management.
+</If>
 
 - **Set up authentication** — `clerk init` detects your framework, installs the SDK, and scaffolds your project with Clerk's authentication setup.
 - **Manage environment variables** — `clerk env pull` pulls your Clerk API keys into your project's env file.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -5,9 +5,11 @@ description: Learn how to use the Clerk CLI to set up authentication, manage con
 
 The Clerk CLI is a command-line tool for you and your agents to set up and manage [Clerk](https://clerk.com) authentication directly from the terminal. It supports 10+ frameworks.
 
-<If sdk={["ios", "android"]}>
+<If
+  notSdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
+>
   > [!NOTE]
-  > `clerk init` doesn't yet scaffold native mobile projects. Mobile developers can still use the CLI for app and environment management.
+  > `clerk init` doesn't currently support scaffolding for this SDK. You can still use the CLI for app and environment management.
 </If>
 
 ## Installation

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -5,13 +5,6 @@ description: Learn how to use the Clerk CLI to set up authentication, manage con
 
 The Clerk CLI is a command-line tool for you and your agents to set up and manage [Clerk](https://clerk.com) authentication directly from the terminal. It supports 10+ frameworks.
 
-<If
-  notSdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
->
-  > [!NOTE]
-  > `clerk init` doesn't currently support scaffolding for this SDK. You can still use the CLI for app and environment management.
-</If>
-
 ## Installation
 
 Install the CLI globally, or run it directly without installing using `npx clerk` or `bunx clerk`.
@@ -42,17 +35,28 @@ Install the CLI globally, or run it directly without installing using `npx clerk
   ```
 </CodeBlockTabs>
 
-## Get started
+<If
+  notSdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
+>
+  > [!NOTE]
+  > `clerk init` doesn't currently support scaffolding for this SDK. You can still use the CLI for app and environment management.
+</If>
 
-Run `clerk init` in your project directory to get started:
+<If
+  sdk={["nextjs", "react", "react-router", "tanstack-react-start", "astro", "vue", "js-frontend", "expo", "nuxt", "expressjs", "fastify"]}
+>
+  ## Get started
 
-```bash {{ filename: 'terminal', prompt: '$' }}
-clerk init
-```
+  Run `clerk init` in your project directory to get started:
 
-This command auto-detects your framework, installs the appropriate Clerk SDK, and applies framework-specific setup such as auth pages, middleware, and providers. If you're authenticated with `clerk auth login`, it also links your project to a Clerk application and pulls your environment variables automatically.
+  ```bash {{ filename: 'terminal', prompt: '$' }}
+  clerk init
+  ```
 
-You can also use `clerk init --starter` to bootstrap a brand new project from a starter template, or run `clerk init` without an account to get started immediately with temporary development keys.
+  This command auto-detects your framework, installs the appropriate Clerk SDK, and applies framework-specific setup such as auth pages, middleware, and providers. If you're authenticated with `clerk auth login`, it also links your project to a Clerk application and pulls your environment variables automatically.
+
+  You can also use `clerk init --starter` to bootstrap a brand new project from a starter template, or run `clerk init` without an account to get started immediately with temporary development keys.
+</If>
 
 ## What you can do
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -5,6 +5,11 @@ description: Learn how to use the Clerk CLI to set up authentication, manage con
 
 The Clerk CLI is a command-line tool for you and your agents to set up and manage [Clerk](https://clerk.com) authentication directly from the terminal. It supports 10+ frameworks.
 
+<If sdk={["ios", "android"]}>
+  > [!NOTE]
+  > `clerk init` doesn't yet scaffold native mobile projects. Mobile developers can still use the CLI for app and environment management.
+</If>
+
 ## Installation
 
 Install the CLI globally, or run it directly without installing using `npx clerk` or `bunx clerk`.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3829,6 +3829,10 @@
               "href": "/docs/reference/native-mobile/configuration"
             },
             {
+              "title": "CLI",
+              "href": "/docs/cli"
+            },
+            {
               "title": "Clerk",
               "href": "/docs/reference/native-mobile/clerk"
             },


### PR DESCRIPTION
### 🔎 Previews:

#### Testing mobile

- Visit https://clerk.com/docs/pr/manovotny-earthy-libra
- Make sure you have **iOS** or **Android** SDK selected
- Notice **CLI** under the **Getting started** section in the sidebar or visit the page directly → https://clerk.com/docs/pr/manovotny-earthy-libra/cli
- Notice the **Getting started** section ***does not*** appear on the page, but a `[!NOTE]` displays instead.

#### Testing supported frameworks

- Visit https://clerk.com/docs/pr/manovotny-earthy-libra
- Make sure you have a support CLI framework selected, ie. **Next.js**
- Visit the page directly → https://clerk.com/docs/pr/manovotny-earthy-libra/cli
- Notice the **Getting started** section appears on the page

### What does this solve? What changed?

The Clerk CLI was launched in #3288, but it was only added to the web SDK sidebar. iOS and Android developers couldn't discover it from the Mobile Navigation, and there was no in-page signal to readers on SDKs that the CLI doesn't fully scaffold.

- Adds a `CLI` entry to the Mobile Navigation sidebar (iOS/Android) under Getting started, between `Configure the SDK` and `Clerk`.
- In `docs/cli.mdx`, adds a scoped `<If notSdk={[...]}>` note that appears on any SDK not supported by `clerk init` (iOS, Android, Chrome Extension, Ruby, Go). The note clarifies that `clerk init` doesn't currently scaffold for that SDK, but the CLI can still be used for app and environment management. Using `notSdk` against the CLI's supported framework list keeps the source of truth aligned with the CLI repo and future-proofs the note against new SDKs.
- Wraps the `## Get started` section in `<If sdk={[...]}>` so `clerk init` scaffolding instructions only render on supported SDKs. Readers on unsupported SDKs see the note and skip straight to `## What you can do`, avoiding dead-end instructions.
- Places the `<If>` note below Installation (which is framework-agnostic) so it sits adjacent to the section it caveats.

### Deadline

- No rush.

### Other resources

- Follow-up to #3288
