### PR TITLE
Fix Account Portal direct links redirect docs

### DIFF
--- a/docs/guides/account-portal/direct-links.mdx
+++ b/docs/guides/account-portal/direct-links.mdx
@@ -5,7 +5,7 @@ description: Learn how to share direct links to your Account Portal pages, and h
 
 ## Redirect URL
 
-If a user accesses an Account Portal page _directly_, the `redirect_url` query param will not be present, so the user cannot be redirected back to your application once they are finished with their Account Portal flow. To prevent this, it is recommend that you always specify the redirect in the link when sharing it.
+When a user accesses an Account Portal page directly, there is no `redirect_url` query param present, so Clerk has no way to redirect the user back to your application after their flow is complete. To ensure users are redirected back, include the `redirect_url` query param in any direct links you share.
 
 You can use the following format for your direct links:
 
@@ -15,25 +15,16 @@ You can use the following format for your direct links:
 
 `https://accounts.myapp.com/sign-in?redirect_url=https://myapp.com/dashboard`
 
-The domain is `myapp.com`, the user is being linked to the sign-in Account Portal page at `http://accounts.myapp.com/sign-in` and they will be redirected to `https://myapp.com/dashboard` after they are signed in.
+The domain is `myapp.com`, the user is being linked to the sign-in Account Portal page at `https://accounts.myapp.com/sign-in` and they will be redirected to `https://myapp.com/dashboard` after they are signed in.
+
+> [!NOTE]
+> The `redirect_url` value must be a URL on your instance's domain or one of its subdomains. In development, `localhost` URLs are also allowed.
 
 ## Fallback redirects
 
-In the case that a user _does_ visit an Account Portal page directly without the query param, you can set up fallback redirects to ensure that the user is redirected back to your application after they are finished with their Account Portal flow.
+If a user visits an Account Portal page directly without a `redirect_url` query param, you can configure a fallback redirect so they are still sent to the right place after completing their flow.
 
-### Sign-in and sign-up
-
-Set the appropriate [environment variables](/docs/guides/development/clerk-environment-variables#api-and-sdk-configuration) to configure the fallback redirects for sign-in and sign-up.
-
-### Sign out
-
-Set the post-sign-out redirect by passing the `afterSignOutUrl` prop to the `<ClerkProvider>` component. See the [reference doc](/docs/reference/components/clerk-provider) for more information.
-
-### Organization redirects
-
-Both the `<OrganizationProfile />` and `<OrganizationSwitcher />` components accept an `afterLeaveOrganizationUrl` prop for setting the redirect after leaving an organization.
-
-The `<OrganizationSwitcher />` component accepts an `afterSelectOrganizationUrl` prop for setting the redirect after selecting an organization, and an `afterCreateOrganizationUrl` prop for setting the redirect after creating an organization.
+In the Clerk Dashboard, navigate to the [**Account Portal**](https://dashboard.clerk.com/~/account-portal) page and select the **Redirects** tab to set the fallback redirect URLs for sign-in, sign-up, and other Account Portal flows.
 
 ## Prefill sign in and sign up fields
 

--- a/docs/guides/account-portal/direct-links.mdx
+++ b/docs/guides/account-portal/direct-links.mdx
@@ -5,7 +5,7 @@ description: Learn how to share direct links to your Account Portal pages, and h
 
 ## Redirect URL
 
-When a user accesses an Account Portal page directly, there is no `redirect_url` query param present, so Clerk has no way to redirect the user back to your application after their flow is complete. To ensure users are redirected back, include the `redirect_url` query param in any direct links you share.
+If a user accesses an Account Portal page _directly_, the `redirect_url` query param will not be present, so the user cannot be redirected back to your application once they are finished with their Account Portal flow. To prevent this, it is recommend that you always specify the redirect in the link when sharing it.
 
 You can use the following format for your direct links:
 

--- a/docs/guides/account-portal/direct-links.mdx
+++ b/docs/guides/account-portal/direct-links.mdx
@@ -5,7 +5,7 @@ description: Learn how to share direct links to your Account Portal pages, and h
 
 ## Redirect URL
 
-If a user accesses an Account Portal page _directly_, the `redirect_url` query param will not be present, so the user cannot be redirected back to your application once they are finished with their Account Portal flow. To prevent this, it is recommend that you always specify the redirect in the link when sharing it.
+If a user accesses an Account Portal page _directly_, the `redirect_url` query param will not be present, so the user cannot be redirected back to your application once they are finished with their Account Portal flow. To prevent this, it is recommended that you always specify the redirect in the link when sharing it.
 
 You can use the following format for your direct links:
 
@@ -18,13 +18,15 @@ You can use the following format for your direct links:
 The domain is `myapp.com`, the user is being linked to the sign-in Account Portal page at `https://accounts.myapp.com/sign-in` and they will be redirected to `https://myapp.com/dashboard` after they are signed in.
 
 > [!NOTE]
-> The `redirect_url` value must be a URL on your instance's domain or one of its subdomains. In development, `localhost` URLs are also allowed.
+> The `redirect_url` value must be a URL on your instance's domain or one of its subdomains, or share the same origin as the requesting page (which is why `localhost` works in development).
 
 ## Fallback redirects
 
-If a user visits an Account Portal page directly without a `redirect_url` query param, you can configure a fallback redirect so they are still sent to the right place after completing their flow.
+If a user visits an Account Portal page directly without a `redirect_url` query param, you can configure a fallback redirect so they're still sent to the right place after they complete their flow.
 
-In the Clerk Dashboard, navigate to the [**Account Portal**](https://dashboard.clerk.com/~/account-portal?tab=redirects) page and select the **Redirects** tab to set the fallback redirect URLs for sign-in, sign-up, and other Account Portal flows.
+In the Clerk Dashboard, navigate to the [**Account Portal**](https://dashboard.clerk.com/~/account-portal?tab=redirects) page and open the **Redirects** tab to set the fallback redirect URLs for sign-in, sign-up, and other Account Portal flows.
+
+If you use self-hosted Clerk components instead of the Account Portal, see [Customize your redirect URLs](/docs/guides/development/customize-redirect-urls) to configure redirects with environment variables or component props.
 
 ## Prefill sign in and sign up fields
 

--- a/docs/guides/account-portal/direct-links.mdx
+++ b/docs/guides/account-portal/direct-links.mdx
@@ -24,7 +24,7 @@ The domain is `myapp.com`, the user is being linked to the sign-in Account Porta
 
 If a user visits an Account Portal page directly without a `redirect_url` query param, you can configure a fallback redirect so they are still sent to the right place after completing their flow.
 
-In the Clerk Dashboard, navigate to the [**Account Portal**](https://dashboard.clerk.com/~/account-portal) page and select the **Redirects** tab to set the fallback redirect URLs for sign-in, sign-up, and other Account Portal flows.
+In the Clerk Dashboard, navigate to the [**Account Portal**](https://dashboard.clerk.com/~/account-portal?tab=redirects) page and select the **Redirects** tab to set the fallback redirect URLs for sign-in, sign-up, and other Account Portal flows.
 
 ## Prefill sign in and sign up fields
 


### PR DESCRIPTION
### 🔎 Previews:
- https://clerk.com/docs/pr/folke-fix-account-portal-direct-links/guides/account-portal/direct-links

### What does this solve? What changed?

- Updates the Account Portal direct links guide so fallback redirect configuration points users to the Clerk Dashboard instead of SDK/component props.
- Previously, the fallback redirects section told users to configure sign-in/sign-up redirects with environment variables and sign-out/organization redirects through component props like `<ClerkProvider>`, `<OrganizationProfile />`, and `<OrganizationSwitcher />`. That guidance does not match where Account Portal fallback redirects are configured.
- The updated docs now direct users to the **Account Portal** page in the Clerk Dashboard and the **Redirects** tab, where fallback redirect URLs for sign-in, sign-up, and other Account Portal flows can be managed.
- Adds a note clarifying that `redirect_url` must use the instance domain or one of its subdomains, with `localhost` allowed in development.
- Fixes the example explanation to use `https://accounts.myapp.com/sign-in` instead of `http://accounts.myapp.com/sign-in`.

### Deadline
- No rush

### Other resources
- https://clerkinc.slack.com/archives/C01QFRQNHSN/p1776762949745409
