### PR TITLE
chore: Add docs for appearance options elevation

### DIFF
--- a/docs/guides/customizing-clerk/appearance-prop/captcha.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/captcha.mdx
@@ -4,7 +4,7 @@ description: Utilize Clerk's captcha prop in order to change the appearance of t
 sdk: astro, chrome-extension, expo, nextjs, nuxt, react, react-router, tanstack-react-start, vue, js-frontend, fastify, expressjs, go, ruby
 ---
 
-{/* JS file: https://github.com/clerk/javascript/blob/main/packages/types/src/appearance.ts#L538 */}
+{/* JS file: https://github.com/clerk/javascript/blob/main/packages/ui/src/internal/appearance.ts */}
 
 The `captcha` property can be used to change the appearance of the CAPTCHA widget.
 

--- a/docs/guides/customizing-clerk/appearance-prop/options.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/options.mdx
@@ -6,7 +6,7 @@ sdk: astro, chrome-extension, expo, nextjs, nuxt, react, react-router, tanstack-
 
 {/* JS file: https://github.com/clerk/javascript/blob/main/packages/types/src/appearance.ts#L538 */}
 
-The `options` property can be used to change the layout of the [`<SignIn/>`](/docs/reference/components/authentication/sign-in) and [`<SignUp/>`](/docs/reference/components/authentication/sign-up) components, as well as set important links to your support, terms, and privacy pages.
+The `options` property can be used to change the layout and behavior of Clerk's prebuilt components, as well as set important links to your support, terms, and privacy pages.
 
 ## Properties
 
@@ -15,6 +15,13 @@ The `options` property can be used to change the layout of the [`<SignIn/>`](/do
   - `boolean`
 
   Whether to enable animations inside the components. Defaults to `true`.
+
+  ---
+
+  - `elevation`
+  - `'raised' | 'flush'`
+
+  Controls the visual elevation of card-based components. `'raised'` renders the card with its border, box-shadow, border-radius, and padding. `'flush'` removes the card border, box-shadow, border-radius, outer padding, and footer background so the component sits flat against its container. Applies to page-mounted card-based components such as [`<SignIn />`](/docs/reference/components/authentication/sign-in), [`<SignUp />`](/docs/reference/components/authentication/sign-up), [`<Waitlist />`](/docs/reference/components/authentication/waitlist), [`<CreateOrganization />`](/docs/reference/components/organization/create-organization), and [`<OrganizationList />`](/docs/reference/components/organization/organization-list). Does not affect profile components ([`<UserProfile />`](/docs/reference/components/user/user-profile), [`<OrganizationProfile />`](/docs/reference/components/organization/organization-profile)) or popover components ([`<UserButton />`](/docs/reference/components/user/user-button), [`<OrganizationSwitcher />`](/docs/reference/components/organization/organization-switcher)), which always render as raised. When a component is opened as a modal, it always renders as raised regardless of this setting. Defaults to `'raised'`.
 
   ---
 

--- a/docs/guides/customizing-clerk/appearance-prop/options.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/options.mdx
@@ -1,23 +1,16 @@
 ---
 title: '`Options` prop'
-description: Utilize Clerk's options prop in order to change the layout of the <SignIn /> and <SignUp /> components, as well as set important links to your support, terms and privacy pages.
+description: Utilize Clerk's options prop in order to change the layout and behavior of Clerk's prebuilt components, as well as set important links to your support, terms, and privacy pages.
 sdk: astro, chrome-extension, expo, nextjs, nuxt, react, react-router, tanstack-react-start, vue, js-frontend, fastify, expressjs, go, ruby
 ---
 
-{/* JS file: https://github.com/clerk/javascript/blob/main/packages/types/src/appearance.ts#L538 */}
+{/* JS file: https://github.com/clerk/javascript/blob/main/packages/ui/src/internal/appearance.ts */}
 
 The `options` property can be used to change the layout and behavior of Clerk's prebuilt components, as well as set important links to your support, terms, and privacy pages.
 
 ## Properties
 
 <Properties>
-  - `autoFocus`
-  - `boolean`
-
-  Whether inputs automatically receive focus when a component is mounted. Set to `false` to prevent components from auto-focusing any input fields. Defaults to `true`.
-
-  ---
-
   - `animations`
   - `boolean`
 
@@ -25,10 +18,17 @@ The `options` property can be used to change the layout and behavior of Clerk's 
 
   ---
 
+  - `autoFocus`
+  - `boolean`
+
+  Whether inputs automatically receive focus when a component is mounted. Set to `false` to prevent components from auto-focusing any input fields. Defaults to `true`.
+
+  ---
+
   - `elevation`
   - `'raised' | 'flush'`
 
-  Controls the visual elevation of card-based components. `'raised'` renders the card with its border, box-shadow, border-radius, and padding. `'flush'` removes the card border, box-shadow, border-radius, outer padding, and footer background so the component sits flat against its container. Applies to page-mounted card-based components such as [`<SignIn />`](/docs/reference/components/authentication/sign-in), [`<SignUp />`](/docs/reference/components/authentication/sign-up), [`<Waitlist />`](/docs/reference/components/authentication/waitlist), [`<CreateOrganization />`](/docs/reference/components/organization/create-organization), and [`<OrganizationList />`](/docs/reference/components/organization/organization-list). Does not affect profile components ([`<UserProfile />`](/docs/reference/components/user/user-profile), [`<OrganizationProfile />`](/docs/reference/components/organization/organization-profile)) or popover components ([`<UserButton />`](/docs/reference/components/user/user-button), [`<OrganizationSwitcher />`](/docs/reference/components/organization/organization-switcher)), which always render as raised. When a component is opened as a modal, it always renders as raised regardless of this setting. Defaults to `'raised'`.
+  Controls the visual elevation of card-based components. `'raised'` renders the card with its border, box-shadow, border-radius, and padding. `'flush'` removes the card border, box-shadow, border-radius, outer padding, and footer background so the component sits flat against its container. Applies to page-mounted card-based components such as [`<SignIn />`](/docs/reference/components/authentication/sign-in), [`<SignUp />`](/docs/reference/components/authentication/sign-up), [`<Waitlist />`](/docs/reference/components/authentication/waitlist), [`<CreateOrganization />`](/docs/reference/components/organization/create-organization), [`<OrganizationList />`](/docs/reference/components/organization/organization-list), and session task components ([`<TaskChooseOrganization />`](/docs/reference/components/authentication/task-choose-organization), [`<TaskResetPassword />`](/docs/reference/components/authentication/task-reset-password), [`<TaskSetupMFA />`](/docs/reference/components/authentication/task-setup-mfa)). Does not affect profile components ([`<UserProfile />`](/docs/reference/components/user/user-profile), [`<OrganizationProfile />`](/docs/reference/components/organization/organization-profile)) or popover components ([`<UserButton />`](/docs/reference/components/user/user-button), [`<OrganizationSwitcher />`](/docs/reference/components/organization/organization-switcher)), which always render as raised. When a component is opened as a modal, it always renders as raised regardless of this setting. Defaults to `'raised'`.
 
   ---
 

--- a/docs/guides/customizing-clerk/appearance-prop/overview.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/overview.mdx
@@ -4,7 +4,7 @@ description: Utilize Clerk's appearance property in order to share styles across
 sdk: astro, chrome-extension, expo, nextjs, nuxt, react, react-router, tanstack-react-start, vue, js-frontend, fastify, expressjs, go, ruby
 ---
 
-{/* JS file: https://github.com/clerk/javascript/blob/main/packages/types/src/appearance.ts#L619 */}
+{/* JS file: https://github.com/clerk/javascript/blob/main/packages/ui/src/internal/appearance.ts */}
 
 Customizing the appearance of Clerk components is a powerful way to make your application look and feel unique. Clerk provides a way to customize the appearance of its components using the `appearance` prop.
 

--- a/docs/guides/customizing-clerk/appearance-prop/variables.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/variables.mdx
@@ -4,7 +4,7 @@ description: Utilize Clerk's variables property in order to adjust the general s
 sdk: astro, chrome-extension, expo, nextjs, nuxt, react, react-router, tanstack-react-start, vue, js-frontend, fastify, expressjs, go, ruby
 ---
 
-{/* JS file: https://github.com/clerk/javascript/blob/main/packages/types/src/appearance.ts#L399 */}
+{/* JS file: https://github.com/clerk/javascript/blob/main/packages/ui/src/internal/appearance.ts */}
 
 The `variables` property is used to adjust the general styles of the component's base theme, like colors, backgrounds, and typography.
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/carp-appearance-flush-option/nextjs/guides/customizing-clerk/appearance-prop/options

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Adds `elevation="raise|flush"` docs

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

-

### Other resources

- https://github.com/clerk/javascript/pull/8510
