### PR TITLE
Add documentation for Organizations integration with OAuth IdP

### DIFF
--- a/docs/_tooltips/slug.mdx
+++ b/docs/_tooltips/slug.mdx
@@ -1,0 +1,2 @@
+A **slug** is a human-readable URL identifier used in URLs and paths to refer to a resource in a clear sharable way.
+An Organization slug of `acme-corp` may appear in a URL like `https://petstore.example.com/acme-corp/dashboard`.

--- a/docs/_tooltips/slug.mdx
+++ b/docs/_tooltips/slug.mdx
@@ -1,2 +1,2 @@
-A **slug** is a human-readable URL identifier used in URLs and paths to refer to a resource in a clear sharable way.
+A **slug** is a human-readable URL identifier used in URLs and paths to refer to a resource in a clear, shareable way.
 An Organization slug of `acme-corp` may appear in a URL like `https://petstore.example.com/acme-corp/dashboard`.

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -85,7 +85,7 @@ The consent screen is enabled by default for all OAuth apps. You can enable or d
 > [!IMPORTANT]
 > Enabling the consent screen for all OAuth apps is **strongly recommended**. Without a consent screen, any logged-in user who visits an OAuth authorization URL automatically grants access to any requested scopes. The consent screen acts as a critical security checkpoint, preventing malicious apps from silently gaining access to user accounts.
 
-### Organizations and OAuth
+### Organizations and OAuth {{ id: 'organizations-and-oauth' }}
 
 When your instance has [Organizations](/docs/guides/organizations/overview) enabled, the `user:org:read` scope becomes available for OAuth applications. This scope enables an integration between Organizations and the OAuth consent flow.
 

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -136,7 +136,14 @@ This endpoint exposes all relevant details in a standardized JSON format. A samp
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code", "refresh_token"],
   "token_endpoint_auth_methods_supported": ["client_secret_basic", "none"],
-  "scopes_supported": ["openid", "profile", "email", "public_metadata", "private_metadata", "user:org:read"],
+  "scopes_supported": [
+    "openid",
+    "profile",
+    "email",
+    "public_metadata",
+    "private_metadata",
+    "user:org:read"
+  ],
   "subject_types_supported": ["public"],
   "id_token_signing_alg_values_supported": ["RS256"],
   "claims_supported": ["sub", "iss", "aud", "exp", "iat", "email", "name", "org_id"],

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -89,15 +89,8 @@ The consent screen is enabled by default for all OAuth apps. You can enable or d
 
 When your instance has [Organizations](/docs/guides/organizations/overview) enabled, the `user:org:read` scope becomes available for OAuth applications. This scope enables an integration between Organizations and the OAuth consent flow.
 
-When an OAuth application requests the `user:org:read` scope, the OAuth consent screen displays an **Organization selector** that allows the user to choose which Organization to associate with the consent. After the user selects an Organization and grants consent, an `org_id` claim is included in both the access token and the ID token (when the `openid` scope is also requested).
-
-The `org_id` property is also available at the following endpoints:
-
-- [`/oauth/userinfo`](/docs/reference/frontend-api/tag/oauth2-identify-provider/post/oauth/userinfo){{ target: '_blank' }} — Returns `org_id` as a property in the response when the user selected an Organization during consent.
-- [`/oauth/token_info`](/docs/reference/frontend-api/tag/oauth2-identify-provider/post/oauth/token_info){{ target: '_blank' }} — Returns `org_id` as a property in the token introspection response.
-
-> [!NOTE]
-> When customizing the OAuth consent flow, you can pass an `organization_id` parameter to the authorization endpoint to pre-select an Organization for the user. This is useful when you already know which Organization context the user should authorize under. The `organization_id` parameter is only honored when the `user:org:read` scope has been granted to the OAuth application.
+When an OAuth client requests the `user:org:read` scope, the OAuth consent screen displays an **Organization selector** that allows the user to choose which Organization to associate with the token. After the user selects an Organization and grants consent, an `org_id` claim is included in both the access token and the ID token (when the `openid` scope is also requested).
+The `org_id` property is also available at the user info and token introspection endpoints.
 
 ## Token expiration and management
 

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -35,6 +35,7 @@ Scopes define the level of access and specific user data that will be shared wit
 | `public_metadata` | Grant access to the user's public and unsafe metadata |
 | `private_metadata` | Grant access to the user's private metadata |
 | `openid` | Enables the OpenID Connect flow |
+| `user:org:read` | Grant access to the user's Organization information. Only available when the instance has [Organizations](/docs/guides/organizations/overview) enabled. See [Organizations and OAuth](#organizations-and-oauth) for details. |
 
 > [!NOTE]
 > Support for adding custom OAuth scopes is **not yet available**, but development is underway. The goal is to allow custom scopes to be added, accepted, and checked through Clerk SDKs. An update will be provided when this feature is available.
@@ -84,6 +85,20 @@ The consent screen is enabled by default for all OAuth apps. You can enable or d
 > [!IMPORTANT]
 > Enabling the consent screen for all OAuth apps is **strongly recommended**. Without a consent screen, any logged-in user who visits an OAuth authorization URL automatically grants access to any requested scopes. The consent screen acts as a critical security checkpoint, preventing malicious apps from silently gaining access to user accounts.
 
+### Organizations and OAuth
+
+When your instance has [Organizations](/docs/guides/organizations/overview) enabled, the `user:org:read` scope becomes available for OAuth applications. This scope enables an integration between Organizations and the OAuth consent flow.
+
+When an OAuth application requests the `user:org:read` scope, the OAuth consent screen displays an **Organization selector** that allows the user to choose which Organization to associate with the consent. After the user selects an Organization and grants consent, an `org_id` claim is included in both the access token and the ID token (when the `openid` scope is also requested).
+
+The `org_id` property is also available at the following endpoints:
+
+- [`/oauth/userinfo`](/docs/reference/frontend-api/tag/oauth2-identify-provider/post/oauth/userinfo){{ target: '_blank' }} — Returns `org_id` as a property in the response when the user selected an Organization during consent.
+- [`/oauth/token_info`](/docs/reference/frontend-api/tag/oauth2-identify-provider/post/oauth/token_info){{ target: '_blank' }} — Returns `org_id` as a property in the token introspection response.
+
+> [!NOTE]
+> When customizing the OAuth consent flow, you can pass an `organization_id` parameter to the authorization endpoint to pre-select an Organization for the user. This is useful when you already know which Organization context the user should authorize under. The `organization_id` parameter is only honored when the `user:org:read` scope has been granted to the OAuth application.
+
 ## Token expiration and management
 
 - OAuth access tokens expire **after 1 day**.
@@ -121,10 +136,10 @@ This endpoint exposes all relevant details in a standardized JSON format. A samp
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code", "refresh_token"],
   "token_endpoint_auth_methods_supported": ["client_secret_basic", "none"],
-  "scopes_supported": ["openid", "profile", "email", "public_metadata", "private_metadata"],
+  "scopes_supported": ["openid", "profile", "email", "public_metadata", "private_metadata", "user:org:read"],
   "subject_types_supported": ["public"],
   "id_token_signing_alg_values_supported": ["RS256"],
-  "claims_supported": ["sub", "iss", "aud", "exp", "iat", "email", "name"],
+  "claims_supported": ["sub", "iss", "aud", "exp", "iat", "email", "name", "org_id"],
   "service_documentation": "https://clerk.com/docs",
   "ui_locales_supported": ["en"],
   "op_tos_uri": "https://clerk.com/legal/standard-terms",

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -89,8 +89,7 @@ The consent screen is enabled by default for all OAuth apps. You can enable or d
 
 When your instance has [Organizations](/docs/guides/organizations/overview) enabled, the `user:org:read` scope becomes available for OAuth applications. This scope enables an integration between Organizations and the OAuth consent flow.
 
-When an OAuth client requests the `user:org:read` scope, the OAuth consent screen displays an **Organization selector** that allows the user to choose which Organization to associate with the token. After the user selects an Organization and grants consent, an `org_id` claim is included in both the access token and the ID token (when the `openid` scope is also requested).
-The `org_id` property is also available at the user info and token introspection endpoints.
+When an OAuth client requests the `user:org:read` scope, the OAuth consent screen displays an **Organization selector** that allows the user to choose which Organization to associate with the token. After the user selects an Organization and grants consent, an `org_id` claim is included in the access token and, when the `openid` scope is also requested, the ID token. The `org_id` property is also available at the user info and token introspection endpoints.
 
 ## Token expiration and management
 
@@ -146,3 +145,6 @@ This endpoint exposes all relevant details in a standardized JSON format. A samp
   "code_challenge_methods_supported": ["S256"]
 }
 ```
+
+> [!NOTE]
+> The `user:org:read` scope and `org_id` claim are only included in this metadata when the instance has Organizations enabled. See [Organizations and OAuth](#organizations-and-oauth) for details.

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -143,6 +143,9 @@ export async function GET() {
 }
 ```
 
+> [!NOTE]
+> The `org_id` property is only present in the response when Organizations are enabled and the `user:org:read` scope was granted. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
+
 The `/oauth/userinfo` endpoint provides the following user properties, depending on the granted scopes:
 
 | Property | Description |
@@ -159,7 +162,7 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | `public_metadata` | The user's public metadata |
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
-| `org_id` | The ID of the Organization the user selected during the OAuth consent flow. Only present when the `user:org:read` scope is granted. |
+| `org_id` | The ID of an Organization to which the user belongs. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth). |
 
 ### Get token information
 
@@ -222,9 +225,6 @@ export async function POST(req: NextRequest) {
   "org_id": "string"
 }
 ```
-
-> [!NOTE]
-> The `org_id` property is only present in the response when Organizations are enabled and the `user:org:read` scope was granted. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
 
 ## Get additional user information with the OAuth 2.0 flow using the OpenID Connect (OIDC) protocol
 

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -159,7 +159,7 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | `public_metadata` | The user's public metadata |
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
-| `org_id` | The ID of the Organization the user selected during the OAuth consent flow. Only present when the `user:org:read` scope is granted and the user selected an Organization. |
+| `org_id` | The ID of the Organization the user selected during the OAuth consent flow. Only present when the `user:org:read` scope is granted. |
 
 ### Get token information
 
@@ -224,7 +224,7 @@ export async function POST(req: NextRequest) {
 ```
 
 > [!NOTE]
-> The `org_id` property is only present in the token info response when the `user:org:read` scope was granted and the user selected an Organization during the OAuth consent flow.
+> The `org_id` property is only present in the response when Organizations are enabled and the `user:org:read` scope was granted. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
 
 ## Get additional user information with the OAuth 2.0 flow using the OpenID Connect (OIDC) protocol
 
@@ -245,23 +245,6 @@ GET /oauth/authorize?
   scope=openid%20profile%20email&...
 Host: clerk.<INSERT_YOUR_APP_DOMAIN>.com
 ```
-
-> [!NOTE]
-> If your OAuth application has been granted the `user:org:read` scope, you can pass an `organization_id` parameter to the authorization endpoint to pre-select an Organization for the user on the consent screen. For example:
->
-> ```http
-> GET /oauth/authorize?
->   client_id=x&
->   response_type=code&
->   state=y&
->   code_challenge=z&
->   redirect_uri=a&
->   scope=openid%20profile%20email%20user:org:read&
->   organization_id=org_abc123&...
-> Host: clerk.<INSERT_YOUR_APP_DOMAIN>.com
-> ```
->
-> This is useful when you already know which Organization context the user should authorize under. Learn more about [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
 
 Once a user successfully authenticates using the OIDC flow, you'll receive:
 
@@ -327,4 +310,4 @@ Depending on the granted scopes, the ID token can include the following addition
 | `public_metadata` | The user's public metadata |
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
-| `org_id` | The ID of the Organization the user selected during the OAuth consent flow. Only present when the `user:org:read` scope is granted and the user selects an Organization. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth). |
+| `org_id` | The ID of an Organization to which the user belongs. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth). |

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -182,15 +182,20 @@ This example is written for Next.js App Router **but can be adapted for any fram
 ```tsx {{ filename: 'app/api/tokeninfo/route.ts' }}
 import { NextRequest, NextResponse } from 'next/server'
 
-// Assume you already have the access token and refresh token available here
+// Assume you already have the access token and refresh token.
+// You can get your OAuth app's Client ID and Client Secret from the Clerk Dashboard:
+// https://dashboard.clerk.com/~/oauth-applications
+// In production, store these as environment variables loaded from `process.env.*`
+// rather than hardcoded here.
 const tokens = {
   accessToken: 'YOUR_ACCESS_TOKEN_HERE',
   refreshToken: 'YOUR_REFRESH_TOKEN_HERE',
 }
+const clientId = 'YOUR_CLIENT_ID_HERE'
+const clientSecret = 'YOUR_CLIENT_SECRET_HERE'
 
 export async function POST(req: NextRequest) {
   try {
-    // clientId and clientSecret come from your Clerk OAuth app
     const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
     // Your Frontend API URL can be found on the API keys page in the Clerk Dashboard
     // https://dashboard.clerk.com/~/api-keys

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -146,7 +146,7 @@ export async function GET() {
 ```
 
 > [!NOTE]
-> The `org_id` property is only present in the response when Organizations are enabled and the `user:org:read` scope was granted. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
+> The `org_id`, `org_name`, and `org_slug` properties are only present in the response when Organizations are enabled, the `user:org:read` scope was granted, and an Organization is associated with the token. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
 
 The `/oauth/userinfo` endpoint provides the following user properties, depending on the granted scopes:
 
@@ -165,8 +165,8 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
 | `org_id` | The ID of an Organization to which the user belongs. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth). |
-| `org_name` | The name of the user's organization |
-| `org_slug` | The [slug](!slug) for the user's organization |
+| `org_name` | The name of the user's Organization |
+| `org_slug` | The [slug](!slug) for the user's Organization |
 
 ### Get token information
 
@@ -229,6 +229,9 @@ export async function POST(req: NextRequest) {
   "org_id": "string"
 }
 ```
+
+> [!NOTE]
+> The `org_id` property is only present in the response when Organizations are enabled, the `user:org:read` scope was granted, and an Organization is associated with the token. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
 
 ## Get additional user information with the OAuth 2.0 flow using the OpenID Connect (OIDC) protocol
 

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -124,7 +124,7 @@ export async function GET() {
 
 ```json
 {
-  "object": "string",
+  "object": "oauth_user_info",
   "instance_id": "string",
   "user_id": "string",
   "sub": "string",
@@ -139,7 +139,9 @@ export async function GET() {
   "public_metadata": {},
   "private_metadata": {},
   "unsafe_metadata": {},
-  "org_id": "string"
+  "org_id": "string",
+  "org_name": "string",
+  "org_slug": "string"
 }
 ```
 
@@ -163,6 +165,8 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
 | `org_id` | The ID of an Organization to which the user belongs. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth). |
+| `org_name` | The name of the user's organization |
+| `org_slug` | The [slug](!slug) for the user's organization |
 
 ### Get token information
 

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -190,13 +190,14 @@ const tokens = {
 
 export async function POST(req: NextRequest) {
   try {
+    // clientId and clientSecret come from your Clerk OAuth app
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
     // Your Frontend API URL can be found on the API keys page in the Clerk Dashboard
     // https://dashboard.clerk.com/~/api-keys
     const response = await fetch(`${process.env.CLERK_FRONTEND_API_URL}/oauth/token_info`, {
       method: 'POST',
       headers: {
-        // Include the access token as a Bearer token in the Authorization header
-        Authorization: `Bearer ${tokens.accessToken}`,
+        Authorization: `Basic ${credentials}`,
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: new URLSearchParams({

--- a/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/single-sign-on.mdx
@@ -138,7 +138,8 @@ export async function GET() {
   "picture": "string",
   "public_metadata": {},
   "private_metadata": {},
-  "unsafe_metadata": {}
+  "unsafe_metadata": {},
+  "org_id": "string"
 }
 ```
 
@@ -158,6 +159,7 @@ The `/oauth/userinfo` endpoint provides the following user properties, depending
 | `public_metadata` | The user's public metadata |
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
+| `org_id` | The ID of the Organization the user selected during the OAuth consent flow. Only present when the `user:org:read` scope is granted and the user selected an Organization. |
 
 ### Get token information
 
@@ -216,9 +218,13 @@ export async function POST(req: NextRequest) {
   "client_id": "string",
   "iat": 0,
   "scope": "string",
-  "sub": "string"
+  "sub": "string",
+  "org_id": "string"
 }
 ```
+
+> [!NOTE]
+> The `org_id` property is only present in the token info response when the `user:org:read` scope was granted and the user selected an Organization during the OAuth consent flow.
 
 ## Get additional user information with the OAuth 2.0 flow using the OpenID Connect (OIDC) protocol
 
@@ -239,6 +245,23 @@ GET /oauth/authorize?
   scope=openid%20profile%20email&...
 Host: clerk.<INSERT_YOUR_APP_DOMAIN>.com
 ```
+
+> [!NOTE]
+> If your OAuth application has been granted the `user:org:read` scope, you can pass an `organization_id` parameter to the authorization endpoint to pre-select an Organization for the user on the consent screen. For example:
+>
+> ```http
+> GET /oauth/authorize?
+>   client_id=x&
+>   response_type=code&
+>   state=y&
+>   code_challenge=z&
+>   redirect_uri=a&
+>   scope=openid%20profile%20email%20user:org:read&
+>   organization_id=org_abc123&...
+> Host: clerk.<INSERT_YOUR_APP_DOMAIN>.com
+> ```
+>
+> This is useful when you already know which Organization context the user should authorize under. Learn more about [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth).
 
 Once a user successfully authenticates using the OIDC flow, you'll receive:
 
@@ -304,3 +327,4 @@ Depending on the granted scopes, the ID token can include the following addition
 | `public_metadata` | The user's public metadata |
 | `private_metadata` | The user's private metadata |
 | `unsafe_metadata` | The user's unsafe metadata |
+| `org_id` | The ID of the Organization the user selected during the OAuth consent flow. Only present when the `user:org:read` scope is granted and the user selects an Organization. See [Organizations and OAuth](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#organizations-and-oauth). |


### PR DESCRIPTION
### 🔎 Previews:

- [How Clerk Implements OAuth](https://clerk.com/docs/pr/cursor-oauth-orgs-integration-docs-76a1/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth)
- [Use OAuth for Single Sign-On](https://clerk.com/docs/pr/cursor-oauth-orgs-integration-docs-76a1/guides/configure/auth-strategies/oauth/single-sign-on)

### What does this solve? What changed?

Adds documentation for the Organizations integration with OAuth Applications (OAuth IdP). When an instance has Organizations enabled, a new `user:org:read` scope becomes available for OAuth apps.

**Changes made:**

1. **`how-clerk-implements-oauth.mdx`:**
   - Added `user:org:read` to the scopes table with a description of its availability and purpose.
   - Added a new "Organizations and OAuth" subsection under "Consent screen management" explaining:
     - The Organization selector shown on the OAuth consent screen when this scope is requested.
     - The `org_id` claim included in access tokens and ID tokens, and at info endpoints
   - Updated the authorization server metadata example to include `user:org:read` in `scopes_supported` and `org_id` in `claims_supported`.

2. **`single-sign-on.mdx`:**
   - Added `org_id`, `org_name`, `org_slug` to the `/oauth/userinfo` response example and properties table.
   - Added `org_id` to the `/oauth/token_info` response example with a clarifying note.
   - Added `org_id` to the ID token additional claims table.

3. Added a `slug` tooltip

### Deadline

- ASAP if possible. (Sorry I released this feature thinking I already had a green light here.)

Part of USER-5273