### PR TITLE
Add example for multiple children on <SignUpButton>/<SignInButton> components

### DIFF
--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -317,7 +317,7 @@ If you want to render multiple elements, wrap them in a single parent element:
   - `children?`
   - `React.ReactNode`
 
-  A single child element or text node to wrap in the `<SignInButton>`. If you want to render multiple elements, wrap them in a single parent element.
+  Children you want to wrap the `<SignInButton>` in. If you want to render multiple elements, wrap them in a single parent element.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -252,6 +252,17 @@ You can create a custom button by wrapping your own button, or button text, in t
   ```
 </If>
 
+If you want to render multiple elements, wrap them in a single parent element:
+
+```jsx
+<SignInButton>
+  <button>
+    <span>Continue</span>
+    <span aria-hidden="true"> →</span>
+  </button>
+</SignInButton>
+```
+
 ## Properties
 
 <Properties>
@@ -306,7 +317,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   - `children?`
   - `React.ReactNode`
 
-  Children you want to wrap the `<SignInButton>` in.
+  A single child element or text node to wrap in the `<SignInButton>`. If you want to render multiple elements, wrap them in a single parent element.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -254,14 +254,40 @@ You can create a custom button by wrapping your own button, or button text, in t
 
 If you want to render multiple elements, wrap them in a single parent element:
 
-```jsx
-<SignInButton>
-  <button>
-    <span>Continue</span>
-    <span aria-hidden="true"> →</span>
-  </button>
-</SignInButton>
-```
+<If sdk={['nextjs', 'react', 'chrome-extension', 'expo', 'react-router', 'tanstack-react-start']}>
+  ```jsx
+  <SignInButton>
+    <button>
+      <span>Continue</span>
+      <span aria-hidden="true"> →</span>
+    </button>
+  </SignInButton>
+  ```
+</If>
+
+<If sdk="astro">
+  ```astro
+  <SignInButton asChild>
+    <button>
+      <span>Continue</span>
+      <span aria-hidden="true"> →</span>
+    </button>
+  </SignInButton>
+  ```
+</If>
+
+<If sdk={['nuxt', 'vue']}>
+  ```vue
+  <template>
+    <SignInButton>
+      <button>
+        <span>Continue</span>
+        <span aria-hidden="true"> →</span>
+      </button>
+    </SignInButton>
+  </template>
+  ```
+</If>
 
 ## Properties
 

--- a/docs/reference/components/unstyled/sign-in-button.mdx
+++ b/docs/reference/components/unstyled/sign-in-button.mdx
@@ -317,7 +317,7 @@ If you want to render multiple elements, wrap them in a single parent element:
   - `children?`
   - `React.ReactNode`
 
-  Children you want to wrap the `<SignInButton>` in. If you want to render multiple elements, wrap them in a single parent element.
+  Children you want to wrap the `<SignInButton>` in. Only accepts one child; if you want to render multiple elements, wrap them in a single parent element.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-up-button.mdx
+++ b/docs/reference/components/unstyled/sign-up-button.mdx
@@ -115,7 +115,7 @@ The `<SignUpButton>` component is a button that, by default, links to your app's
 
 ### Custom usage
 
-You can create a custom button by wrapping your own button, or button text, in the `<SignUpButton>` component. If you want to render multiple elements, wrap them in a single parent element such as `<button>` or `<span>`.
+You can create a custom button by wrapping your own button, or button text, in the `<SignUpButton>` component.
 
 <If sdk="nextjs">
   ```jsx {{ filename: 'app/page.tsx' }}
@@ -124,10 +124,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>
-          <span>Get started</span>
-          <span aria-hidden="true"> →</span>
-        </button>
+        <button>Custom sign up button</button>
       </SignUpButton>
     )
   }
@@ -141,10 +138,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   function App() {
     return (
       <SignUpButton>
-        <button>
-          <span>Get started</span>
-          <span aria-hidden="true"> →</span>
-        </button>
+        <button>Custom sign up button</button>
       </SignUpButton>
     )
   }
@@ -162,10 +156,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   ---
 
   <SignUpButton asChild>
-    <button>
-      <span>Get started</span>
-      <span aria-hidden="true"> →</span>
-    </button>
+    <button>Custom sign up button</button>
   </SignUpButton>
   ```
 </If>
@@ -179,10 +170,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>
-          <span>Get started</span>
-          <span aria-hidden="true"> →</span>
-        </button>
+        <button>Custom sign up button</button>
       </SignUpButton>
     )
   }
@@ -196,10 +184,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>
-          <span>Get started</span>
-          <span aria-hidden="true"> →</span>
-        </button>
+        <button>Custom sign up button</button>
       </SignUpButton>
     )
   }
@@ -213,10 +198,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>
-          <span>Get started</span>
-          <span aria-hidden="true"> →</span>
-        </button>
+        <button>Custom sign up button</button>
       </SignUpButton>
     )
   }
@@ -231,10 +213,7 @@ You can create a custom button by wrapping your own button, or button text, in t
 
   <template>
     <SignUpButton>
-      <button>
-        <span>Get started</span>
-        <span aria-hidden="true"> →</span>
-      </button>
+      <button>Custom sign up button</button>
     </SignUpButton>
   </template>
   ```
@@ -248,10 +227,7 @@ You can create a custom button by wrapping your own button, or button text, in t
 
   <template>
     <SignUpButton>
-      <button>
-        <span>Get started</span>
-        <span aria-hidden="true"> →</span>
-      </button>
+      <button>Custom sign up button</button>
     </SignUpButton>
   </template>
   ```
@@ -269,15 +245,23 @@ You can create a custom button by wrapping your own button, or button text, in t
   function Home() {
     return (
       <SignUpButton>
-        <button>
-          <span>Get started</span>
-          <span aria-hidden="true"> →</span>
-        </button>
+        <button>Custom sign up button</button>
       </SignUpButton>
     )
   }
   ```
 </If>
+
+If you want to render multiple elements, wrap them in a single parent element:
+
+```jsx
+<SignUpButton>
+  <button>
+    <span>Get started</span>
+    <span aria-hidden="true"> →</span>
+  </button>
+</SignUpButton>
+```
 
 ## Properties
 

--- a/docs/reference/components/unstyled/sign-up-button.mdx
+++ b/docs/reference/components/unstyled/sign-up-button.mdx
@@ -115,7 +115,7 @@ The `<SignUpButton>` component is a button that, by default, links to your app's
 
 ### Custom usage
 
-You can create a custom button by wrapping your own button, or button text, in the `<SignUpButton>` component.
+You can create a custom button by wrapping your own button, or button text, in the `<SignUpButton>` component. If you want to render multiple elements, wrap them in a single parent element such as `<button>` or `<span>`.
 
 <If sdk="nextjs">
   ```jsx {{ filename: 'app/page.tsx' }}
@@ -124,7 +124,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>Custom sign up button</button>
+        <button>
+          <span>Get started</span>
+          <span aria-hidden="true"> →</span>
+        </button>
       </SignUpButton>
     )
   }
@@ -138,7 +141,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   function App() {
     return (
       <SignUpButton>
-        <button>Custom sign up button</button>
+        <button>
+          <span>Get started</span>
+          <span aria-hidden="true"> →</span>
+        </button>
       </SignUpButton>
     )
   }
@@ -156,7 +162,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   ---
 
   <SignUpButton asChild>
-    <button>Custom sign up button</button>
+    <button>
+      <span>Get started</span>
+      <span aria-hidden="true"> →</span>
+    </button>
   </SignUpButton>
   ```
 </If>
@@ -170,7 +179,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>Custom sign up button</button>
+        <button>
+          <span>Get started</span>
+          <span aria-hidden="true"> →</span>
+        </button>
       </SignUpButton>
     )
   }
@@ -184,7 +196,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>Custom sign up button</button>
+        <button>
+          <span>Get started</span>
+          <span aria-hidden="true"> →</span>
+        </button>
       </SignUpButton>
     )
   }
@@ -198,7 +213,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   export default function Home() {
     return (
       <SignUpButton>
-        <button>Custom sign up button</button>
+        <button>
+          <span>Get started</span>
+          <span aria-hidden="true"> →</span>
+        </button>
       </SignUpButton>
     )
   }
@@ -213,7 +231,10 @@ You can create a custom button by wrapping your own button, or button text, in t
 
   <template>
     <SignUpButton>
-      <button>Custom sign up button</button>
+      <button>
+        <span>Get started</span>
+        <span aria-hidden="true"> →</span>
+      </button>
     </SignUpButton>
   </template>
   ```
@@ -227,7 +248,10 @@ You can create a custom button by wrapping your own button, or button text, in t
 
   <template>
     <SignUpButton>
-      <button>Custom sign up button</button>
+      <button>
+        <span>Get started</span>
+        <span aria-hidden="true"> →</span>
+      </button>
     </SignUpButton>
   </template>
   ```
@@ -245,7 +269,10 @@ You can create a custom button by wrapping your own button, or button text, in t
   function Home() {
     return (
       <SignUpButton>
-        <button>Custom sign up button</button>
+        <button>
+          <span>Get started</span>
+          <span aria-hidden="true"> →</span>
+        </button>
       </SignUpButton>
     )
   }
@@ -306,7 +333,7 @@ You can create a custom button by wrapping your own button, or button text, in t
   - `children?`
   - `React.ReactNode`
 
-  Children you want to wrap the `<SignUpButton>` in.
+  A single child element or text node to wrap in the `<SignUpButton>`. If you want to render multiple elements, wrap them in a single parent element.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-up-button.mdx
+++ b/docs/reference/components/unstyled/sign-up-button.mdx
@@ -317,7 +317,7 @@ If you want to render multiple elements, wrap them in a single parent element:
   - `children?`
   - `React.ReactNode`
 
-  A single child element or text node to wrap in the `<SignUpButton>`. If you want to render multiple elements, wrap them in a single parent element.
+  Children you want to wrap the `<SignUpButton>` in. If you want to render multiple elements, wrap them in a single parent element.
 
   ---
 

--- a/docs/reference/components/unstyled/sign-up-button.mdx
+++ b/docs/reference/components/unstyled/sign-up-button.mdx
@@ -254,14 +254,40 @@ You can create a custom button by wrapping your own button, or button text, in t
 
 If you want to render multiple elements, wrap them in a single parent element:
 
-```jsx
-<SignUpButton>
-  <button>
-    <span>Get started</span>
-    <span aria-hidden="true"> →</span>
-  </button>
-</SignUpButton>
-```
+<If sdk={['nextjs', 'react', 'chrome-extension', 'expo', 'react-router', 'tanstack-react-start']}>
+  ```jsx
+  <SignUpButton>
+    <button>
+      <span>Get started</span>
+      <span aria-hidden="true"> →</span>
+    </button>
+  </SignUpButton>
+  ```
+</If>
+
+<If sdk="astro">
+  ```astro
+  <SignUpButton asChild>
+    <button>
+      <span>Get started</span>
+      <span aria-hidden="true"> →</span>
+    </button>
+  </SignUpButton>
+  ```
+</If>
+
+<If sdk={['nuxt', 'vue']}>
+  ```vue
+  <template>
+    <SignUpButton>
+      <button>
+        <span>Get started</span>
+        <span aria-hidden="true"> →</span>
+      </button>
+    </SignUpButton>
+  </template>
+  ```
+</If>
 
 ## Properties
 
@@ -317,7 +343,7 @@ If you want to render multiple elements, wrap them in a single parent element:
   - `children?`
   - `React.ReactNode`
 
-  Children you want to wrap the `<SignUpButton>` in. If you want to render multiple elements, wrap them in a single parent element.
+  Children you want to wrap the `<SignUpButton>` in. Only accepts one child; if you want to render multiple elements, wrap them in a single parent element.
 
   ---
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-docs-11718/nextjs/reference/components/unstyled/sign-up-button
- https://clerk.com/docs/pr/ss-docs-11718/nextjs/reference/components/unstyled/sign-in-button

### What does this solve? What changed?

A customer hit an error when passing multiple sibling elements directly as children to `SignUpButton`. The previous docs showed custom content usage, but they did not make the single-child requirement explicit. This update clarifies that multiple elements need to be wrapped in a single parent element and adds an example that demonstrates the correct pattern.

**Changes:**

- Added a new example showing how to render multiple elements inside a custom button by wrapping them in a single parent element.
- Updated the children prop description to better reflect how it can be used.
- Kept the existing simple custom button examples in place and added the multi-element example separately 

These changes were also applied to the `SignInButton` component. 

### Deadline

No rush.

### Other resources

[Linear](https://linear.app/clerk/issue/DOCS-11718/feedback-for-docsnextjsreferencecomponentsunstyledsign-up-button)