### PR TITLE
Clarify Next.js App Router proxy handler path for __clerk

### DIFF
--- a/docs/_partials/frontend-api-proxy/create-frontend-api-proxy-handlers.mdx
+++ b/docs/_partials/frontend-api-proxy/create-frontend-api-proxy-handlers.mdx
@@ -1,7 +1,10 @@
 > [!IMPORTANT]
 > When using route handlers instead of the `frontendApiProxy` middleware option, the `proxyUrl` is **not** auto-derived. You must set the `proxyUrl` option on `clerkMiddleware()` or set the `NEXT_PUBLIC_CLERK_PROXY_URL` environment variable for the authentication handshake to work correctly.
 
-```ts {{ filename: 'app/api/__clerk/[[...path]]/route.ts' }}
+> [!NOTE]
+> In Next.js App Router, folders that start with `_` are treated as private folders. To create a literal `__clerk` route segment, use `%5F%5Fclerk` in the file path. The resulting route is still `/__clerk/*`.
+
+```ts {{ filename: 'app/api/%5F%5Fclerk/[[...path]]/route.ts' }}
 import { createFrontendApiProxyHandlers } from '@clerk/nextjs/server'
 
 export const { GET, POST, PUT, DELETE, PATCH } = createFrontendApiProxyHandlers()

--- a/docs/_partials/frontend-api-proxy/create-frontend-api-proxy-handlers.mdx
+++ b/docs/_partials/frontend-api-proxy/create-frontend-api-proxy-handlers.mdx
@@ -2,7 +2,7 @@
 > When using route handlers instead of the `frontendApiProxy` middleware option, the `proxyUrl` is **not** auto-derived. You must set the `proxyUrl` option on `clerkMiddleware()` or set the `NEXT_PUBLIC_CLERK_PROXY_URL` environment variable for the authentication handshake to work correctly.
 
 > [!NOTE]
-> In Next.js App Router, folders that start with `_` are treated as private folders. To create a literal `__clerk` route segment, use `%5F%5Fclerk` in the file path. The resulting route is still `/__clerk/*`.
+> In Next.js App Router, folders that start with `_` are treated as [private folders](https://nextjs.org/docs/app/getting-started/project-structure#private-folders). To create a literal `__clerk` route segment, use `%5F%5Fclerk` in the file path. The resulting route is still `/__clerk/*`.
 
 ```ts {{ filename: 'app/api/%5F%5Fclerk/[[...path]]/route.ts' }}
 import { createFrontendApiProxyHandlers } from '@clerk/nextjs/server'

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -381,6 +381,9 @@ export const config = {
 
 As an alternative to handling the proxy in middleware, you can use route handlers in a Next.js App Router. **This is useful if you prefer to keep proxy logic separate from your middleware.**
 
+> [!NOTE]
+> In Next.js App Router, folders that start with `_` are treated as private folders. To create a literal `__clerk` route segment, use `%5F%5Fclerk` in the file path. The resulting route is still `/__clerk/*`.
+
 #### `createFrontendApiProxyHandlers()`
 
 Returns an object with `GET`, `POST`, `PUT`, `DELETE`, and `PATCH` handlers that can be directly exported from a route file.
@@ -391,7 +394,7 @@ Returns an object with `GET`, `POST`, `PUT`, `DELETE`, and `PATCH` handlers that
 
 For more control, you can use `clerkFrontendApiProxy()` directly in individual route handlers.
 
-```ts {{ filename: 'app/api/__clerk/[[...path]]/route.ts' }}
+```ts {{ filename: 'app/api/%5F%5Fclerk/[[...path]]/route.ts' }}
 import { clerkFrontendApiProxy } from '@clerk/nextjs/server'
 
 export async function GET(request: Request) {

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -382,7 +382,7 @@ export const config = {
 As an alternative to handling the proxy in middleware, you can use route handlers in a Next.js App Router. **This is useful if you prefer to keep proxy logic separate from your middleware.**
 
 > [!NOTE]
-> In Next.js App Router, folders that start with `_` are treated as private folders. To create a literal `__clerk` route segment, use `%5F%5Fclerk` in the file path. The resulting route is still `/__clerk/*`.
+> In Next.js App Router, folders that start with `_` are treated as [private folders](https://nextjs.org/docs/app/getting-started/project-structure#private-folders). To create a literal `__clerk` route segment, use `%5F%5Fclerk` in the file path. The resulting route is still `/__clerk/*`.
 
 #### `createFrontendApiProxyHandlers()`
 


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/ss-docs-11744/reference/nextjs/clerk-middleware.mdx
- https://clerk.com/docs/pr/ss-docs-11744/guides/dashboard/dns-domains/proxy-fapi

### What does this solve? What changed?

Updates the Next.js Frontend API proxy docs to show the correct App Router file path for the `__clerk` route handler and explains why the folder name is encoded.

**Changes**

- Updated the App Router route-handler filename from: `app/api/__clerk/[[...path]]/route.ts` to `app/api/%5F%5Fclerk/[[...path]]/route.ts`
- Added a note explaining that in Next.js App Router, folders starting with `_` are treated as private folders
- Clarified that although the filesystem path uses `%5F%5Fclerk`, the actual route remains `/__clerk/*`

### Deadline

ASAP. 

### Other resources

[Linear](https://linear.app/clerk/issue/DOCS-11744/fix-nextjs-filepath-for-proxy-handler-in-docs)