### PR TITLE
Include in build script output llms-full.txt per sdk

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -7467,6 +7467,121 @@ sourceFile: /docs/api-doc.mdx
 # API Documentation
 `)
   })
+
+  test('Should output per-SDK llms-full.txt files containing the SDK variant for shadowed docs and core docs that are not SDK-scoped', async () => {
+    const { tempDir, readFile, listFiles } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              { title: 'Quickstart', href: '/docs/quickstart' },
+              { title: 'API Doc', href: '/docs/api-doc' },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/quickstart.mdx',
+        content: `---
+title: Quickstart
+description: Shared
+---
+
+Shared content
+`,
+      },
+      {
+        path: './docs/api-doc.mdx',
+        content: `---
+title: API Documentation
+description: x
+sdk: nextjs, react
+---
+
+Default content
+`,
+      },
+      {
+        path: './docs/api-doc.react.mdx',
+        content: `---
+title: API Documentation for React
+description: x
+---
+
+React content
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['nextjs', 'react'],
+        llms: {
+          fullPath: '_llms/llms-full.txt',
+          perSdkFullPath: '_llms/{sdk}/llms-full.txt',
+        },
+      }),
+    )
+
+    const dist = await listFiles('dist/_llms')
+    expect(dist).toEqual(['llms-full.txt', 'nextjs/llms-full.txt', 'react/llms-full.txt'])
+
+    const nextjs = await readFile('./dist/_llms/nextjs/llms-full.txt')
+    expect(nextjs).toContain('title: Quickstart')
+    expect(nextjs).toContain('Shared content')
+    expect(nextjs).toContain('activeSdk: nextjs')
+    expect(nextjs).toContain('Default content')
+    expect(nextjs).not.toContain('activeSdk: react')
+    expect(nextjs).not.toContain('React content')
+    expect(nextjs).not.toContain('redirectPage:')
+
+    const react = await readFile('./dist/_llms/react/llms-full.txt')
+    expect(react).toContain('title: Quickstart')
+    expect(react).toContain('Shared content')
+    expect(react).toContain('activeSdk: react')
+    expect(react).toContain('React content')
+    expect(react).not.toContain('activeSdk: nextjs')
+    expect(react).not.toContain('Default content')
+    expect(react).not.toContain('redirectPage:')
+  })
+
+  test('Should not emit a per-SDK llms-full.txt for SDKs with no docs', async () => {
+    const { tempDir, listFiles } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [[{ title: 'API Doc', href: '/docs/api-doc' }]],
+        }),
+      },
+      {
+        path: './docs/api-doc.mdx',
+        content: `---
+title: API Documentation
+description: x
+sdk: nextjs
+---
+
+Next.js only
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['nextjs', 'react'],
+        llms: {
+          perSdkFullPath: '_llms/{sdk}/llms-full.txt',
+        },
+      }),
+    )
+
+    expect(await listFiles('dist/_llms')).toEqual(['nextjs/llms-full.txt'])
+  })
 })
 
 describe('Multiple document variants for pages', () => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -78,7 +78,12 @@ import { extractSDKsFromIfProp } from './lib/utils/extractSDKsFromIfProp'
 import { scopeHrefToSDK } from './lib/utils/scopeHrefToSDK'
 
 import { VFile } from 'vfile'
-import { writeLLMs as generateLLMs, writeLLMsFull as generateLLMsFull, listOutputDocsFiles } from './lib/llms'
+import {
+  filterOutputDocsForSdk,
+  writeLLMs as generateLLMs,
+  writeLLMsFull as generateLLMsFull,
+  listOutputDocsFiles,
+} from './lib/llms'
 import { checkPartials } from './lib/plugins/checkPartials'
 import { checkTypedoc } from './lib/plugins/checkTypedoc'
 import { filterOtherSDKsContentOut } from './lib/plugins/filterOtherSDKsContentOut'
@@ -209,6 +214,7 @@ async function main() {
     llms: {
       overviewPath: '_llms/llms.txt',
       fullPath: '_llms/llms-full.txt',
+      perSdkFullPath: '_llms/{sdk}/llms-full.txt',
     },
     flags: {
       watch: args.includes('--watch'),
@@ -1194,7 +1200,7 @@ ${yaml.stringify({
 
   abortSignal?.throwIfAborted()
 
-  if (config.llms?.fullPath || config.llms?.overviewPath) {
+  if (config.llms?.fullPath || config.llms?.overviewPath || config.llms?.perSdkFullPath) {
     const outputtedDocsFiles = listOutputDocsFiles(config, store.writtenFiles, mdxFilePaths)
 
     if (config.llms?.fullPath) {
@@ -1205,6 +1211,17 @@ ${yaml.stringify({
     if (config.llms?.overviewPath) {
       const llms = await generateLLMs(outputtedDocsFiles)
       await writeFile(config.llms.overviewPath, llms)
+    }
+
+    if (config.llms?.perSdkFullPath) {
+      const perSdkPathTemplate = config.llms.perSdkFullPath
+      for (const sdk of config.validSdks) {
+        const sdkDocs = filterOutputDocsForSdk(outputtedDocsFiles, sdk, config.validSdks)
+        if (sdkDocs.length === 0) continue
+
+        const sdkLlmsFull = await generateLLMsFull(sdkDocs)
+        await writeFile(perSdkPathTemplate.replace('{sdk}', sdk), sdkLlmsFull)
+      }
     }
   }
 

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -54,6 +54,10 @@ type BuildConfigOptions = {
   llms?: {
     overviewPath?: string
     fullPath?: string
+    // Path template for per-SDK full bundles. The `{sdk}` placeholder is
+    // replaced with each canonical SDK key from `validSdks`. When omitted,
+    // per-SDK bundles are not emitted.
+    perSdkFullPath?: string
   }
   siteFlags?: {
     inputPath: string
@@ -178,6 +182,7 @@ export async function createConfig(config: BuildConfigOptions) {
         ? {
             overviewPath: config.llms.overviewPath,
             fullPath: config.llms.fullPath,
+            perSdkFullPath: config.llms.perSdkFullPath,
           }
         : null,
 

--- a/scripts/lib/llms.test.ts
+++ b/scripts/lib/llms.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest'
+import { filterOutputDocsForSdk, sdkPrefixOfPath, type OutputtedDocsFile } from './llms'
+import type { SDK } from './schemas'
+
+const VALID_SDKS_FIXTURE = ['nextjs', 'react', 'react-router', 'js-frontend'] as const satisfies readonly SDK[]
+
+const makeDoc = (overrides: Partial<OutputtedDocsFile> & Pick<OutputtedDocsFile, 'path'>): OutputtedDocsFile => ({
+  url: '/docs/' + overrides.path.replace(/\.mdx$/, ''),
+  content: '',
+  title: 'Title',
+  sdkScoped: false,
+  availableSdks: null,
+  ...overrides,
+})
+
+describe('sdkPrefixOfPath', () => {
+  test('returns null for paths with no SDK prefix', () => {
+    expect(sdkPrefixOfPath('getting-started/index.mdx', VALID_SDKS_FIXTURE)).toBeNull()
+    expect(sdkPrefixOfPath('index.mdx', VALID_SDKS_FIXTURE)).toBeNull()
+  })
+
+  test('returns the matching SDK for a prefixed path', () => {
+    expect(sdkPrefixOfPath('nextjs/api-doc.mdx', VALID_SDKS_FIXTURE)).toBe('nextjs')
+    expect(sdkPrefixOfPath('js-frontend/api-doc.mdx', VALID_SDKS_FIXTURE)).toBe('js-frontend')
+  })
+
+  test('does not confuse SDKs that share a prefix segment', () => {
+    expect(sdkPrefixOfPath('react-router/api-doc.mdx', VALID_SDKS_FIXTURE)).toBe('react-router')
+    expect(sdkPrefixOfPath('react/api-doc.mdx', VALID_SDKS_FIXTURE)).toBe('react')
+  })
+
+  test('does not match an SDK name that only happens to be a substring', () => {
+    expect(sdkPrefixOfPath('reactish/api-doc.mdx', VALID_SDKS_FIXTURE)).toBeNull()
+  })
+})
+
+describe('filterOutputDocsForSdk', () => {
+  test('keeps non-SDK-scoped docs that have no SDK variants', () => {
+    const docs = [makeDoc({ path: 'index.mdx' }), makeDoc({ path: 'getting-started.mdx' })]
+
+    expect(filterOutputDocsForSdk(docs, 'nextjs', VALID_SDKS_FIXTURE)).toEqual(docs)
+  })
+
+  test('drops the core landing-redirect when a target-SDK variant exists', () => {
+    const landing = makeDoc({ path: 'api-doc.mdx', sdkScoped: false })
+    const nextjsVariant = makeDoc({ path: 'nextjs/api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs', 'react'] })
+    const reactVariant = makeDoc({ path: 'react/api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs', 'react'] })
+    const docs = [landing, nextjsVariant, reactVariant]
+
+    expect(filterOutputDocsForSdk(docs, 'nextjs', VALID_SDKS_FIXTURE)).toEqual([nextjsVariant])
+  })
+
+  test('drops core landing-redirects even when the target SDK has no variant for that doc', () => {
+    const docs = [
+      makeDoc({ path: 'api-doc.mdx', sdkScoped: false }),
+      makeDoc({ path: 'nextjs/api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs', 'react'] }),
+      makeDoc({ path: 'react/api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs', 'react'] }),
+    ]
+
+    expect(filterOutputDocsForSdk(docs, 'js-frontend', VALID_SDKS_FIXTURE)).toEqual([])
+  })
+
+  test('drops single-SDK docs (no variant dir) for SDKs not in their availableSdks', () => {
+    const nextjsOnly = makeDoc({ path: 'api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs'] })
+
+    expect(filterOutputDocsForSdk([nextjsOnly], 'nextjs', VALID_SDKS_FIXTURE)).toEqual([nextjsOnly])
+    expect(filterOutputDocsForSdk([nextjsOnly], 'react', VALID_SDKS_FIXTURE)).toEqual([])
+  })
+
+  test('drops files belonging to other SDKs', () => {
+    const docs = [
+      makeDoc({ path: 'index.mdx' }),
+      makeDoc({ path: 'nextjs/api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs', 'react'] }),
+      makeDoc({ path: 'react/api-doc.mdx', sdkScoped: true, availableSdks: ['nextjs', 'react'] }),
+    ]
+
+    expect(filterOutputDocsForSdk(docs, 'nextjs', VALID_SDKS_FIXTURE).map((d) => d.path)).toEqual([
+      'index.mdx',
+      'nextjs/api-doc.mdx',
+    ])
+  })
+
+  test('handles SDKs that share a prefix segment without leakage', () => {
+    const docs = [
+      makeDoc({ path: 'guides/setup.mdx' }),
+      makeDoc({
+        path: 'react-router/guides/setup.mdx',
+        sdkScoped: true,
+        availableSdks: ['react', 'react-router'],
+      }),
+      makeDoc({ path: 'react/guides/setup.mdx', sdkScoped: true, availableSdks: ['react', 'react-router'] }),
+    ]
+
+    expect(filterOutputDocsForSdk(docs, 'react-router', VALID_SDKS_FIXTURE).map((d) => d.path)).toEqual([
+      'react-router/guides/setup.mdx',
+    ])
+  })
+})

--- a/scripts/lib/llms.ts
+++ b/scripts/lib/llms.ts
@@ -1,5 +1,6 @@
 import type { BuildConfig } from './config'
 import { removeMdxSuffix } from './utils/removeMdxSuffix'
+import type { SDK } from './schemas'
 import yaml from 'yaml'
 
 type Docs = Map<string, string>
@@ -8,9 +9,57 @@ export const writeLLMsFull = async (outputtedDocsFiles: OutputtedDocsFiles) => {
   return outputtedDocsFiles.map((file) => file.content).join('\n')
 }
 
+// Returns the SDK whose folder a dist-relative path lives under, or null for
+// non-SDK-scoped (core) paths. The match requires a `${sdk}/` segment so that
+// SDKs sharing a prefix (e.g. `react` vs `react-router`) are disambiguated.
+export const sdkPrefixOfPath = (filePath: string, validSdks: readonly SDK[]): SDK | null => {
+  for (const sdk of validSdks) {
+    if (filePath === sdk || filePath.startsWith(`${sdk}/`)) return sdk
+  }
+  return null
+}
+
+// Pick the docs that belong in the per-SDK llms-full bundle for `targetSdk`.
+// Rules:
+//   - Files under `{otherSdk}/...` are dropped.
+//   - Files under `{targetSdk}/...` are kept (the real SDK-specific content).
+//   - Core (non-prefixed) files are kept unless either:
+//       a) they're shadowed by any `{anySdk}/<same path>` (the core file is
+//          just a landing-redirect for an SDK-split doc), OR
+//       b) they're SDK-scoped (single-SDK docs without their own variant dir)
+//          and `targetSdk` isn't listed in `availableSdks`.
+export const filterOutputDocsForSdk = <T extends Pick<OutputtedDocsFile, 'path' | 'sdkScoped' | 'availableSdks'>>(
+  docs: T[],
+  targetSdk: SDK,
+  validSdks: readonly SDK[],
+): T[] => {
+  const allPaths = new Set(docs.map((doc) => doc.path))
+  const isShadowed = (corePath: string) => validSdks.some((sdk) => allPaths.has(`${sdk}/${corePath}`))
+
+  return docs.filter((doc) => {
+    const sdk = sdkPrefixOfPath(doc.path, validSdks)
+    if (sdk !== null) return sdk === targetSdk
+    if (isShadowed(doc.path)) return false
+    if (doc.sdkScoped) return doc.availableSdks?.includes(targetSdk) ?? false
+    return true
+  })
+}
+
 export const writeLLMs = async (outputtedDocsFiles: OutputtedDocsFiles) => {
   const list = outputtedDocsFiles.map((page) => `- [${page.title}](${page.url})`).join('\n')
   return `# Clerk\n\n## Docs\n\n${list}`
+}
+
+// Parse the comma-separated `availableSdks` frontmatter field into a list of
+// SDK keys. Returns null when the field is absent or empty.
+const parseAvailableSdks = (raw: unknown): SDK[] | null => {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return trimmed
+    .split(',')
+    .map((sdk) => sdk.trim())
+    .filter((sdk) => sdk.length > 0) as SDK[]
 }
 
 export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { path: string }[]) => {
@@ -33,7 +82,7 @@ export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { pa
     })
     .map((file) => {
       const frontmatter = yaml.parse(file.content.split('---')[1])
-      const { title } = frontmatter
+      const { title, sdkScoped, availableSdks } = frontmatter ?? {}
 
       if (!title) {
         // console.error(`Title not found in ${file.path} - will be ignored from llm txt files`)
@@ -43,9 +92,12 @@ export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { pa
       return {
         ...file,
         title,
+        sdkScoped: sdkScoped === true || sdkScoped === 'true',
+        availableSdks: parseAvailableSdks(availableSdks),
       }
     })
     .filter((page) => page !== null)
 }
 
+export type OutputtedDocsFile = NonNullable<ReturnType<typeof listOutputDocsFiles>[number]>
 type OutputtedDocsFiles = ReturnType<typeof listOutputDocsFiles>


### PR DESCRIPTION
## Summary

Companion to [clerk/clerk#2385](https://github.com/clerk/clerk/pull/2385). That PR replaces `/docs/llms-full.txt` with a small index that links out to per-SDK full-context dumps at `/docs/llms/{sdk}/llms-full.txt`. Those routes call `getFileContents('_llms/{sdk}/llms-full.txt', branch)` from this repo — so we need to actually produce those files in the build.

## What this changes

- New optional `llms.perSdkFullPath` config (template, defaults to `_llms/{sdk}/llms-full.txt`). When set, the build emits one bundle per canonical SDK in `validSdks` after the existing `_llms/llms-full.txt`.
- `filterOutputDocsForSdk(docs, targetSdk, validSdks)` decides what goes in each per-SDK bundle:
  - Files under `{targetSdk}/…` — kept (the real SDK-specific content).
  - Files under `{otherSdk}/…` — dropped.
  - Core (non-prefixed) files — dropped if shadowed by any `{anySdk}/<same path>` (those core files are landing-redirect pages).
  - Single-SDK docs that don't get their own variant directory (`sdkScoped: true` at the core path) — included only when `targetSdk` is in `availableSdks`.
- `listOutputDocsFiles` now also extracts `sdkScoped` + `availableSdks` from each doc's frontmatter so the filter has what it needs for single-SDK docs.
- The old `_llms/llms-full.txt` is preserved, it will still be needed until clerk/clerk is updated

The `{sdk}` keys in the path are the canonical 16 SDKs from `VALID_SDKS` — matching what `clerk/clerk` resolves migration aliases to via `sdkMap`.

## Verification

- `pnpm exec vitest run` — 191/191 tests pass, including:
  - `scripts/lib/llms.test.ts` — unit tests for `sdkPrefixOfPath` (incl. `react` vs `react-router` disambiguation) and `filterOutputDocsForSdk` (core/shadowed/single-SDK/other-SDK cases).
  - `scripts/build-docs.test.ts` — two new integration tests covering the per-SDK output (multi-SDK doc with `.react.mdx` variant + shared core doc; and skipping emission for SDKs with zero content).
- `pnpm run build` against the real docs:
  - Emits all 16 per-SDK bundles plus the existing combined one.
  - Sample sizes: combined 367k lines · `nextjs` 123k · `react` 119k · `js-frontend` 114k · `go` 96k.
  - Each per-SDK file has zero `redirectPage:` frontmatter and a single distinct `activeSdk:` value matching the bundle.

## Follow-ups

- Once this lands, the routes added in clerk/clerk#2385 will start serving real content. Until then those routes 404 (called out in that PR's testing notes).

Made with [Cursor](https://cursor.com)