### PR TITLE
Add redirects for top docs 404s

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -2797,7 +2797,7 @@
   },
   {
     "source": "/docs/mcp/overview",
-    "destination": "/docs/guides/ai/overview"
+    "destination": "/docs/guides/ai/mcp/clerk-mcp-server"
   },
   {
     "source": "/docs/mcp/connect-mcp-client",

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4410,5 +4410,25 @@
   {
     "source": "/docs/expo",
     "destination": "/docs/expo/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/mcp",
+    "destination": "/docs/guides/ai/mcp/clerk-mcp-server"
+  },
+  {
+    "source": "/docs/android",
+    "destination": "/docs/android/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/react",
+    "destination": "/docs/react/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/reference/nextjs/use-sign-up",
+    "destination": "/docs/reference/hooks/use-sign-up"
+  },
+  {
+    "source": "/docs/organizations",
+    "destination": "/docs/guides/organizations/overview"
   }
 ]

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4425,7 +4425,7 @@
   },
   {
     "source": "/docs/reference/nextjs/use-sign-up",
-    "destination": "/docs/reference/hooks/use-sign-up"
+    "destination": "/docs/nextjs/reference/hooks/use-sign-up"
   },
   {
     "source": "/docs/organizations",


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-indecisive-calf/mcp
- https://clerk.com/docs/pr/manovotny-indecisive-calf/mcp/overview
- https://clerk.com/docs/pr/manovotny-indecisive-calf/android
- https://clerk.com/docs/pr/manovotny-indecisive-calf/react
- https://clerk.com/docs/pr/manovotny-indecisive-calf/reference/nextjs/use-sign-up
- https://clerk.com/docs/pr/manovotny-indecisive-calf/organizations

### What does this solve? What changed?

Investigated the top 10 docs 404s from the last 14 days and added redirects for the 5 that warranted action. Also repointed the existing `/docs/mcp/overview` redirect to the same destination as the new `/docs/mcp` redirect, since the previous destination (`/docs/guides/ai/overview`) was a general AI overview rather than MCP-specific content.

#### Investigation methodology

- Searched the full Clerk GitHub org via `gh search code` for each URL to check for broken internal links
- Cross-referenced each URL against existing redirects in `redirects/static/docs.json` and `redirects/dynamic/docs.jsonc`
- Checked the actual file structure to identify correct current URLs
- Validated with `lint:check-duplicate-redirects` — all checks pass

#### Analysis of all 10 URLs

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/nextjs/guides/customizing-clerk/appe` | **Analytics truncation** — Exactly 50 chars; truncated display of `/docs/nextjs/guides/customizing-clerk/appearance-prop/*`. The bare truncated path is not a real URL. | Skipped |
| 2 | `/docs/android` | **Legit near-miss** — Section root. Many `/docs/android/*` paths are referenced and `/docs/android/getting-started/quickstart` is already used as a redirect destination. | ✅ Added redirect |
| 3 | `/docs/remix/gett` | **Analytics truncation** — Truncated display of `/docs/remix/getting-started/quickstart`, which already redirects to Core 2. | Skipped |
| 4 | `/docs/fastify/guides/customizing-clerk/appearance-prop` | **AI-fabricated** — Zero references in clerk org. Fastify SDK has never had a `customizing-clerk` section. No demand evidence. | Skipped |
| 5 | `/docs/nextjs/guides/customizing-cl` | **Analytics truncation** — 34 chars; truncated display. No references to the bare `/docs/nextjs/guides/customizing-clerk` parent. | Skipped |
| 6 | `/docs/mcp` | **Legit near-miss** — Structural gap: sibling redirects exist for `/docs/mcp/overview`, `/docs/mcp/connect-mcp-client`, `/docs/mcp/build-mcp-server`, but the root was missed. Pointed at `clerk-mcp-server` since that's the most relevant landing page for someone looking for Clerk's MCP integration. | ✅ Added redirect |
| 7 | `/docs/react` | **Legit near-miss** — Section root. `/docs/react/getting-started/quickstart` is used as a destination by 6 existing redirects, and `/docs/react/*` subpaths are heavily referenced across the clerk org. | ✅ Added redirect |
| 8 | `/docs/chrome-extension/guides/development/custom-flows/account-updates` | **Never existed** — Parent directory only; no `account-updates` index/overview page ever existed. No references in clerk org. No sensible target. | Skipped |
| 9 | `/docs/reference/nextjs/use-sign-up` | **Legit near-miss** — Structural gap. Kept the `nextjs` SDK prefix on the destination, consistent with the existing dynamic redirect `/docs/:sdk(...nextjs...)/hooks/:path*` → `/docs/:sdk/reference/hooks/:path*`. | ✅ Added redirect |
| 10 | `/docs/organizations` | **Legit near-miss** — Section root with 30+ sibling `/docs/organizations/*` redirects in place. `clerk/lead-agent` ships a direct external reference to `https://clerk.com/docs/organizations/overview`. | ✅ Added redirect |

#### Changes

**Static redirects** (`redirects/static/docs.json`):

- `/docs/mcp` → `/docs/guides/ai/mcp/clerk-mcp-server`
- `/docs/mcp/overview` → `/docs/guides/ai/mcp/clerk-mcp-server` (repointed from `/docs/guides/ai/overview`)
- `/docs/android` → `/docs/android/getting-started/quickstart`
- `/docs/react` → `/docs/react/getting-started/quickstart`
- `/docs/reference/nextjs/use-sign-up` → `/docs/nextjs/reference/hooks/use-sign-up`
- `/docs/organizations` → `/docs/guides/organizations/overview`

### Deadline

- No rush

### Other resources

- Previous 404 redirect PRs: [#3307](https://github.com/clerk/clerk-docs/pull/3307), [#3284](https://github.com/clerk/clerk-docs/pull/3284), [#3269](https://github.com/clerk/clerk-docs/pull/3269)
