### PR TITLE
Add descriptions to llms.txt file

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -7422,7 +7422,7 @@ description: Generated API docs
 
 ## Docs
 
-- [API Documentation]({{SITE_URL}}/docs/api-doc)`)
+- [API Documentation]({{SITE_URL}}/docs/api-doc): Generated API docs`)
   })
 
   test('Should output llms-full.txt full pages', async () => {

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -2203,6 +2203,92 @@ sdk: react, nextjs
     // Test SDK-scoped nested index.mdx - canonical should be /docs/:sdk:/sdk not /docs/:sdk:/sdk/index
     expect(await readFile('./dist/react/sdk/index.mdx')).toContain('canonical: /docs/:sdk:/sdk\n')
     expect(await readFile('./dist/nextjs/sdk/index.mdx')).toContain('canonical: /docs/:sdk:/sdk\n')
+
+    // directory.json should mirror the canonical URLs (root index has no trailing slash).
+    const directory = JSON.parse(await readFile('./dist/directory.json')) as Array<{
+      path: string
+      url: string
+    }>
+    const urlByPath = Object.fromEntries(directory.map((entry) => [entry.path, entry.url]))
+    expect(urlByPath['index.mdx']).toBe('/docs')
+    expect(urlByPath['guides/index.mdx']).toBe('/docs/guides')
+    expect(urlByPath['react/sdk/index.mdx']).toBe('/docs/react/sdk')
+    expect(urlByPath['nextjs/sdk/index.mdx']).toBe('/docs/nextjs/sdk')
+  })
+
+  test('directory.json excludes partials and tooltips', async () => {
+    const { tempDir, readFile } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              { title: 'Intro', href: '/docs/intro' },
+              { title: 'Billing Overview', href: '/docs/billing/overview' },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/_partials/global-partial.mdx',
+        content: `Shared global partial content.`,
+      },
+      {
+        path: './docs/billing/_partials/local-partial.mdx',
+        content: `Local billing partial content.`,
+      },
+      {
+        path: './docs/_tooltips/sample-tooltip.mdx',
+        content: `Sample tooltip content.`,
+      },
+      {
+        path: './docs/intro.mdx',
+        content: `---
+title: Intro
+description: Intro page
+---
+
+<Include src="_partials/global-partial" />
+
+[Tooltip](!sample-tooltip)
+`,
+      },
+      {
+        path: './docs/billing/overview.mdx',
+        content: `---
+title: Billing Overview
+description: Billing overview page
+---
+
+<Include src="_partials/local-partial" />
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['react'],
+        tooltips: {
+          inputPath: '../docs/_tooltips',
+          outputPath: './_tooltips',
+        },
+      }),
+    )
+
+    const directory = JSON.parse(await readFile('./dist/directory.json')) as Array<{
+      path: string
+      url: string
+    }>
+
+    expect(directory).toEqual([
+      { path: 'intro.mdx', url: '/docs/intro' },
+      { path: 'billing/overview.mdx', url: '/docs/billing/overview' },
+    ])
+
+    expect(directory.some((entry) => entry.path.includes('_partials'))).toBe(false)
+    expect(directory.some((entry) => entry.path.includes('_tooltips'))).toBe(false)
   })
 
   test('should not inject :sdk: for single SDK documents when multiple SDKs are available', async () => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1167,12 +1167,17 @@ ${yaml.stringify({
   const mdxFilePaths = mdxFiles
     .map((entry) => entry.path.replace(/\\/g, '/')) // Replace backslashes with forward slashes
     .filter((filePath) => !filePath.includes(config.partialsFolderName)) // Exclude partials
-    .map((path) => ({
-      path,
-      url: `${config.baseDocsLink}${removeMdxSuffix(path)
+    .map((path) => {
+      const slug = removeMdxSuffix(path)
         .replace(/^index$/, '') // remove root index
-        .replace(/\/index$/, '')}`, // remove /index from the end,
-    }))
+        .replace(/\/index$/, '') // remove /index from the end
+
+      // Strip the trailing slash from baseDocsLink when the page is the root
+      // index, so the canonical URL is `/docs` rather than `/docs/`.
+      const base = slug === '' ? config.baseDocsLink.replace(/\/$/, '') : config.baseDocsLink
+
+      return { path, url: `${base}${slug}` }
+    })
 
   await writeFile('directory.json', JSON.stringify(mdxFilePaths))
 
@@ -1195,7 +1200,7 @@ ${yaml.stringify({
   abortSignal?.throwIfAborted()
 
   if (config.llms?.fullPath || config.llms?.overviewPath) {
-    const outputtedDocsFiles = listOutputDocsFiles(config, store.writtenFiles, mdxFilePaths)
+    const outputtedDocsFiles = listOutputDocsFiles(store.writtenFiles, mdxFilePaths)
 
     if (config.llms?.fullPath) {
       const llmsFull = await generateLLMsFull(outputtedDocsFiles)

--- a/scripts/check-redirects.ts
+++ b/scripts/check-redirects.ts
@@ -159,7 +159,7 @@ async function loadDirectory(): Promise<Set<string>> {
         validUrls.add(entry.url.slice(0, -1))
       }
       // Also add the URL with trailing slash if it doesn't have one
-      if (!entry.url.endsWith('/') && entry.url !== '/docs') {
+      if (!entry.url.endsWith('/')) {
         validUrls.add(entry.url + '/')
       }
     }

--- a/scripts/lib/llms.test.ts
+++ b/scripts/lib/llms.test.ts
@@ -31,9 +31,7 @@ describe('normalizeFrontmatterDescription', () => {
   })
 
   test('collapses internal whitespace and newlines into single spaces', () => {
-    expect(normalizeFrontmatterDescription('Line one\nLine two\t  with  spaces')).toBe(
-      'Line one Line two with spaces',
-    )
+    expect(normalizeFrontmatterDescription('Line one\nLine two\t  with  spaces')).toBe('Line one Line two with spaces')
   })
 
   test('returns undefined for empty or whitespace-only strings', () => {

--- a/scripts/lib/llms.test.ts
+++ b/scripts/lib/llms.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'vitest'
+import type { BuildConfig } from './config'
+import { formatLLMsDocLine, listOutputDocsFiles, normalizeFrontmatterDescription, writeLLMs } from './llms'
+
+const baseConfig = { baseDocsLink: '/docs/' } as unknown as BuildConfig
+
+describe('formatLLMsDocLine', () => {
+  test('appends description after a colon when present', () => {
+    expect(
+      formatLLMsDocLine({
+        title: 'Quickstart',
+        url: 'https://example.com/docs/quickstart',
+        description: 'Get up and running with Clerk in minutes.',
+      }),
+    ).toBe('- [Quickstart](https://example.com/docs/quickstart): Get up and running with Clerk in minutes.')
+  })
+
+  test('omits the colon when no description is provided', () => {
+    expect(
+      formatLLMsDocLine({
+        title: 'Quickstart',
+        url: 'https://example.com/docs/quickstart',
+      }),
+    ).toBe('- [Quickstart](https://example.com/docs/quickstart)')
+  })
+})
+
+describe('normalizeFrontmatterDescription', () => {
+  test('returns trimmed string when description is non-empty', () => {
+    expect(normalizeFrontmatterDescription('  Hello world  ')).toBe('Hello world')
+  })
+
+  test('collapses internal whitespace and newlines into single spaces', () => {
+    expect(normalizeFrontmatterDescription('Line one\nLine two\t  with  spaces')).toBe(
+      'Line one Line two with spaces',
+    )
+  })
+
+  test('returns undefined for empty or whitespace-only strings', () => {
+    expect(normalizeFrontmatterDescription('')).toBeUndefined()
+    expect(normalizeFrontmatterDescription('   ')).toBeUndefined()
+  })
+
+  test('returns undefined for non-string input', () => {
+    expect(normalizeFrontmatterDescription(undefined)).toBeUndefined()
+    expect(normalizeFrontmatterDescription(null)).toBeUndefined()
+    expect(normalizeFrontmatterDescription(123)).toBeUndefined()
+  })
+})
+
+describe('listOutputDocsFiles', () => {
+  test('extracts title and description from frontmatter', () => {
+    const docs = new Map<string, string>([
+      [
+        'quickstart.mdx',
+        `---
+title: Quickstart
+description: Get up and running with Clerk in minutes.
+---
+
+Body content`,
+      ],
+    ])
+
+    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'quickstart.mdx' }])
+
+    expect(result).toEqual([
+      {
+        path: 'quickstart.mdx',
+        url: '{{SITE_URL}}/docs/quickstart',
+        content: docs.get('quickstart.mdx'),
+        title: 'Quickstart',
+        description: 'Get up and running with Clerk in minutes.',
+      },
+    ])
+  })
+
+  test('leaves description undefined when frontmatter omits it', () => {
+    const docs = new Map<string, string>([
+      [
+        'overview.mdx',
+        `---
+title: Overview
+---
+
+Body`,
+      ],
+    ])
+
+    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'overview.mdx' }])
+
+    expect(result).toEqual([
+      {
+        path: 'overview.mdx',
+        url: '{{SITE_URL}}/docs/overview',
+        content: docs.get('overview.mdx'),
+        title: 'Overview',
+        description: undefined,
+      },
+    ])
+  })
+
+  test('skips entries without a title', () => {
+    const docs = new Map<string, string>([
+      [
+        'no-title.mdx',
+        `---
+description: A description but no title
+---
+
+Body`,
+      ],
+    ])
+
+    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'no-title.mdx' }])
+
+    expect(result).toEqual([])
+  })
+
+  test('filters out paths starting with ~/', () => {
+    const docs = new Map<string, string>([
+      [
+        '~/quick-redirect.mdx',
+        `---
+title: Quick Redirect
+---
+
+Body`,
+      ],
+    ])
+
+    const result = listOutputDocsFiles(baseConfig, docs, [{ path: '~/quick-redirect.mdx' }])
+
+    expect(result).toEqual([])
+  })
+
+  test('strips index and /index from the URL', () => {
+    const docs = new Map<string, string>([
+      [
+        'index.mdx',
+        `---
+title: Welcome
+---
+
+Body`,
+      ],
+      [
+        'guides/index.mdx',
+        `---
+title: Guides
+---
+
+Body`,
+      ],
+    ])
+
+    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'index.mdx' }, { path: 'guides/index.mdx' }])
+
+    expect(result.map((entry) => entry.url)).toEqual(['{{SITE_URL}}/docs/', '{{SITE_URL}}/docs/guides'])
+  })
+
+  test('throws when a doc cannot be found in the docs map', () => {
+    const docs = new Map<string, string>()
+
+    expect(() => listOutputDocsFiles(baseConfig, docs, [{ path: 'missing.mdx' }])).toThrow('Doc not found: missing.mdx')
+  })
+})
+
+describe('writeLLMs', () => {
+  test('renders a markdown list with descriptions when available', async () => {
+    const result = await writeLLMs([
+      {
+        path: 'quickstart.mdx',
+        url: '{{SITE_URL}}/docs/quickstart',
+        content: '',
+        title: 'Quickstart',
+        description: 'Get up and running with Clerk in minutes.',
+      },
+      {
+        path: 'overview.mdx',
+        url: '{{SITE_URL}}/docs/overview',
+        content: '',
+        title: 'Overview',
+        description: undefined,
+      },
+    ])
+
+    expect(result).toBe(
+      [
+        '# Clerk',
+        '',
+        '## Docs',
+        '',
+        '- [Quickstart]({{SITE_URL}}/docs/quickstart): Get up and running with Clerk in minutes.',
+        '- [Overview]({{SITE_URL}}/docs/overview)',
+      ].join('\n'),
+    )
+  })
+})

--- a/scripts/lib/llms.test.ts
+++ b/scripts/lib/llms.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import type { BuildConfig } from './config'
 import { formatLLMsDocLine, listOutputDocsFiles, normalizeFrontmatterDescription, writeLLMs } from './llms'
-
-const baseConfig = { baseDocsLink: '/docs/' } as unknown as BuildConfig
 
 describe('formatLLMsDocLine', () => {
   test('appends description after a colon when present', () => {
@@ -60,7 +57,7 @@ Body content`,
       ],
     ])
 
-    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'quickstart.mdx' }])
+    const result = listOutputDocsFiles(docs, [{ path: 'quickstart.mdx', url: '/docs/quickstart' }])
 
     expect(result).toEqual([
       {
@@ -85,7 +82,7 @@ Body`,
       ],
     ])
 
-    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'overview.mdx' }])
+    const result = listOutputDocsFiles(docs, [{ path: 'overview.mdx', url: '/docs/overview' }])
 
     expect(result).toEqual([
       {
@@ -110,7 +107,7 @@ Body`,
       ],
     ])
 
-    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'no-title.mdx' }])
+    const result = listOutputDocsFiles(docs, [{ path: 'no-title.mdx', url: '/docs/no-title' }])
 
     expect(result).toEqual([])
   })
@@ -127,12 +124,12 @@ Body`,
       ],
     ])
 
-    const result = listOutputDocsFiles(baseConfig, docs, [{ path: '~/quick-redirect.mdx' }])
+    const result = listOutputDocsFiles(docs, [{ path: '~/quick-redirect.mdx', url: '/docs/quick-redirect' }])
 
     expect(result).toEqual([])
   })
 
-  test('strips index and /index from the URL', () => {
+  test('prefixes the supplied URL with {{SITE_URL}} verbatim, including the docs root', () => {
     const docs = new Map<string, string>([
       [
         'index.mdx',
@@ -152,15 +149,20 @@ Body`,
       ],
     ])
 
-    const result = listOutputDocsFiles(baseConfig, docs, [{ path: 'index.mdx' }, { path: 'guides/index.mdx' }])
+    const result = listOutputDocsFiles(docs, [
+      { path: 'index.mdx', url: '/docs' },
+      { path: 'guides/index.mdx', url: '/docs/guides' },
+    ])
 
-    expect(result.map((entry) => entry.url)).toEqual(['{{SITE_URL}}/docs/', '{{SITE_URL}}/docs/guides'])
+    expect(result.map((entry) => entry.url)).toEqual(['{{SITE_URL}}/docs', '{{SITE_URL}}/docs/guides'])
   })
 
   test('throws when a doc cannot be found in the docs map', () => {
     const docs = new Map<string, string>()
 
-    expect(() => listOutputDocsFiles(baseConfig, docs, [{ path: 'missing.mdx' }])).toThrow('Doc not found: missing.mdx')
+    expect(() => listOutputDocsFiles(docs, [{ path: 'missing.mdx', url: '/docs/missing' }])).toThrow(
+      'Doc not found: missing.mdx',
+    )
   })
 })
 

--- a/scripts/lib/llms.ts
+++ b/scripts/lib/llms.ts
@@ -8,9 +8,19 @@ export const writeLLMsFull = async (outputtedDocsFiles: OutputtedDocsFiles) => {
   return outputtedDocsFiles.map((file) => file.content).join('\n')
 }
 
+export const formatLLMsDocLine = (page: { title: string; url: string; description?: string }) => {
+  return page.description ? `- [${page.title}](${page.url}): ${page.description}` : `- [${page.title}](${page.url})`
+}
+
 export const writeLLMs = async (outputtedDocsFiles: OutputtedDocsFiles) => {
-  const list = outputtedDocsFiles.map((page) => `- [${page.title}](${page.url})`).join('\n')
+  const list = outputtedDocsFiles.map(formatLLMsDocLine).join('\n')
   return `# Clerk\n\n## Docs\n\n${list}`
+}
+
+export const normalizeFrontmatterDescription = (raw: unknown): string | undefined => {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim().replace(/\s+/g, ' ')
+  return trimmed.length > 0 ? trimmed : undefined
 }
 
 export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { path: string }[]) => {
@@ -43,6 +53,7 @@ export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { pa
       return {
         ...file,
         title,
+        description: normalizeFrontmatterDescription(frontmatter.description),
       }
     })
     .filter((page) => page !== null)

--- a/scripts/lib/llms.ts
+++ b/scripts/lib/llms.ts
@@ -1,5 +1,3 @@
-import type { BuildConfig } from './config'
-import { removeMdxSuffix } from './utils/removeMdxSuffix'
 import yaml from 'yaml'
 
 type Docs = Map<string, string>
@@ -23,10 +21,10 @@ export const normalizeFrontmatterDescription = (raw: unknown): string | undefine
   return trimmed.length > 0 ? trimmed : undefined
 }
 
-export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { path: string }[]) => {
+export const listOutputDocsFiles = (docs: Docs, files: { path: string; url: string }[]) => {
   return files
     .filter(({ path }) => !path.startsWith('~/')) // Exclude these quick redirect pages
-    .map(({ path }) => {
+    .map(({ path, url }) => {
       const content = docs.get(path)
 
       if (!content) {
@@ -35,9 +33,7 @@ export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { pa
 
       return {
         path,
-        url: `{{SITE_URL}}${config.baseDocsLink}${removeMdxSuffix(path)
-          .replace(/^index$/, '') // remove root index
-          .replace(/\/index$/, '')}`, // remove /index from the end,
+        url: `{{SITE_URL}}${url}`,
         content,
       }
     })

--- a/scripts/trace-redirect.ts
+++ b/scripts/trace-redirect.ts
@@ -80,7 +80,7 @@ async function loadDirectory() {
         validUrls.add(entry.url.slice(0, -1))
       }
       // Also add the URL with trailing slash if it doesn't have one
-      if (!entry.url.endsWith('/') && entry.url !== '/docs') {
+      if (!entry.url.endsWith('/')) {
         validUrls.add(entry.url + '/')
       }
     }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk-docs-git-nick-llms-txt-with-description.clerkstage.dev/_llms/llms.txt
- https://clerk.com/docs/pr/nick-llms-txt-with-description/llms.txt

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Adds the guides descriptions to the llms.txt file to better inform llms which guide that went to look at

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- no rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

Replaces https://github.com/clerk/clerk/pull/2386