### PR TITLE
Fixes Typedoc outputs for all hooks + types 

### DIFF
--- a/scripts/lib/typedoc.ts
+++ b/scripts/lib/typedoc.ts
@@ -8,6 +8,7 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 import readdirp from 'readdirp'
 import { remark } from 'remark'
+import remarkGfm from 'remark-gfm'
 import remarkMdx from 'remark-mdx'
 import type { Node } from 'unist'
 import type { BuildConfig } from './config'
@@ -46,6 +47,7 @@ export const readTypedoc = (config: BuildConfig) => async (filePath: string) => 
 
       const vfile = await remark()
         .use(remarkMdx)
+        .use(remarkGfm)
         .use(() => (tree) => {
           node = tree
         })
@@ -71,6 +73,7 @@ export const readTypedoc = (config: BuildConfig) => async (filePath: string) => 
       let node: Node | null = null
 
       const vfile = await remark()
+        .use(remarkGfm)
         .use(() => (tree) => {
           node = tree
         })


### PR DESCRIPTION
### What does this solve? What changed?

This PR fixes an issue where Typedoc-generated markdown tables embedded via `<Typedoc /> `were rendering as plain text in `clerk-docs`, instead of as formatted tables.This content rendered correctly when pasted directly into a docs page, but rendered incorrectly when loaded through the `<Typedoc />` component.

The reason was that Typedoc files were being parsed through a separate pipeline in `scripts/lib/typedoc.ts`, and that parser did not include `remark-gfm` (one of the recent additions introduced in this [PR](https://github.com/clerk/clerk-docs/pull/3303)). As a result, GFM table syntax inside Typedoc files was treated as plain text before being embedded into docs pages.

Meanwhile, normal docs pages already used `remark-gfm`, which is why the same content worked when written manually in a docs file. This only affected the outputs in the `shared` and `react` folders. 

**Fix**

This PR adds `remark-gfm` to the Typedoc parsing logic in `scripts/lib/typedoc.ts`, including both:

- the main `remarkMdx` parsing path
- the `plain-markdown` fallback path
- 
This makes Typedoc-generated content support the same GFM table parsing behavior as the rest of the docs pipeline.

**To test**

- Head to any hooks page or types page to see the Properties / Returns tables being fixed compared to the current docs. 

### Deadline

ASAP.