### PR TITLE
docs(scim): clarify directory sync custom attribute paths

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -91,19 +91,23 @@ Attribute definitions are configured at the enterprise connection level and shar
 
 #### How SCIM attribute mapping works
 
-Clerk exposes a `/Schemas` endpoint that your IdP queries to discover what attributes Clerk accepts. In addition to the standard User schema, Clerk advertises a custom extension schema (`urn:clerk:scim:schemas:extension:custom:2.0:User`) that accepts any attribute name and maps it directly to the corresponding `publicMetadata` key.
+Clerk exposes a `/Schemas` endpoint that your IdP queries to discover what attributes Clerk accepts. In addition to the standard User schema, Clerk advertises a custom extension schema (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User`) that lets your IdP send arbitrary attributes Clerk would not otherwise accept.
+
+For each custom attribute, the SCIM path can target a top-level core attribute (e.g., `title`), a nested attribute (e.g., `name.givenName`), or an attribute under any extension namespace your IdP populates — including the standard enterprise extension or Clerk's custom extension.
 
 To configure SCIM attribute mapping for a custom attribute:
 
 1. First, [define your custom attributes](/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping#define-custom-attributes) at the enterprise connection level.
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your connection.
 1. Scroll to the **Attribute mapping** card. In the **Custom attributes** section, select **Map custom attribute**.
-1. In the **SCIM attribute** field, enter the SCIM schema path your IdP sends (e.g., `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department`).
+1. In the **SCIM attribute** field, enter the SCIM path your IdP sends:
+   - `urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department` if your IdP sends `department` under Clerk's custom extension.
+   - `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` if your IdP uses the standard enterprise extension.
 1. In the **Clerk User attribute** dropdown, select one of your custom attributes.
 1. Select **Map attribute**.
 1. In your IdP, ensure the attribute is configured to be pushed via SCIM.
 
-For example, you might map the shared `department` attribute to `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department` in Okta.
+For example, in Okta you can configure the `department` profile attribute to be sent under Clerk's custom extension (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department`), then map that path to your shared `department` attribute in Clerk.
 
 ## Role mapping
 


### PR DESCRIPTION
## Summary

Follow-up to #3334. The directory sync guide still advertised the wrong custom extension URN (`urn:clerk:scim:schemas:extension:custom:2.0:User`) and implied custom attributes only worked through that namespace.

Backend behavior: `scim_path` resolves any field on the SCIM user payload via gjson — top-level core attributes, nested attributes, or anything under an extension namespace (standard enterprise extension or Clerk's custom extension).

## Changes

- Fixed URN to `urn:ietf:params:scim:schemas:extension:clerk:2.0:User`.
- Added a sentence covering top-level / nested / extension-namespace paths.
- Step example now shows both Clerk and enterprise extension paths.
- Switched colon to dot for the trailing path component (gjson syntax).

## Test plan

- [ ] Render preview, verify formatting of nested bullet list under step 4.