### PR TITLE
add user.updateMetadata method

### DIFF
--- a/docs/guides/users/extending.mdx
+++ b/docs/guides/users/extending.mdx
@@ -61,14 +61,14 @@ See the following examples to see how to set unsafe metadata on the frontend (cl
 
 <Tabs items={["Client-side", "Server-side"]}>
   <Tab>
-    Use the [`updateMetadata()`](/docs/reference/objects/user#update-metadata) method to update unsafe metadata from the frontend. The provided value is **deep-merged** with the existing `unsafeMetadata`, and any key set to `null` is removed.
+    Use the [`User.updateMetadata()`](/docs/reference/objects/user#update-metadata) method to update unsafe metadata from the frontend. The provided value is **deep-merged** with the existing `unsafeMetadata`, and any key set to `null` is removed.
 
     > [!TIP]
-    > The older [`update()`](/docs/reference/objects/user#update) method also accepts `unsafeMetadata`, but it **fully replaces** the value instead of merging. Prefer `updateMetadata()` when you only need to change specific keys.
+    > You can also use [`User.update()`](/docs/reference/objects/user#update) to update unsafe metadata, but it **fully replaces** the value instead of merging. Use `User.updateMetadata()` when you need to change specific keys.
 
     <Tabs items={["React-based SDKs", "JavaScript"]}>
       <Tab>
-        For React-based SDKs, such as Next.js, use the [`useUser()`](/docs/reference/hooks/use-user) hook to access the `User` object.
+        For React-based SDKs, such as Next.js, use the [`useUser()`](/docs/reference/hooks/use-user) hook to access the `User` object and call the `updateMetadata()` method.
 
         ```tsx {{ filename: 'page.tsx' }}
         export default function Page() {
@@ -95,7 +95,7 @@ See the following examples to see how to set unsafe metadata on the frontend (cl
       </Tab>
 
       <Tab>
-        When using the JavaScript SDK, use the [`User.updateMetadata()`](/docs/reference/objects/user#update-metadata) method.
+        When using the JavaScript SDK, use the [`Clerk`](/docs/reference/objects/clerk) object to access the `User` object and call the `updateMetadata()` method.
 
         ```js {{ filename: 'main.js' }}
         import { Clerk } from '@clerk/clerk-js'

--- a/docs/guides/users/extending.mdx
+++ b/docs/guides/users/extending.mdx
@@ -61,9 +61,14 @@ See the following examples to see how to set unsafe metadata on the frontend (cl
 
 <Tabs items={["Client-side", "Server-side"]}>
   <Tab>
+    Use the [`updateMetadata()`](/docs/reference/objects/user#update-metadata) method to update unsafe metadata from the frontend. The provided value is **deep-merged** with the existing `unsafeMetadata`, and any key set to `null` is removed.
+
+    > [!TIP]
+    > The older [`update()`](/docs/reference/objects/user#update) method also accepts `unsafeMetadata`, but it **fully replaces** the value instead of merging. Prefer `updateMetadata()` when you only need to change specific keys.
+
     <Tabs items={["React-based SDKs", "JavaScript"]}>
       <Tab>
-        For React-based SDKs, such as Next.js, use the [`useUser()`](/docs/reference/hooks/use-user) hook to update unsafe metadata.
+        For React-based SDKs, such as Next.js, use the [`useUser()`](/docs/reference/hooks/use-user) hook to access the `User` object.
 
         ```tsx {{ filename: 'page.tsx' }}
         export default function Page() {
@@ -76,7 +81,7 @@ See the following examples to see how to set unsafe metadata on the frontend (cl
 
               <button
                 onClick={() => {
-                  user?.update({
+                  user?.updateMetadata({
                     unsafeMetadata: { birthday },
                   })
                 }}
@@ -90,7 +95,7 @@ See the following examples to see how to set unsafe metadata on the frontend (cl
       </Tab>
 
       <Tab>
-        When using the JavaScript SDK, use the [`User.update()`](/docs/reference/objects/user#update) method to update unsafe metadata.
+        When using the JavaScript SDK, use the [`User.updateMetadata()`](/docs/reference/objects/user#update-metadata) method.
 
         ```js {{ filename: 'main.js' }}
         import { Clerk } from '@clerk/clerk-js'
@@ -103,7 +108,7 @@ See the following examples to see how to set unsafe metadata on the frontend (cl
 
         if (clerk.isSignedIn) {
           await clerk.user
-            .update({
+            .updateMetadata({
               unsafeMetadata: {
                 birthday: '01-01-2000',
               },

--- a/docs/reference/objects/user.mdx
+++ b/docs/reference/objects/user.mdx
@@ -775,7 +775,7 @@ function update(params: UpdateUserParams): Promise<User>
   - `unsafeMetadata?`
   - [`UserUnsafeMetadata`](/docs/reference/types/metadata#user-unsafe-metadata)
 
-  Metadata that can be read and set from the Frontend API. One common use case for this attribute is to implement custom fields that will be attached to the `User` object. Updating this value overrides the previous value; it does not merge. To perform a merge, you can pass something like `{ …user.unsafeMetadata, …newData }` to this parameter.
+  Metadata that can be read and set from the Frontend API. One common use case for this attribute is to implement custom fields that will be attached to the `User` object. Using `update()` to update this value fully replaces the existing value. To perform a merge, use [`updateMetadata()`](#update-metadata) instead.
 </Properties>
 
 ### `updateMetadata()`

--- a/docs/reference/objects/user.mdx
+++ b/docs/reference/objects/user.mdx
@@ -778,6 +778,23 @@ function update(params: UpdateUserParams): Promise<User>
   Metadata that can be read and set from the Frontend API. One common use case for this attribute is to implement custom fields that will be attached to the `User` object. Updating this value overrides the previous value; it does not merge. To perform a merge, you can pass something like `{ …user.unsafeMetadata, …newData }` to this parameter.
 </Properties>
 
+### `updateMetadata()`
+
+Updates the user's `unsafeMetadata` using deep-merge semantics. Unlike [`update()`](#update), which fully replaces `unsafeMetadata`, this method merges the provided value with the existing `unsafeMetadata`. Top-level and nested keys are merged, and any key set to `null` is removed. Only `unsafeMetadata` is writable from the frontend; `publicMetadata` and `privateMetadata` can only be set from the [Backend API](/docs/reference/backend-api){{ target: '_blank' }}.
+
+```ts
+function updateMetadata(params: UpdateUserMetadataParams): Promise<User>
+```
+
+#### `UpdateUserMetadataParams`
+
+<Properties>
+  - `unsafeMetadata`
+  - [`UserUnsafeMetadata`](/docs/reference/types/metadata#user-unsafe-metadata)
+
+  The metadata to deep-merge with the user's existing `unsafeMetadata`. Keys at any nesting level whose value is `null` are removed.
+</Properties>
+
 ### `updatePassword()`
 
 Updates the user's password. Passwords must be at least 8 characters long.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/bruno-user-5297-add-update-user-metadata/nextjs/reference/objects/user#update-metadata
- https://clerk.com/docs/pr/bruno-user-5297-add-update-user-metadata/guides/users/extending#unsafe-metadata

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Updates docs  with method `user.updateMetadata` to be added in https://github.com/clerk/javascript/pull/8537

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
