### PR TITLE
docs(scim): align directory sync mapping with the new dashboard dropdown

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
@@ -63,9 +63,7 @@ For each custom attribute, you map the shared attribute to the SCIM path your Id
 
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your enterprise connection.
 1. Scroll to the **Attribute mapping** card. Under **Custom attributes**, select **Map custom attribute**.
-1. In the **SCIM attribute** field, enter the SCIM path your IdP sends:
-   - `urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department` if your IdP sends `department` under Clerk's custom extension.
-   - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` if your IdP uses the standard enterprise extension.
+1. In the **SCIM attribute** dropdown, select the path that matches your IdP's attribute. The dropdown is populated from the schemas your directory has already received via SCIM. If the dropdown is empty, trigger a sync from your IdP first — the schema appears after the first user is provisioned.
 1. In the **Clerk User attribute** dropdown, select one of your defined custom attributes.
 1. Select **Map attribute**.
 

--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -91,19 +91,19 @@ Attribute definitions are configured at the enterprise connection level and shar
 
 #### How SCIM attribute mapping works
 
-Clerk exposes a `/Schemas` endpoint that your IdP queries to discover what attributes Clerk accepts. In addition to the standard User schema, Clerk advertises a custom extension schema (`urn:clerk:scim:schemas:extension:custom:2.0:User`) that accepts any attribute name and maps it directly to the corresponding `publicMetadata` key.
+Clerk exposes a `/Schemas` endpoint that your IdP queries to discover what attributes Clerk accepts. In addition to the standard User schema, Clerk advertises a custom extension schema (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User`) that accepts any attribute name and maps it directly to the corresponding `publicMetadata` key.
 
 To configure SCIM attribute mapping for a custom attribute:
 
 1. First, [define your custom attributes](/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping#define-custom-attributes) at the enterprise connection level.
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your connection.
 1. Scroll to the **Attribute mapping** card. In the **Custom attributes** section, select **Map custom attribute**.
-1. In the **SCIM attribute** field, enter the SCIM schema path your IdP sends (e.g., `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department`).
+1. In the **SCIM attribute** dropdown, select the path that matches your IdP's attribute. The dropdown is populated from the schemas your directory has already received via SCIM. If the dropdown is empty, trigger a sync from your IdP first — the schema appears after the first user is provisioned.
 1. In the **Clerk User attribute** dropdown, select one of your custom attributes.
 1. Select **Map attribute**.
 1. In your IdP, ensure the attribute is configured to be pushed via SCIM.
 
-For example, you might map the shared `department` attribute to `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department` in Okta.
+For example, you might map the shared `department` attribute to `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` in Okta.
 
 ## Role mapping
 

--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -98,7 +98,7 @@ To configure SCIM attribute mapping for a custom attribute:
 1. First, [define your custom attributes](/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping#define-custom-attributes) at the enterprise connection level.
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your connection.
 1. Scroll to the **Attribute mapping** card. In the **Custom attributes** section, select **Map custom attribute**.
-1. In the **SCIM attribute** field, enter the SCIM schema path your IdP sends (e.g., `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department`).
+1. In the **SCIM attribute** dropdown, select the path that matches your IdP's attribute. The dropdown is populated from the schemas your directory has already received via SCIM. If the dropdown is empty, trigger a sync from your IdP first — the schema appears after the first user is provisioned.
 1. In the **Clerk User attribute** dropdown, select one of your custom attributes.
 1. Select **Map attribute**.
 1. In your IdP, ensure the attribute is configured to be pushed via SCIM.


### PR DESCRIPTION
## Summary

The dashboard's SCIM custom-attribute mapping field is now a discovery-populated dropdown (clerk/dashboard#9027) rather than a free-text input. Replace the "enter the schema path" step with a dropdown selection step in both the custom-attribute mapping and directory sync pages, and add an empty-state note pointing users at their IdP for the first sync.

This PR also mirrors the Clerk extension URN correction and dot-joined Okta example path from #3334 into `directory-sync.mdx`, which #3334 did not cover. Both pages now agree on the URN form and example path style.

## Related

- Dashboard PR: clerk/dashboard#9027
- Earlier docs fix: clerk/clerk-docs#3334
- Linear: ORGS-1421