### PR TITLE
Add redirect for /docs/expo (top 5 docs 404s)

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4406,5 +4406,9 @@
   {
     "source": "/docs/reference/react/use-auth",
     "destination": "/docs/reference/hooks/use-auth"
+  },
+  {
+    "source": "/docs/expo",
+    "destination": "/docs/expo/getting-started/quickstart"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-mature-twin/expo

### What does this solve? What changed?

Investigated the top 5 docs 404s from the last 7 days and added a redirect for the 1 that warranted action.

#### Investigation methodology

- Searched the full Clerk GitHub org via `gh search code` for each URL to check for broken internal links
- Cross-referenced each URL against existing redirects in `redirects/static/docs.json` and `redirects/dynamic/docs.jsonc`
- Checked the actual file structure to identify correct current URLs
- Validated with `lint:check-duplicate-redirects` — all checks pass

#### Analysis of all 5 URLs

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/guides/development/testin` | **Truncated URL** — Final `g` is missing. No clerk-org references match this exact path. Almost certainly a tool/AI truncation artifact, not a near-miss worth handling. | Skipped |
| 2 | `/docs/android/guides/development/deployment/production` | **AI-fabricated** — The deployment/production guide is global (`/docs/guides/development/deployment/production`), not SDK-scoped. The SDK-prefixed variants for the old native-mobile path are already covered (lines 4395–4404 in `docs.json` cover `/docs/{ios,android}/reference/native-mobile/production`). No clerk-org references. | Skipped |
| 3 | `/docs/authentication/mfa` | **AI-fabricated** — Already analyzed in [#3307](https://github.com/clerk/clerk-docs/pull/3307). Never a real path; the historical `/docs/authentication/multi-factor-authentication` and `/docs/authentication/multi-factor` are already redirected. | Skipped |
| 4 | `/docs/expo` | **Legit near-miss** — Structural gap: `/docs/nextjs` redirects to `/docs/nextjs/getting-started/quickstart`, but the equivalent bare `/docs/expo` had no redirect. Many clerk-org references (skills, evals, dashboard, CLI) link to `/docs/expo/...`. | ✅ Added redirect |
| 5 | `/docs/account-portal/exports` | **AI-fabricated** — There is no "exports" concept under account-portal. User exports live under `/docs/deployments/exporting-users` (already covered). No clerk-org references. | Skipped |

#### Changes

**Static redirect** (`redirects/static/docs.json`):
- `/docs/expo` → `/docs/expo/getting-started/quickstart`

### Deadline

- No rush

### Other resources

- Previous 404 redirect PRs: [#3307](https://github.com/clerk/clerk-docs/pull/3307), [#3284](https://github.com/clerk/clerk-docs/pull/3284), [#3269](https://github.com/clerk/clerk-docs/pull/3269)