### PR TITLE
Fix link in contributing guide 

### DIFF
--- a/contributing/CONTRIBUTING.md
+++ b/contributing/CONTRIBUTING.md
@@ -114,7 +114,7 @@ When you open a pull request, a member of the Clerk team can add the `deploy-pre
 
 ### Previewing changes locally (for Clerk employees)
 
-Clerk employees can run the application and preview their documentation changes locally. To do this, follow the [instructions in the `clerk` README](https://github.com/clerk/clerk/tree/main?tab=readme-ov-file#running-the-app-locally).
+Clerk employees can run the application and preview their documentation changes locally. To do this, follow the [instructions in the `clerk` README](https://github.com/clerk/clerk/tree/main?tab=readme-ov-file#getting-started).
 
 ## Validating your changes
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

Fixes link in our contributing guide to lead to the correct section. 

### Deadline

ASAP. 

### Other resources

[Linear](https://linear.app/clerk/issue/DOCS-11754/contributingmd-broken-link-to-preview-changes-locally)