### PR TITLE
docs(scim): fix custom attribute extension URN

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
@@ -57,17 +57,17 @@ For a full walkthrough of setting up a SAML connection, see the [custom SAML pro
 
 When Directory Sync is enabled, SCIM is the **exclusive source of truth** for attribute values. SCIM-managed attributes are read-only in Clerk and cannot be edited from the Dashboard or by the user in `<UserProfile />`. When SCIM is disabled, attributes become editable again.
 
-Clerk's SCIM implementation exposes a `/Schemas` endpoint that advertises a custom schema extension (`urn:clerk:scim:schemas:extension:custom:2.0:User`). This tells your IdP that Clerk accepts arbitrary custom attributes, which are mapped directly to `publicMetadata`.
+Clerk's SCIM implementation exposes a `/Schemas` endpoint that advertises a custom schema extension (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User`). This tells your IdP that Clerk accepts arbitrary custom attributes, which are mapped directly to `publicMetadata`.
 
-For each custom attribute, you map the shared attribute to the SCIM schema attribute name your IdP sends:
+For each custom attribute, you map the shared attribute to the SCIM path your IdP sends. The path can target a top-level core attribute (e.g., `title`), a nested attribute (e.g., `name.givenName`), or an attribute under any extension namespace your IdP populates — including the standard enterprise extension or Clerk's custom extension:
 
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your enterprise connection.
 1. Scroll to the **Attribute mapping** card. Under **Custom attributes**, select **Map custom attribute**.
-1. In the **SCIM attribute** field, enter the SCIM schema path your IdP sends (e.g., `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department`).
+1. In the **SCIM attribute** field, enter the SCIM path your IdP sends (e.g., `urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department` if your IdP sends `department` under Clerk's custom extension, or `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` if it uses the standard enterprise extension).
 1. In the **Clerk User attribute** dropdown, select one of your defined custom attributes.
 1. Select **Map attribute**.
 
-For example, the shared `department` attribute might map to `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department` in Okta.
+For example, in Okta you can configure the `department` profile attribute to be sent under Clerk's custom extension (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department`), then map that path to your shared `department` attribute in Clerk.
 
 For a full walkthrough of setting up Directory Sync, see the [Directory Sync guide](/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync).
 

--- a/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
@@ -63,7 +63,9 @@ For each custom attribute, you map the shared attribute to the SCIM path your Id
 
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your enterprise connection.
 1. Scroll to the **Attribute mapping** card. Under **Custom attributes**, select **Map custom attribute**.
-1. In the **SCIM attribute** field, enter the SCIM path your IdP sends (e.g., `urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department` if your IdP sends `department` under Clerk's custom extension, or `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` if it uses the standard enterprise extension).
+1. In the **SCIM attribute** field, enter the SCIM path your IdP sends:
+   - `urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department` if your IdP sends `department` under Clerk's custom extension.
+   - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` if your IdP uses the standard enterprise extension.
 1. In the **Clerk User attribute** dropdown, select one of your defined custom attributes.
 1. Select **Map attribute**.
 


### PR DESCRIPTION
## Summary

The custom attribute mapping guide had two factual errors that I caught while fact-checking against the backend:

- It advertised a fictional schema extension URN (`urn:clerk:scim:schemas:extension:custom:2.0:User`). The real URN that `/Schemas` advertises and that user payloads accept is `urn:ietf:params:scim:schemas:extension:clerk:2.0:User`.
- The "SCIM attribute" example told users to enter `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department` — which is the standard enterprise extension, not Clerk's. The backend accepts any path the IdP sends (top-level core attribute, nested, or any extension namespace).

This PR:

- Corrects the URN.
- Rewrites the example so it shows Clerk's custom extension as the primary path while noting the standard enterprise extension also works.
- Clarifies that the SCIM path can target a top-level core attribute (e.g. `title`), a nested attribute (e.g. `name.givenName`), or any extension namespace.