### PR TITLE
Add clarity surrounding user enumeration protection

### DIFF
--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -26,7 +26,9 @@ search:
 This guide demonstrates how to build a custom user interface that **allows users to sign up or sign in within a single flow**. There are two approaches:
 
 - [**Standard flow**](#standard-sign-in-or-up-flow): The sign-in attempt immediately tells you whether an account exists. If it doesn't exist yet, you start the sign-up flow. This is simple and gives users immediate feedback, but it reveals whether an account exists before any verification, making it susceptible to [user enumeration](/docs/guides/secure/user-enumeration-protection) attacks.
+  - Mimics the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 - [**`signUpIfMissing` flow**](#sign-in-or-up-with-sign-up-if-missing): The sign-in proceeds to verification regardless of whether an account exists. Only after verification does the backend reveal whether the account exists or needs to be created. This prevents user enumeration attacks.
+  - Mimics the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 ## Standard sign-in-or-up flow
 
@@ -37,6 +39,9 @@ This guide demonstrates how to build a custom user interface that **allows users
 <Include src="_partials/custom-flows/enable-email-password" />
 
 ### Build the flow
+
+> [!TIP]
+> This flow mimics the Account Portal/prebuilt components' flows when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 
 To blend a sign-up and sign-in flow into a single flow, you must **treat it as a sign-in flow**, but with the ability to sign up a new user if they don't have an account. You can do this by **checking for the `form_identifier_not_found` error** if the sign-in process fails, and then starting the sign-up process.
 
@@ -1226,6 +1231,9 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
 </If>
 
 ## Sign-in-or-up with `signUpIfMissing`
+
+> [!TIP]
+> This flow mimics the Account Portal/prebuilt components' flows when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 <If notSdk={["ios", "android"]}>
   The `signUpIfMissing` option offers a privacy-preserving alternative to the standard sign-in-or-up flow. Unlike the standard flow, which discloses whether an account exists from the outset, this option proceeds to the verification step regardless of if the account exists. Only after the user has successfully completed the verification step does the flow reveal if an account already exists or if one needs to be created. Although it is **recommended** to pair the `signUpIfMissing` flow with [strict user enumeration protections](/docs/guides/secure/user-enumeration-protection) in the Clerk Dashboard for maximum security, **this option doesn't require that setting.**

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -32,6 +32,9 @@ This guide demonstrates how to build a custom user interface that **allows users
 
 ## Standard sign-in-or-up flow
 
+> [!TIP]
+> This flow mimics the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
+
 ### Enable email and password authentication
 
 **This example uses the [email and password sign-in custom flow](/docs/guides/development/custom-flows/authentication/email-password) as a base. However, you can modify this approach according to the settings you've configured for your application's instance in the Clerk Dashboard.**
@@ -39,9 +42,6 @@ This guide demonstrates how to build a custom user interface that **allows users
 <Include src="_partials/custom-flows/enable-email-password" />
 
 ### Build the flow
-
-> [!TIP]
-> This flow mimics the Account Portal/prebuilt components' flows when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 
 To blend a sign-up and sign-in flow into a single flow, you must **treat it as a sign-in flow**, but with the ability to sign up a new user if they don't have an account. You can do this by **checking for the `form_identifier_not_found` error** if the sign-in process fails, and then starting the sign-up process.
 
@@ -1233,7 +1233,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
 ## Sign-in-or-up with `signUpIfMissing`
 
 > [!TIP]
-> This flow mimics the Account Portal/prebuilt components' flows when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
+> This flow mimics the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 <If notSdk={["ios", "android"]}>
   The `signUpIfMissing` option offers a privacy-preserving alternative to the standard sign-in-or-up flow. Unlike the standard flow, which discloses whether an account exists from the outset, this option proceeds to the verification step regardless of if the account exists. Only after the user has successfully completed the verification step does the flow reveal if an account already exists or if one needs to be created. Although it is **recommended** to pair the `signUpIfMissing` flow with [strict user enumeration protections](/docs/guides/secure/user-enumeration-protection) in the Clerk Dashboard for maximum security, **this option doesn't require that setting.**

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -26,9 +26,14 @@ search:
 This guide demonstrates how to build a custom user interface that **allows users to sign up or sign in within a single flow**. There are two approaches:
 
 - [**Standard flow**](#standard-sign-in-or-up-flow): The sign-in attempt immediately tells you whether an account exists. If it doesn't exist yet, you start the sign-up flow. This is simple and gives users immediate feedback, but it reveals whether an account exists before any verification, making it susceptible to [user enumeration](/docs/guides/secure/user-enumeration-protection) attacks.
+  - Similar to the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 - [**`signUpIfMissing` flow**](#sign-in-or-up-with-sign-up-if-missing): The sign-in proceeds to verification regardless of whether an account exists. Only after verification does the backend reveal whether the account exists or needs to be created. This prevents user enumeration attacks.
+  - Similar to the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 ## Standard sign-in-or-up flow
+
+> [!TIP]
+> This flow is similar to the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 
 ### Enable email and password authentication
 
@@ -1226,6 +1231,9 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
 </If>
 
 ## Sign-in-or-up with `signUpIfMissing`
+
+> [!TIP]
+> This flow is similar to the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 <If notSdk={["ios", "android"]}>
   The `signUpIfMissing` option offers a privacy-preserving alternative to the standard sign-in-or-up flow. Unlike the standard flow, which discloses whether an account exists from the outset, this option proceeds to the verification step regardless of if the account exists. Only after the user has successfully completed the verification step does the flow reveal if an account already exists or if one needs to be created. Although it is **recommended** to pair the `signUpIfMissing` flow with [strict user enumeration protections](/docs/guides/secure/user-enumeration-protection) in the Clerk Dashboard for maximum security, **this option doesn't require that setting.**

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -26,14 +26,9 @@ search:
 This guide demonstrates how to build a custom user interface that **allows users to sign up or sign in within a single flow**. There are two approaches:
 
 - [**Standard flow**](#standard-sign-in-or-up-flow): The sign-in attempt immediately tells you whether an account exists. If it doesn't exist yet, you start the sign-up flow. This is simple and gives users immediate feedback, but it reveals whether an account exists before any verification, making it susceptible to [user enumeration](/docs/guides/secure/user-enumeration-protection) attacks.
-  - Mimics the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 - [**`signUpIfMissing` flow**](#sign-in-or-up-with-sign-up-if-missing): The sign-in proceeds to verification regardless of whether an account exists. Only after verification does the backend reveal whether the account exists or needs to be created. This prevents user enumeration attacks.
-  - Mimics the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 ## Standard sign-in-or-up flow
-
-> [!TIP]
-> This flow mimics the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 
 ### Enable email and password authentication
 
@@ -1231,9 +1226,6 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
 </If>
 
 ## Sign-in-or-up with `signUpIfMissing`
-
-> [!TIP]
-> This flow mimics the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
 
 <If notSdk={["ios", "android"]}>
   The `signUpIfMissing` option offers a privacy-preserving alternative to the standard sign-in-or-up flow. Unlike the standard flow, which discloses whether an account exists from the outset, this option proceeds to the verification step regardless of if the account exists. Only after the user has successfully completed the verification step does the flow reveal if an account already exists or if one needs to be created. Although it is **recommended** to pair the `signUpIfMissing` flow with [strict user enumeration protections](/docs/guides/secure/user-enumeration-protection) in the Clerk Dashboard for maximum security, **this option doesn't require that setting.**

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -28,7 +28,7 @@ This guide demonstrates how to build a custom user interface that **allows users
 - [**Standard flow**](#standard-sign-in-or-up-flow): The sign-in attempt immediately tells you whether an account exists. If it doesn't exist yet, you start the sign-up flow. This is simple and gives users immediate feedback, but it reveals whether an account exists before any verification, making it susceptible to [user enumeration](/docs/guides/secure/user-enumeration-protection) attacks.
   - Similar to the Account Portal/prebuilt components' behavior when [**bulk** user enumeration protection](/docs/guides/secure/user-enumeration-protection#bulk-user-enumeration-protection) is enabled.
 - [**`signUpIfMissing` flow**](#sign-in-or-up-with-sign-up-if-missing): The sign-in proceeds to verification regardless of whether an account exists. Only after verification does the backend reveal whether the account exists or needs to be created. This prevents user enumeration attacks.
-  - Similar to the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
+  - Similar to the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled, except the sign-in **will** transfer to sign-up if the account does not exist.
 
 ## Standard sign-in-or-up flow
 

--- a/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/sign-in-or-up.mdx
@@ -1233,7 +1233,7 @@ To blend a sign-up and sign-in flow into a single flow, you must **treat it as a
 ## Sign-in-or-up with `signUpIfMissing`
 
 > [!TIP]
-> This flow is similar to the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled.
+> This flow is similar to the Account Portal/prebuilt components' behavior when [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) is enabled, except the sign-in **will** transfer to sign-up if the account does not exist.
 
 <If notSdk={["ios", "android"]}>
   The `signUpIfMissing` option offers a privacy-preserving alternative to the standard sign-in-or-up flow. Unlike the standard flow, which discloses whether an account exists from the outset, this option proceeds to the verification step regardless of if the account exists. Only after the user has successfully completed the verification step does the flow reveal if an account already exists or if one needs to be created. Although it is **recommended** to pair the `signUpIfMissing` flow with [strict user enumeration protections](/docs/guides/secure/user-enumeration-protection) in the Clerk Dashboard for maximum security, **this option doesn't require that setting.**

--- a/docs/guides/secure/user-enumeration-protection.mdx
+++ b/docs/guides/secure/user-enumeration-protection.mdx
@@ -35,7 +35,7 @@ Strict enumeration covers:
 - Sign up: If you sign up with an email or phone number that already exists, Clerk won't send a verification code. Instead, it sends a notification (email or SMS) letting the account owner know someone tried to sign up, and suggesting they sign in instead.
 - Sign in: When the account exists, sign-in proceeds normally. When it doesn't, Clerk's behavior depends on the strategy:
   - **Password or Web3 wallet**: The attempt is rejected without revealing whether the account exists.
-  - **Email code or email link**: Clerk sends a notification to the address explaining that someone tried to sign in, and suggesting they sign up instead.
+  - **Email code or email link**: Clerk shows the verification screen and sends a notification to the address explaining that there was a sign-in attempt, but there was no account found.
   - **Phone code**: Clerk shows the verification screen as if a message was sent, but doesn't actually send anything.
     - Because SMS can be costly during an enumeration attack, Clerk doesn't send SMS for sign-in attempts to non-existent accounts. We're exploring ways to add SMS notifications as we develop our anti-fraud protections.
-- User profile: If you add an email or phone number to your profile that already exists, Clerk shows the verification screen as if a message was sent, but doesn't actually send anything. Clerk doesn’t send notifications in this case, since these attempts are more likely to be attacks than real updates.
+- User profile: If you add an email or phone number to your profile that already exists, Clerk shows the verification screen as if a message was sent, but doesn't actually send anything. Clerk doesn't send notifications in this case, since these attempts are more likely to be attacks than real updates.

--- a/docs/guides/secure/user-enumeration-protection.mdx
+++ b/docs/guides/secure/user-enumeration-protection.mdx
@@ -30,6 +30,9 @@ Clerk's existing PII protections still apply. For example, during sign-in, even 
 
 With **Strict user enumeration protection**, users **won't receive feedback about whether their identifier matches an existing account** until they verify their identity.
 
+> [!NOTE]
+> Sign-in-or-up isn't supported under strict for the Account Portal or prebuilt components — a sign-in attempt for a non-existent account can't transfer to sign-up. If you need a sign-in-or-up experience under strict, use the [`signUpIfMissing` custom flow](/docs/guides/development/custom-flows/authentication/sign-in-or-up#sign-in-or-up-with-sign-up-if-missing) instead.
+
 Strict enumeration covers:
 
 - Sign up: If you sign up with an email or phone number that already exists, Clerk won't send a verification code. Instead, it sends a notification (email or SMS) letting the account owner know someone tried to sign up, and suggesting they sign in instead.

--- a/docs/guides/secure/user-enumeration-protection.mdx
+++ b/docs/guides/secure/user-enumeration-protection.mdx
@@ -31,7 +31,7 @@ Clerk's existing PII protections still apply. For example, during sign-in, even 
 With **Strict user enumeration protection**, users **won't receive feedback about whether their identifier matches an existing account** until they verify their identity.
 
 > [!NOTE]
-> Sign-in-or-up isn't supported under strict for the Account Portal or prebuilt components — a sign-in attempt for a non-existent account can't transfer to sign-up. If you need a sign-in-or-up experience under strict, use the [`signUpIfMissing` custom flow](/docs/guides/development/custom-flows/authentication/sign-in-or-up#sign-in-or-up-with-sign-up-if-missing) instead.
+> Sign-in-or-up isn't supported under **strict** for the Account Portal or prebuilt components — a sign-in attempt for a non-existent account can't transfer to sign-up. If you need a sign-in-or-up experience under **strict**, use the [`signUpIfMissing` custom flow](/docs/guides/development/custom-flows/authentication/sign-in-or-up#sign-in-or-up-with-sign-up-if-missing) instead.
 
 Strict enumeration covers:
 

--- a/docs/guides/secure/user-enumeration-protection.mdx
+++ b/docs/guides/secure/user-enumeration-protection.mdx
@@ -35,7 +35,7 @@ Strict enumeration covers:
 - Sign up: If you sign up with an email or phone number that already exists, Clerk won't send a verification code. Instead, it sends a notification (email or SMS) letting the account owner know someone tried to sign up, and suggesting they sign in instead.
 - Sign in: When the account exists, sign-in proceeds normally. When it doesn't, Clerk's behavior depends on the strategy:
   - **Password or Web3 wallet**: The attempt is rejected without revealing whether the account exists.
-  - **Email code or email link**: Clerk shows the verification screen and sends a notification to the address explaining that there was a sign-in attempt, but there was no account found.
+  - **Email code or email link**: Clerk shows the verification screen and sends a notification to the address explaining that someone attempted to sign in to a non-existent account.
   - **Phone code**: Clerk shows the verification screen as if a message was sent, but doesn't actually send anything.
     - Because SMS can be costly during an enumeration attack, Clerk doesn't send SMS for sign-in attempts to non-existent accounts. We're exploring ways to add SMS notifications as we develop our anti-fraud protections.
 - User profile: If you add an email or phone number to your profile that already exists, Clerk shows the verification screen as if a message was sent, but doesn't actually send anything. Clerk doesn't send notifications in this case, since these attempts are more likely to be attacks than real updates.

--- a/docs/reference/components/authentication/sign-in.mdx
+++ b/docs/reference/components/authentication/sign-in.mdx
@@ -281,7 +281,7 @@ All props are optional.
   - `withSignUp?`
   - `boolean`
 
-  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up (unless you have [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) enabled). If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`.
+  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. [Sign-in-or-up isn't supported under strict user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection); use the [`signUpIfMissing` custom flow](/docs/guides/development/custom-flows/authentication/sign-in-or-up#sign-in-or-up-with-sign-up-if-missing) instead. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`.
 </Properties>
 
 ## Customization

--- a/docs/reference/components/authentication/sign-in.mdx
+++ b/docs/reference/components/authentication/sign-in.mdx
@@ -281,7 +281,7 @@ All props are optional.
   - `withSignUp?`
   - `boolean`
 
-  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`.
+  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up (unless you have [**strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection) enabled). If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`.
 </Properties>
 
 ## Customization

--- a/docs/reference/components/authentication/sign-in.mdx
+++ b/docs/reference/components/authentication/sign-in.mdx
@@ -281,7 +281,7 @@ All props are optional.
   - `withSignUp?`
   - `boolean`
 
-  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. [Sign-in-or-up isn't supported under strict user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection); use the [`signUpIfMissing` custom flow](/docs/guides/development/custom-flows/authentication/sign-in-or-up#sign-in-or-up-with-sign-up-if-missing) instead. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`.
+  Opt into sign-in-or-up flow by setting this prop to `true`. When `true`, if a user does not exist, they will be prompted to sign up. If a user exists, they will be prompted to sign in. Defaults to `true` if the `CLERK_SIGN_IN_URL` environment variable is set. Otherwise, defaults to `false`. [Sign-in-or-up isn't supported under **strict** user enumeration protection](/docs/guides/secure/user-enumeration-protection#strict-user-enumeration-protection); use the [`signUpIfMissing` custom flow](/docs/guides/development/custom-flows/authentication/sign-in-or-up#sign-in-or-up-with-sign-up-if-missing) instead.
 </Properties>
 
 ## Customization


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

`secure/user-enumeration-protection`: tested bulk versus strict user enumeration flows when signing up/signing in and updated the docs accordingly.

`development/custom-flows/authentication/sign-in-or-up`: updated the copy to more clearly explain how the two flow options relate to user enumeration protection settings.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
https://linear.app/clerk/issue/DOCS-11693/clarify-sign-in-or-up-behavior-with-strict-user-enumeration-protection