### PR TITLE
docs(expo): document EAS production caveat for Google Sign-In client IDs

### DIFF
--- a/docs/_partials/expo/authview-apple-callout.mdx
+++ b/docs/_partials/expo/authview-apple-callout.mdx
@@ -1,2 +1,0 @@
-> [!IMPORTANT]
-> If you're using [`<AuthView />`](/docs/reference/expo/native-components/auth-view) from `@clerk/expo/native`, you do **not** need to install `expo-apple-authentication`, `expo-crypto`, or use the `useSignInWithApple()` hook — `<AuthView />` handles the sign-in flow automatically.

--- a/docs/_partials/expo/authview-google-callout.mdx
+++ b/docs/_partials/expo/authview-google-callout.mdx
@@ -1,2 +1,0 @@
-> [!IMPORTANT]
-> If you're using [`<AuthView />`](/docs/reference/expo/native-components/auth-view) from `@clerk/expo/native`, you do **not** need to install `expo-crypto` or use the `useSignInWithGoogle()` hook — `<AuthView />` handles the sign-in flow automatically.

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -428,13 +428,7 @@ Use the following tabs to choose your preferred approach:
 
       ## Native sign-in with Google and Apple (optional)
 
-      If you want to add native Sign in with Google and Sign in with Apple buttons that authenticate without opening a browser, you'll need to install `expo-crypto`:
-
-      ```bash
-      npx expo install expo-crypto
-      ```
-
-      Then, refer to the [Sign in with Google](/docs/guides/configure/auth-strategies/sign-in-with-google) and [Sign in with Apple](/docs/guides/configure/auth-strategies/sign-in-with-apple) guides for full setup instructions, including any additional dependencies specific to each provider. **This approach requires a [development build](https://docs.expo.dev/develop/development-builds/introduction/) because it uses native modules. It cannot run in Expo Go.**
+      If you want to add native Sign in with Google and Sign in with Apple buttons that authenticate without opening a browser, refer to the [Sign in with Google](/docs/guides/configure/auth-strategies/sign-in-with-google) and [Sign in with Apple](/docs/guides/configure/auth-strategies/sign-in-with-apple) guides for full setup instructions, including any additional dependencies specific to each provider. **This approach requires a [development build](https://docs.expo.dev/develop/development-builds/introduction/) because it uses native modules. It cannot run in Expo Go.**
     </Steps>
   </Tab>
 </Tabs>

--- a/docs/guides/configure/auth-strategies/sign-in-with-apple.expo.mdx
+++ b/docs/guides/configure/auth-strategies/sign-in-with-apple.expo.mdx
@@ -49,7 +49,8 @@ This guide will teach you how to add native [Sign in with Apple](https://develop
 
   ## Install dependencies
 
-  <Include src="_partials/expo/authview-apple-callout" />
+  > [!IMPORTANT]
+  > If you're using [`<AuthView />`](/docs/reference/expo/native-components/auth-view) from `@clerk/expo/native`, you can skip this step as it handles the sign-in flow automatically.
 
   The [`useSignInWithApple()`](/docs/reference/expo/native-hooks/use-sign-in-with-apple) hook requires the following packages:
 
@@ -84,7 +85,8 @@ This guide will teach you how to add native [Sign in with Apple](https://develop
 
   ## Build your authentication flow
 
-  <Include src="_partials/expo/authview-apple-callout" />
+  > [!IMPORTANT]
+  > If you're using [`<AuthView />`](/docs/reference/expo/native-components/auth-view) from `@clerk/expo/native`, you can skip this step as it handles the sign-in flow automatically.
 
   1. <Include src="_partials/expo/hooks/use-sign-in-with-apple-example" />
   1. Then, add the `<AppleSignInButton />` component to your sign-in or sign-up page.

--- a/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
+++ b/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
@@ -142,6 +142,41 @@ To make the setup process easier, it's recommended to keep two browser tabs open
     </Tab>
   </Tabs>
 
+  > [!IMPORTANT]
+  > **Required for EAS / production builds.** Expo only inlines `EXPO_PUBLIC_*` environment variables into your own application source — they are **not** inlined into code inside `node_modules`, so `process.env.EXPO_PUBLIC_CLERK_GOOGLE_*` reads from inside `@clerk/expo` resolve to `undefined` in production bundles. This is why a production build may fail with `Google Sign-In credentials not found...` even though the variables are set in EAS and visible in build logs.
+  >
+  > To make the client IDs reliably available at runtime, also expose them through `expoConfig.extra` in your `app.json` or `app.config.ts`. The hook reads from `Constants.expoConfig.extra` first, then falls back to `process.env`.
+
+  <Tabs items={["app.json", "app.config.ts"]}>
+    <Tab>
+      ```json {{ filename: 'app.json' }}
+      {
+        "expo": {
+          "extra": {
+            "EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID": "your-web-client-id.apps.googleusercontent.com",
+            "EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID": "your-ios-client-id.apps.googleusercontent.com",
+            "EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID": "your-android-client-id.apps.googleusercontent.com"
+          }
+        }
+      }
+      ```
+    </Tab>
+
+    <Tab>
+      ```ts {{ filename: 'app.config.ts' }}
+      export default {
+        expo: {
+          extra: {
+            EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID,
+            EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID,
+            EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID,
+          },
+        },
+      }
+      ```
+    </Tab>
+  </Tabs>
+
   ## Set up native Sign in with Google (iOS only)
 
   This step is for **iOS only** and is **optional**. Currently, Sign in with Google will open a web browser to initiate the flow. If you'd rather have the app handle the flow natively and not open a web browser, follow this step.
@@ -159,13 +194,15 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   <Tabs items={["app.json", "app.config.ts"]}>
     <Tab>
-      Replace `your-ios-client-id` with the same `<your-ios-client-id>` from your `EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID` environment variable (it should only be the part of your iOS Client ID before ".apps.googleusercontent.com").
+      Replace `your-ios-client-id` with the same `<your-ios-client-id>` from your `EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID` environment variable (it should only be the part of your iOS Client ID before ".apps.googleusercontent.com"). Keep the client ID entries you added in the previous step in the same `extra` block.
 
       ```json {{ filename: 'app.json' }}
       {
         "expo": {
           "plugins": ["@clerk/expo"],
           "extra": {
+            "EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID": "your-web-client-id.apps.googleusercontent.com",
+            "EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID": "your-ios-client-id.apps.googleusercontent.com",
             "EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME": "com.googleusercontent.apps.your-ios-client-id"
           }
         }
@@ -179,6 +216,8 @@ To make the setup process easier, it's recommended to keep two browser tabs open
         expo: {
           plugins: ['@clerk/expo'],
           extra: {
+            EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID,
+            EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID,
             EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME,
           },
         },

--- a/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
+++ b/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
@@ -144,10 +144,14 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   ## Configure the Clerk Expo plugin
 
-  Add the `@clerk/expo` plugin to your app config and mirror your Google client IDs into `expoConfig.extra`. This step is **required for all platforms** (iOS and Android) when building with EAS or any production / non-dev bundle.
+  Add the `@clerk/expo` plugin and your Google OAuth client IDs to the `extra` field in your app config. This step is **required for all platforms** (iOS and Android) when building with EAS or any production / non-dev bundle.
 
-  > [!IMPORTANT]
-  > Expo only inlines `EXPO_PUBLIC_*` environment variables into your own application source — they are **not** inlined into code inside `node_modules`. As a result, `process.env.EXPO_PUBLIC_CLERK_GOOGLE_*` reads from inside `@clerk/expo` resolve to `undefined` in EAS production bundles, even when the variables are correctly configured in EAS and visible in build logs. The hook reads from `Constants.expoConfig.extra` first and falls back to `process.env`, so exposing the values through `extra` makes them reliably available in production.
+  > [!QUIZ]
+  > Why do we need to add the Google client IDs to our app config if they are already in our environment variables?
+  >
+  > ---
+  >
+  > Expo only inlines `EXPO_PUBLIC_*` environment variables into your own application source — they are **not** inlined into code inside `node_modules`. As a result, the Google OAuth client ID's in your environment variables resolve to `undefined` in EAS production bundles, even when the variables are correctly configured in EAS and visible in build logs. The `useSignInWithGoogle()` hook reads from your app config first and falls back to `process.env`, so exposing the values through your app config makes them reliably available in production.
 
   > [!QUIZ]
   > What is the difference between `app.json` and `app.config.ts`?
@@ -189,9 +193,13 @@ To make the setup process easier, it's recommended to keep two browser tabs open
     </Tab>
   </Tabs>
 
-  ### Enable the native Sign in with Google flow (iOS only, optional)
+  ### (iOS only) Enable the native Sign in with Google flow
 
-  By default, Sign in with Google opens a web browser to initiate the flow. On iOS, you can optionally have the app handle the flow natively (no web browser) by adding `EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME` to the same `extra` block. Replace `your-ios-client-id` with the same `<your-ios-client-id>` from your `EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID` environment variable (it should only be the part of your iOS Client ID before ".apps.googleusercontent.com").
+  This step is for **iOS only** and is **optional**.
+
+  By default, Sign in with Google opens a web browser to initiate the flow. On iOS, you can optionally have the app handle the flow natively (no web browser) by adding `EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME` to the `extra` field in your app config.
+
+  In the following example, replace `your-ios-client-id` with the same `<your-ios-client-id>` from your `EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID` environment variable (it should only be the part of your iOS Client ID before ".apps.googleusercontent.com").
 
   <Tabs items={["app.json", "app.config.ts"]}>
     <Tab>
@@ -228,11 +236,6 @@ To make the setup process easier, it's recommended to keep two browser tabs open
     </Tab>
   </Tabs>
 
-  The plugin resolves the `EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME` value from either of the following:
-
-  1. An environment variable (recommended for EAS builds, configured in `eas.json`).
-  1. The `config.extra` field in your app config.
-
   For EAS builds, add the environment variable to your build profile in `eas.json`:
 
   ```json {{ filename: 'eas.json' }}
@@ -249,7 +252,8 @@ To make the setup process easier, it's recommended to keep two browser tabs open
 
   ## Build your authentication flow
 
-  <Include src="_partials/expo/authview-google-callout" />
+  > [!IMPORTANT]
+  > If you're using [`<AuthView />`](/docs/reference/expo/native-components/auth-view) from `@clerk/expo/native`, you can skip this step as it handles the sign-in flow automatically.
 
   1. The [`useSignInWithGoogle()`](/docs/reference/expo/native-hooks/use-sign-in-with-google) hook requires `expo-crypto` for generating secure nonces during the authentication flow.
      ```bash {{ filename: 'terminal' }}

--- a/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
+++ b/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
@@ -169,7 +169,8 @@ To make the setup process easier, it's recommended to keep two browser tabs open
           extra: {
             EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID,
             EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID,
-            EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID,
+            EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID:
+              process.env.EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID,
           },
         },
       }

--- a/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
+++ b/docs/guides/configure/auth-strategies/sign-in-with-google.expo.mdx
@@ -142,16 +142,26 @@ To make the setup process easier, it's recommended to keep two browser tabs open
     </Tab>
   </Tabs>
 
+  ## Configure the Clerk Expo plugin
+
+  Add the `@clerk/expo` plugin to your app config and mirror your Google client IDs into `expoConfig.extra`. This step is **required for all platforms** (iOS and Android) when building with EAS or any production / non-dev bundle.
+
   > [!IMPORTANT]
-  > **Required for EAS / production builds.** Expo only inlines `EXPO_PUBLIC_*` environment variables into your own application source — they are **not** inlined into code inside `node_modules`, so `process.env.EXPO_PUBLIC_CLERK_GOOGLE_*` reads from inside `@clerk/expo` resolve to `undefined` in production bundles. This is why a production build may fail with `Google Sign-In credentials not found...` even though the variables are set in EAS and visible in build logs.
+  > Expo only inlines `EXPO_PUBLIC_*` environment variables into your own application source — they are **not** inlined into code inside `node_modules`. As a result, `process.env.EXPO_PUBLIC_CLERK_GOOGLE_*` reads from inside `@clerk/expo` resolve to `undefined` in EAS production bundles, even when the variables are correctly configured in EAS and visible in build logs. The hook reads from `Constants.expoConfig.extra` first and falls back to `process.env`, so exposing the values through `extra` makes them reliably available in production.
+
+  > [!QUIZ]
+  > What is the difference between `app.json` and `app.config.ts`?
   >
-  > To make the client IDs reliably available at runtime, also expose them through `expoConfig.extra` in your `app.json` or `app.config.ts`. The hook reads from `Constants.expoConfig.extra` first, then falls back to `process.env`.
+  > ---
+  >
+  > `app.json` is for projects using static JSON configuration. `app.config.ts` is for projects that need dynamic configuration (environment variables, conditional logic, etc.). When both files exist, `app.config.ts` receives the values from `app.json` and can extend or override them.
 
   <Tabs items={["app.json", "app.config.ts"]}>
     <Tab>
       ```json {{ filename: 'app.json' }}
       {
         "expo": {
+          "plugins": ["@clerk/expo"],
           "extra": {
             "EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID": "your-web-client-id.apps.googleusercontent.com",
             "EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID": "your-ios-client-id.apps.googleusercontent.com",
@@ -166,6 +176,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
       ```ts {{ filename: 'app.config.ts' }}
       export default {
         expo: {
+          plugins: ['@clerk/expo'],
           extra: {
             EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID,
             EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID,
@@ -178,25 +189,12 @@ To make the setup process easier, it's recommended to keep two browser tabs open
     </Tab>
   </Tabs>
 
-  ## Set up native Sign in with Google (iOS only)
+  ### Enable the native Sign in with Google flow (iOS only, optional)
 
-  This step is for **iOS only** and is **optional**. Currently, Sign in with Google will open a web browser to initiate the flow. If you'd rather have the app handle the flow natively and not open a web browser, follow this step.
-
-  ### Configure the Clerk Expo plugin
-
-  The `@clerk/expo` config plugin configures the URL scheme needed for Google's authentication callback. Add the plugin to your `app.json` or `app.config.ts`, depending on your app's configuration:
-
-  > [!QUIZ]
-  > What is the difference between `app.json` and `app.config.ts`?
-  >
-  > ---
-  >
-  > `app.json` is for projects using static JSON configuration. `app.config.ts` is for projects that need dynamic configuration (environment variables, conditional logic, etc.). When both files exist, `app.config.ts` receives the values from `app.json` and can extend or override them.
+  By default, Sign in with Google opens a web browser to initiate the flow. On iOS, you can optionally have the app handle the flow natively (no web browser) by adding `EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME` to the same `extra` block. Replace `your-ios-client-id` with the same `<your-ios-client-id>` from your `EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID` environment variable (it should only be the part of your iOS Client ID before ".apps.googleusercontent.com").
 
   <Tabs items={["app.json", "app.config.ts"]}>
     <Tab>
-      Replace `your-ios-client-id` with the same `<your-ios-client-id>` from your `EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID` environment variable (it should only be the part of your iOS Client ID before ".apps.googleusercontent.com"). Keep the client ID entries you added in the previous step in the same `extra` block.
-
       ```json {{ filename: 'app.json' }}
       {
         "expo": {
@@ -204,6 +202,7 @@ To make the setup process easier, it's recommended to keep two browser tabs open
           "extra": {
             "EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID": "your-web-client-id.apps.googleusercontent.com",
             "EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID": "your-ios-client-id.apps.googleusercontent.com",
+            "EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID": "your-android-client-id.apps.googleusercontent.com",
             "EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME": "com.googleusercontent.apps.your-ios-client-id"
           }
         }
@@ -219,6 +218,8 @@ To make the setup process easier, it's recommended to keep two browser tabs open
           extra: {
             EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_WEB_CLIENT_ID,
             EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_CLIENT_ID,
+            EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID:
+              process.env.EXPO_PUBLIC_CLERK_GOOGLE_ANDROID_CLIENT_ID,
             EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME: process.env.EXPO_PUBLIC_CLERK_GOOGLE_IOS_URL_SCHEME,
           },
         },


### PR DESCRIPTION
## Summary

- Document that `EXPO_PUBLIC_*` env vars are **not** inlined into `node_modules` (this is intentional Expo behavior, per [Expo docs](https://docs.expo.dev/guides/environment-variables/) — "Code inside node_modules is not affected for security purposes"), so production EAS builds of `useSignInWithGoogle()` need the Google client IDs mirrored into `expoConfig.extra`.
- Add an `IMPORTANT` callout + tabbed `app.json` / `app.config.ts` examples to the "Configure environment variables" step.
- Update the existing iOS URL scheme `extra` example to include the client IDs in the same block so users don't accidentally overwrite them.

## Why

The `@clerk/expo` hook reads `Constants.expoConfig.extra.EXPO_PUBLIC_CLERK_GOOGLE_*` first and falls back to `process.env.EXPO_PUBLIC_CLERK_GOOGLE_*`. Because Expo's babel preset doesn't inline `EXPO_PUBLIC_*` into `node_modules` for security reasons, the `process.env` fallback resolves to `undefined` in production EAS bundles, and the hook throws `Google Sign-In credentials not found...` even when the EAS env vars are correctly configured and visible in build logs. The docs previously only mentioned `.env`, leaving users no way to make the values reachable in production.

Fixes #3256

## Test plan

- [ ] Preview deploys render the new callout + tabs correctly
- [ ] iOS / Android tabs both show the new `extra` block
- [ ] iOS URL scheme section still works and now shows cumulative `extra` shape