### PR TITLE
docs: Add autoFocus appearance option

### DIFF
--- a/docs/guides/customizing-clerk/appearance-prop/options.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/options.mdx
@@ -11,6 +11,13 @@ The `options` property can be used to change the layout of the [`<SignIn/>`](/do
 ## Properties
 
 <Properties>
+  - `autoFocus`
+  - `boolean`
+
+  Whether inputs automatically receive focus when a component is mounted. Set to `false` to prevent components from auto-focusing any input fields. Defaults to `true`.
+
+  ---
+
   - `animations`
   - `boolean`
 


### PR DESCRIPTION
- https://clerk.com/docs/pr/alex-add-autofocus-option-docs/nextjs/guides/customizing-clerk/appearance-prop/options

## Summary
- Documents the new `autoFocus` option in `appearance.options`
- When set to `false`, prevents Clerk components from auto-focusing input fields on mount
- Defaults to `true` to preserve existing behavior

Depends on https://github.com/clerk/javascript/pull/8521

## Test plan
- [ ] Verify the new property renders correctly in the options docs page
- [ ] Confirm alphabetical ordering is maintained (before `animations`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)