### PR TITLE
Group SDK-scoped pages under sub-headers in /docs/llms.txt

### DIFF
--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -7487,6 +7487,108 @@ sdk: nextjs, react
 - [SDK Doc]({{SITE_URL}}/docs/react/sdk-doc)`)
   })
 
+  test('Should group reference/<sdk>/ pages and URL-aliased SDKs under their SDK sub-header', async () => {
+    const { tempDir, readFile } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              { title: 'Generic Guide', href: '/docs/generic-guide' },
+              { title: 'Vue Plugin', href: '/docs/reference/vue/clerk-plugin' },
+              { title: 'Astro Middleware', href: '/docs/reference/astro/clerk-middleware' },
+              { title: 'JS Overview', href: '/docs/reference/javascript/overview' },
+              { title: 'Express Middleware', href: '/docs/reference/express/clerk-middleware' },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/generic-guide.mdx',
+        content: `---
+title: Generic Guide
+description: A generic guide
+---
+
+# Generic Guide
+`,
+      },
+      {
+        path: './docs/reference/vue/clerk-plugin.mdx',
+        content: `---
+title: clerkPlugin
+description: Vue clerkPlugin reference
+---
+
+# clerkPlugin
+`,
+      },
+      {
+        path: './docs/reference/astro/clerk-middleware.mdx',
+        content: `---
+title: clerkMiddleware (Astro)
+description: Astro middleware reference
+---
+
+# clerkMiddleware
+`,
+      },
+      {
+        path: './docs/reference/javascript/overview.mdx',
+        content: `---
+title: JavaScript Overview
+description: JS frontend SDK overview
+---
+
+# JavaScript Overview
+`,
+      },
+      {
+        path: './docs/reference/express/clerk-middleware.mdx',
+        content: `---
+title: clerkMiddleware (Express)
+description: Express middleware reference
+---
+
+# clerkMiddleware
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['vue', 'astro', 'js-frontend', 'expressjs'],
+        llms: {
+          overviewPath: 'llms.txt',
+        },
+      }),
+    )
+
+    expect(await readFile('./dist/llms.txt')).toEqual(`# Clerk
+
+## Docs
+
+- [Generic Guide]({{SITE_URL}}/docs/generic-guide)
+
+### Vue
+
+- [clerkPlugin]({{SITE_URL}}/docs/reference/vue/clerk-plugin)
+
+### Astro
+
+- [clerkMiddleware (Astro)]({{SITE_URL}}/docs/reference/astro/clerk-middleware)
+
+### JavaScript
+
+- [JavaScript Overview]({{SITE_URL}}/docs/reference/javascript/overview)
+
+### Express
+
+- [clerkMiddleware (Express)]({{SITE_URL}}/docs/reference/express/clerk-middleware)`)
+  })
+
   test('Should output llms-full.txt full pages', async () => {
     const { tempDir, readFile } = await createTempFiles([
       {

--- a/scripts/build-docs.test.ts
+++ b/scripts/build-docs.test.ts
@@ -7425,6 +7425,68 @@ description: Generated API docs
 - [API Documentation]({{SITE_URL}}/docs/api-doc)`)
   })
 
+  test('Should group SDK-scoped pages under sub-headers in llms.txt overview', async () => {
+    const { tempDir, readFile } = await createTempFiles([
+      {
+        path: './docs/manifest.json',
+        content: JSON.stringify({
+          navigation: [
+            [
+              { title: 'Generic Doc', href: '/docs/generic-doc' },
+              { title: 'SDK Doc', href: '/docs/sdk-doc' },
+            ],
+          ],
+        }),
+      },
+      {
+        path: './docs/generic-doc.mdx',
+        content: `---
+title: Generic Doc
+description: A generic guide
+---
+
+# Generic Doc
+`,
+      },
+      {
+        path: './docs/sdk-doc.mdx',
+        content: `---
+title: SDK Doc
+description: An SDK-scoped guide
+sdk: nextjs, react
+---
+
+# SDK Doc
+`,
+      },
+    ])
+
+    await build(
+      await createConfig({
+        ...baseConfig,
+        basePath: tempDir,
+        validSdks: ['nextjs', 'react'],
+        llms: {
+          overviewPath: 'llms.txt',
+        },
+      }),
+    )
+
+    expect(await readFile('./dist/llms.txt')).toEqual(`# Clerk
+
+## Docs
+
+- [Generic Doc]({{SITE_URL}}/docs/generic-doc)
+
+### Next.js
+
+- [SDK Doc]({{SITE_URL}}/docs/nextjs/sdk-doc)
+
+### React
+
+- [SDK Doc]({{SITE_URL}}/docs/react/sdk-doc)`)
+  })
+
   test('Should output llms-full.txt full pages', async () => {
     const { tempDir, readFile } = await createTempFiles([
       {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1207,7 +1207,7 @@ ${yaml.stringify({
     }
 
     if (config.llms?.overviewPath) {
-      const llms = await generateLLMs(outputtedDocsFiles)
+      const llms = await generateLLMs(outputtedDocsFiles, config.validSdks)
       await writeFile(config.llms.overviewPath, llms)
     }
   }

--- a/scripts/lib/llms.test.ts
+++ b/scripts/lib/llms.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, test } from 'vitest'
-import { listOutputDocsFiles, normalizeFrontmatterDescription, writeLLMs } from './llms'
+import { formatLLMsDocLine, listOutputDocsFiles, normalizeFrontmatterDescription, writeLLMs } from './llms'
+
+describe('formatLLMsDocLine', () => {
+  test('appends description after a colon when present', () => {
+    expect(
+      formatLLMsDocLine({
+        title: 'Quickstart',
+        url: 'https://example.com/docs/quickstart',
+        description: 'Get up and running with Clerk in minutes.',
+        path: 'quickstart.mdx',
+        content: '',
+      }),
+    ).toBe('- [Quickstart](https://example.com/docs/quickstart): Get up and running with Clerk in minutes.')
+  })
+
+  test('omits the colon when no description is provided', () => {
+    expect(
+      formatLLMsDocLine({
+        title: 'Quickstart',
+        url: 'https://example.com/docs/quickstart',
+        description: undefined,
+        path: 'quickstart.mdx',
+        content: '',
+      }),
+    ).toBe('- [Quickstart](https://example.com/docs/quickstart)')
+  })
+})
 
 describe('normalizeFrontmatterDescription', () => {
   test('returns trimmed string when description is non-empty', () => {

--- a/scripts/lib/llms.ts
+++ b/scripts/lib/llms.ts
@@ -1,16 +1,70 @@
 import type { BuildConfig } from './config'
 import { removeMdxSuffix } from './utils/removeMdxSuffix'
 import yaml from 'yaml'
+import type { SDK } from './schemas'
 
 type Docs = Map<string, string>
+
+// Display names for SDKs when rendered as sub-headers in llms.txt.
+// Keep these in sync with VALID_SDKS in ./schemas.ts.
+const SDK_DISPLAY_NAMES: Record<SDK, string> = {
+  nextjs: 'Next.js',
+  react: 'React',
+  'js-frontend': 'JavaScript',
+  'chrome-extension': 'Chrome Extension',
+  expo: 'Expo',
+  android: 'Android',
+  ios: 'iOS',
+  expressjs: 'Express',
+  fastify: 'Fastify',
+  'react-router': 'React Router',
+  'tanstack-react-start': 'TanStack React Start',
+  go: 'Go',
+  astro: 'Astro',
+  nuxt: 'Nuxt',
+  vue: 'Vue',
+  ruby: 'Ruby',
+}
+
+const getSdkFromPath = (path: string, validSdks: readonly SDK[]): SDK | null => {
+  const firstSegment = path.split('/')[0]
+  return validSdks.includes(firstSegment as SDK) ? (firstSegment as SDK) : null
+}
+
+const getSdkDisplayName = (sdk: SDK): string => SDK_DISPLAY_NAMES[sdk] ?? sdk
 
 export const writeLLMsFull = async (outputtedDocsFiles: OutputtedDocsFiles) => {
   return outputtedDocsFiles.map((file) => file.content).join('\n')
 }
 
-export const writeLLMs = async (outputtedDocsFiles: OutputtedDocsFiles) => {
-  const list = outputtedDocsFiles.map((page) => `- [${page.title}](${page.url})`).join('\n')
-  return `# Clerk\n\n## Docs\n\n${list}`
+export const writeLLMs = async (outputtedDocsFiles: OutputtedDocsFiles, validSdks: readonly SDK[]) => {
+  const generic: OutputtedDocsFiles = []
+  const bySdk = new Map<SDK, OutputtedDocsFiles>()
+
+  for (const page of outputtedDocsFiles) {
+    const sdk = getSdkFromPath(page.path, validSdks)
+    if (sdk === null) {
+      generic.push(page)
+    } else {
+      const list = bySdk.get(sdk) ?? []
+      list.push(page)
+      bySdk.set(sdk, list)
+    }
+  }
+
+  const formatPage = (page: OutputtedDocsFiles[number]) => `- [${page.title}](${page.url})`
+
+  const sections: string[] = [`## Docs`, generic.map(formatPage).join('\n')]
+
+  // Emit SDK sections in the order they appear in validSdks for stable, predictable output.
+  for (const sdk of validSdks) {
+    const pages = bySdk.get(sdk)
+    if (!pages || pages.length === 0) continue
+    sections.push(`### ${getSdkDisplayName(sdk)}`)
+    sections.push(pages.map(formatPage).join('\n'))
+  }
+
+  return `# Clerk\n\n${sections.filter((section) => section.length > 0).join('\n\n')}`
 }
 
 export const listOutputDocsFiles = (config: BuildConfig, docs: Docs, files: { path: string }[]) => {

--- a/scripts/lib/llms.ts
+++ b/scripts/lib/llms.ts
@@ -26,9 +26,29 @@ const SDK_DISPLAY_NAMES: Record<SDK, string> = {
   ruby: 'Ruby',
 }
 
+// Some SDKs are referenced in URL/file paths under a slug that doesn't match
+// their SDK key (e.g. /docs/reference/javascript/... is the js-frontend SDK).
+// This map allows those path segments to be recognized as SDK-scoped.
+const PATH_SEGMENT_SDK_ALIASES: Record<string, SDK> = {
+  javascript: 'js-frontend',
+  express: 'expressjs',
+}
+
 const getSdkFromPath = (path: string, validSdks: readonly SDK[]): SDK | null => {
-  const firstSegment = path.split('/')[0]
-  return validSdks.includes(firstSegment as SDK) ? (firstSegment as SDK) : null
+  // Skip the trailing file segment (e.g. "expo.mdx") - we only want directory
+  // segments, so a generic doc whose filename contains an SDK name is not
+  // misclassified as SDK-scoped.
+  const segments = path.split('/').slice(0, -1)
+  for (const segment of segments) {
+    if (validSdks.includes(segment as SDK)) {
+      return segment as SDK
+    }
+    const aliased = PATH_SEGMENT_SDK_ALIASES[segment]
+    if (aliased && validSdks.includes(aliased)) {
+      return aliased
+    }
+  }
+  return null
 }
 
 const getSdkDisplayName = (sdk: SDK): string => SDK_DISPLAY_NAMES[sdk] ?? sdk

--- a/scripts/lib/llms.ts
+++ b/scripts/lib/llms.ts
@@ -55,6 +55,9 @@ export const writeLLMsFull = async (outputtedDocsFiles: OutputtedDocsFiles) => {
   return outputtedDocsFiles.map((file) => file.content).join('\n')
 }
 
+export const formatLLMsDocLine = (page: OutputtedDocsFiles[number]) =>
+  page.description ? `- [${page.title}](${page.url}): ${page.description}` : `- [${page.title}](${page.url})`
+
 export const writeLLMs = async (outputtedDocsFiles: OutputtedDocsFiles, validSdks: readonly SDK[]) => {
   const generic: OutputtedDocsFiles = []
   const bySdk = new Map<SDK, OutputtedDocsFiles>()
@@ -70,17 +73,14 @@ export const writeLLMs = async (outputtedDocsFiles: OutputtedDocsFiles, validSdk
     }
   }
 
-  const formatPage = (page: OutputtedDocsFiles[number]) =>
-    page.description ? `- [${page.title}](${page.url}): ${page.description}` : `- [${page.title}](${page.url})`
-
-  const sections: string[] = [`## Docs`, generic.map(formatPage).join('\n')]
+  const sections: string[] = [`## Docs`, generic.map(formatLLMsDocLine).join('\n')]
 
   // Emit SDK sections in the order they appear in validSdks for stable, predictable output.
   for (const sdk of validSdks) {
     const pages = bySdk.get(sdk)
     if (!pages || pages.length === 0) continue
     sections.push(`### ${getSdkDisplayName(sdk)}`)
-    sections.push(pages.map(formatPage).join('\n'))
+    sections.push(pages.map(formatLLMsDocLine).join('\n'))
   }
 
   return `# Clerk\n\n${sections.filter((section) => section.length > 0).join('\n\n')}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- [/docs/llms.txt](https://clerk.com/docs/pr/cursor-llms-txt-sdk-subheaders-859f/llms.txt)

### What does this solve? What changed?

Restructures the auto-generated `/docs/llms.txt` overview so that SDK-scoped pages are grouped under per-SDK sub-headers, instead of being interleaved as one flat list. Generic (non-SDK) pages are listed first under `## Docs`, then each SDK gets its own `### <SDK Display Name>` section.

For example:

```
# Clerk

## Docs

- [Generic Doc]({{SITE_URL}}/docs/generic-doc)

### Next.js

- [SDK Doc]({{SITE_URL}}/docs/nextjs/sdk-doc)

### React

- [SDK Doc]({{SITE_URL}}/docs/react/sdk-doc)
```

A page is treated as SDK-scoped if **any directory segment** in its path matches a known SDK. This covers two patterns:

1. SDK-variant outputs from the build, e.g. `nextjs/api-doc.mdx`.
2. Reference-style docs that live under a non-SDK top-level folder, e.g. `reference/vue/clerk-plugin.mdx`, `reference/astro/clerk-middleware.mdx`, `reference/nuxt/integration.mdx`.

The trailing filename segment is intentionally excluded so a generic doc like `guides/.../core-2/expo.mdx` is not misclassified as an Expo-scoped page.

Two URL slugs don't match their SDK key, so they're recognized via an alias map:

- `javascript` → `js-frontend`
- `express` → `expressjs`

Implementation details:

- `scripts/lib/llms.ts` – `writeLLMs` buckets pages with `getSdkFromPath`, which scans directory segments and consults `PATH_SEGMENT_SDK_ALIASES`. Generic pages are emitted first; SDK sections follow in the order defined by `validSdks` for stable, deterministic output. A `SDK_DISPLAY_NAMES` map provides human-friendly section titles (e.g. `nextjs` → `Next.js`, `tanstack-react-start` → `TanStack React Start`, `js-frontend` → `JavaScript`).
- `scripts/build-docs.ts` – passes `config.validSdks` into `writeLLMs` so the grouping logic shares the canonical SDK list.
- `scripts/build-docs.test.ts` – adds two new tests:
  - `Should group SDK-scoped pages under sub-headers in llms.txt overview` – covers the SDK-variant case (`dist/<sdk>/foo.mdx`).
  - `Should group reference/<sdk>/ pages and URL-aliased SDKs under their SDK sub-header` – covers `reference/vue`, `reference/astro`, `reference/javascript` (→ `js-frontend`) and `reference/express` (→ `expressjs`).

All 150 existing build-docs tests pass.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0784fb6-6a67-4b44-b520-714b9a19859f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0784fb6-6a67-4b44-b520-714b9a19859f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

