### PR TITLE
chore: Update Next.js middleware matcher to match on `/__clerk/` paths

### DIFF
--- a/docs/_partials/frontend-api-proxy/basic-usage-nextjs.mdx
+++ b/docs/_partials/frontend-api-proxy/basic-usage-nextjs.mdx
@@ -14,8 +14,10 @@ export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
-    // Always run for API routes and the proxy path
-    '/(api|trpc|__clerk)(.*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```

--- a/docs/_partials/frontend-api-proxy/multi-domain-usage-nextjs.mdx
+++ b/docs/_partials/frontend-api-proxy/multi-domain-usage-nextjs.mdx
@@ -14,8 +14,10 @@ export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
-    // Always run for API routes and the proxy path
-    '/(api|trpc|__clerk)(.*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -64,6 +64,8 @@ llm:
          '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
          // Always run for API routes
          '/(api|trpc)(.*)',
+         // Always run for Clerk-specific frontend API routes
+         '/__clerk/(.*)',
        ],
      }
      ```

--- a/docs/getting-started/quickstart/pages-router.mdx
+++ b/docs/getting-started/quickstart/pages-router.mdx
@@ -64,6 +64,8 @@ sdk: nextjs
          '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
          // Always run for API routes
          '/(api|trpc)(.*)',
+         // Always run for Clerk-specific frontend API routes
+         '/__clerk/(.*)',
        ],
      }
      ```

--- a/docs/guides/configure/session-tasks.mdx
+++ b/docs/guides/configure/session-tasks.mdx
@@ -93,6 +93,8 @@ export default function Page() {
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```

--- a/docs/guides/dashboard/dns-domains/satellite-domains.mdx
+++ b/docs/guides/dashboard/dns-domains/satellite-domains.mdx
@@ -365,6 +365,8 @@ When `satelliteAutoSync` is `false` (the default), you must ensure your sign-in 
             '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
             // Always run for API routes
             '/(api|trpc)(.*)',
+            // Always run for Clerk-specific frontend API routes
+            '/__clerk/(.*)',
           ],
         }
         ```

--- a/docs/guides/development/add-onboarding-flow.mdx
+++ b/docs/guides/development/add-onboarding-flow.mdx
@@ -103,6 +103,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```

--- a/docs/guides/development/custom-sign-in-or-up-page.mdx
+++ b/docs/guides/development/custom-sign-in-or-up-page.mdx
@@ -52,6 +52,8 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```

--- a/docs/guides/development/custom-sign-up-page.mdx
+++ b/docs/guides/development/custom-sign-up-page.mdx
@@ -55,6 +55,8 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```

--- a/docs/guides/development/geo-blocking.mdx
+++ b/docs/guides/development/geo-blocking.mdx
@@ -47,6 +47,8 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -89,6 +91,8 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```

--- a/docs/guides/development/integrations/databases/neon.mdx
+++ b/docs/guides/development/integrations/databases/neon.mdx
@@ -58,6 +58,8 @@ This tutorial demonstrates how to integrate Neon Postgres with Clerk in a Next.j
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```

--- a/docs/guides/development/migrating/authjs.mdx
+++ b/docs/guides/development/migrating/authjs.mdx
@@ -120,6 +120,7 @@ This guide shows how to migrate an application using Auth.js (formerly NextAuth.
       '/((?!.*\\..*|_next).*)', // Don't run middleware on static files
       '/', // Run middleware on index page
       '/(api|trpc)(.*)', // Run middleware on API routes
+      '/__clerk/(.*)', // Run middleware on Clerk frontend API routes
     ],
   }
   ```

--- a/docs/guides/development/upgrading/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-2/nextjs.mdx
@@ -92,6 +92,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -124,7 +126,7 @@ export default clerkMiddleware(async (auth, request) => {
 })
 
 export const config = {
-  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)', '/__clerk/(.*)'],
 }
 ```
 
@@ -152,6 +154,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -174,6 +178,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -197,6 +203,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -218,6 +226,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -250,6 +260,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -279,6 +291,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -302,6 +316,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     };
     ```
@@ -322,6 +338,8 @@ Of course, in most cases you'll have a more complicated setup than this. You can
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```

--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -662,6 +662,8 @@ The following deprecated APIs have been removed from all Clerk SDKs.
             '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
             // Always run for API routes
             '/(api|trpc)(.*)',
+            // Always run for Clerk-specific frontend API routes
+            '/__clerk/(.*)',
           ],
         }
       ```

--- a/docs/guides/development/webhooks/debugging.mdx
+++ b/docs/guides/development/webhooks/debugging.mdx
@@ -37,6 +37,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```

--- a/docs/guides/organizations/org-slugs-in-urls.mdx
+++ b/docs/guides/organizations/org-slugs-in-urls.mdx
@@ -142,6 +142,8 @@ This guide shows you how to add Organization slugs to your app's URLs, configure
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```

--- a/docs/guides/secure/basic-rbac.mdx
+++ b/docs/guides/secure/basic-rbac.mdx
@@ -128,6 +128,8 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```

--- a/docs/guides/secure/best-practices/csp-headers.mdx
+++ b/docs/guides/secure/best-practices/csp-headers.mdx
@@ -263,6 +263,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -26,6 +26,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -78,6 +80,8 @@ There are two methods that you can use:
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```
@@ -103,6 +107,8 @@ There are two methods that you can use:
       '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
       // Always run for API routes
       '/(api|trpc)(.*)',
+      // Always run for Clerk-specific frontend API routes
+      '/__clerk/(.*)',
     ],
   }
   ```
@@ -139,6 +145,8 @@ There are two methods that you can use:
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -171,6 +179,8 @@ There are two methods that you can use:
         '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
         // Always run for API routes
         '/(api|trpc)(.*)',
+        // Always run for Clerk-specific frontend API routes
+        '/__clerk/(.*)',
       ],
     }
     ```
@@ -209,6 +219,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -236,6 +248,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -275,6 +289,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -299,6 +315,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -335,6 +353,8 @@ export const config = {
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
+    // Always run for Clerk-specific frontend API routes
+    '/__clerk/(.*)',
   ],
 }
 ```
@@ -367,8 +387,10 @@ export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
-    // Always run for API routes and the proxy path
-    '/(api|trpc|custom-clerk-proxy)(.*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)',
+    // Always run for the custom proxy path
+    '/custom-clerk-proxy/(.*)',
   ],
 }
 ```

--- a/prompts/nextjs-quickstart.md
+++ b/prompts/nextjs-quickstart.md
@@ -31,6 +31,7 @@ export const config = {
   matcher: [
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
+    '/__clerk/(.*)',
   ],
 }
 ```


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Ensures our documented middleware matcher includes routes that start with `/__clerk/`. This is important because our new proxy behavior relies on the clerk middleware executing for the proxy path, which starts with `/__clerk/` by default.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
