### PR TITLE
Fix failing llms.txt overview test after description change

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -7422,7 +7422,7 @@ description: Generated API docs
 
 ## Docs
 
-- [API Documentation]({{SITE_URL}}/docs/api-doc)`)
+- [API Documentation]({{SITE_URL}}/docs/api-doc): Generated API docs`)
   })
 
   test('Should output llms-full.txt full pages', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The test suite was failing on `nick/llms-txt-with-description` with one test failure:

```
FAIL  scripts/build-docs.test.ts > LLMs > Should output llms.txt overview
- - [API Documentation]({{SITE_URL}}/docs/api-doc)
+ - [API Documentation]({{SITE_URL}}/docs/api-doc): Generated API docs
```

Commit `da957c6e` ("Add descriptions to llms.txt file") updated `scripts/lib/llms.ts` so that `writeLLMs` now appends `": <description>"` to each entry when a doc has a frontmatter description. The unit tests in `scripts/lib/llms.test.ts` were added/updated to cover the new behavior, but the integration test in `scripts/build-docs.test.ts` for the same code path was missed — its fixture doc has `description: Generated API docs`, so the new output now ends with `: Generated API docs`.

## What

- Update the expected output string in `LLMs > Should output llms.txt overview` in `scripts/build-docs.test.ts` to include the description suffix that the new format produces.

## Verification

```
pnpm test --run
```

All 192 tests pass (4 files).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8063ed1d-e318-4819-888b-72d2a5e2a630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8063ed1d-e318-4819-888b-72d2a5e2a630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

