### PR TITLE
There was an uppercase 'A' where it should be lowercase 'a'.

### DIFF
--- a/docs/guides/how-clerk-works/security/vulnerability-disclosure-policy.mdx
+++ b/docs/guides/how-clerk-works/security/vulnerability-disclosure-policy.mdx
@@ -50,4 +50,4 @@ In the interest of the safety of our users, staff, the Internet at large and you
 If you believe you've found a security vulnerability in one of our products or platforms send it to us by emailing [security@clerk.dev](mailto:security@clerk.dev). Include the following details with your report:
 
 Description of the location and potential impact of the vulnerability; and
-A detailed description of the steps required to reproduce the vulnerability (POC scripts, screenshots, and compressed screen captures are all helpful to us).
+a detailed description of the steps required to reproduce the vulnerability (POC scripts, screenshots, and compressed screen captures are all helpful to us).


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

Fix letter case.



### Deadline

no rush


### Other resources

none
