### PR TITLE
docs(scim): drop URN requirement for custom attribute paths

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
@@ -57,9 +57,9 @@ For a full walkthrough of setting up a SAML connection, see the [custom SAML pro
 
 When Directory Sync is enabled, SCIM is the **exclusive source of truth** for attribute values. SCIM-managed attributes are read-only in Clerk and cannot be edited from the Dashboard or by the user in `<UserProfile />`. When SCIM is disabled, attributes become editable again.
 
-Clerk's SCIM implementation exposes a `/Schemas` endpoint that advertises a custom schema extension (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User`). This tells your IdP that Clerk accepts arbitrary custom attributes, which are mapped directly to `publicMetadata`.
+Clerk's SCIM implementation accepts any attribute path your IdP sends and maps it directly to the corresponding `publicMetadata` key. There's no required schema or namespace — use whatever path your IdP is already configured to push.
 
-For each custom attribute, you map the shared attribute to the SCIM path your IdP sends. The path can target a top-level core attribute (e.g., `title`), a nested attribute (e.g., `name.givenName`), or an attribute under any extension namespace your IdP populates — including the standard enterprise extension or Clerk's custom extension:
+For each custom attribute, you map the shared attribute to the SCIM path your IdP sends. The path can target a top-level core attribute (e.g., `title`), a nested attribute (e.g., `name.givenName`), or an attribute under any extension namespace your IdP populates:
 
 1. In the Clerk Dashboard, navigate to the **Directory sync** tab on your enterprise connection.
 1. Scroll to the **Attribute mapping** card. Under **Custom attributes**, select **Map custom attribute**.
@@ -67,7 +67,7 @@ For each custom attribute, you map the shared attribute to the SCIM path your Id
 1. In the **Clerk User attribute** dropdown, select one of your defined custom attributes.
 1. Select **Map attribute**.
 
-For example, in Okta you can configure the `department` profile attribute to be sent under Clerk's custom extension (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User.department`), then map that path to your shared `department` attribute in Clerk.
+For example, in Okta you can configure the `department` profile attribute to be sent under any path you choose (such as the top-level `department` core attribute, or under the standard enterprise extension), then map that path to your shared `department` attribute in Clerk.
 
 For a full walkthrough of setting up Directory Sync, see the [Directory Sync guide](/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync).
 

--- a/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync.mdx
@@ -91,7 +91,7 @@ Attribute definitions are configured at the enterprise connection level and shar
 
 #### How SCIM attribute mapping works
 
-Clerk exposes a `/Schemas` endpoint that your IdP queries to discover what attributes Clerk accepts. In addition to the standard User schema, Clerk advertises a custom extension schema (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User`) that accepts any attribute name and maps it directly to the corresponding `publicMetadata` key.
+Clerk's SCIM implementation accepts any attribute path your IdP sends and maps it directly to the corresponding `publicMetadata` key. There's no required schema or namespace — use whatever path your IdP is already configured to push (a core attribute like `title`, a nested attribute like `name.givenName`, or anything under an extension namespace).
 
 To configure SCIM attribute mapping for a custom attribute:
 
@@ -103,7 +103,7 @@ To configure SCIM attribute mapping for a custom attribute:
 1. Select **Map attribute**.
 1. In your IdP, ensure the attribute is configured to be pushed via SCIM.
 
-For example, you might map the shared `department` attribute to `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department` in Okta.
+For example, you might map the shared `department` attribute to whichever path your IdP sends — such as the top-level `department` core attribute, or any extension path Okta is configured to push.
 
 ## Role mapping
 


### PR DESCRIPTION
### What does this solve? What changed?

Clerk's SCIM endpoint now accepts any attribute path and maps it directly to `publicMetadata`, so the docs no longer need to prescribe Clerk's custom extension URN (`urn:ietf:params:scim:schemas:extension:clerk:2.0:User`). 

Removed URN-specific language and examples from the custom attribute mapping and directory sync pages, replacing them with general guidance that any SCIM path (core, nested, or extension) works.

- Updated `custom-attribute-mapping.mdx` SCIM section + Okta example
- Updated `directory-sync.mdx` SCIM mapping section + Okta example