### PR TITLE
fix: Remove clerk elements reference from how clerk works

### DIFF
--- a/docs/guides/how-clerk-works/overview.mdx
+++ b/docs/guides/how-clerk-works/overview.mdx
@@ -41,12 +41,6 @@ Clerk's [prebuilt UI components](/docs/reference/components/overview) are Clerk'
 
 > **Customizability:** You can [modify the CSS for any part of the prebuilt components](/docs/guides/customizing-clerk/appearance-prop/overview), but not the HTML structure or the logic/ordering of how the authentication flow works.
 
-### Clerk Elements
-
-The next level of abstraction is [Clerk Elements](/docs/guides/customizing-clerk/elements/overview), a headless UI library that provides the foundational building blocks used in Clerk's prebuilt components. Similar to established libraries like [Radix](https://www.radix-ui.com), [Reach UI](https://reach.tech), and [Headless UI](https://headlessui.com), Clerk Elements exposes a set of unstyled React components that handle complex authentication logic while giving you complete control over the presentation layer. **Clerk Elements is still in beta**, and only supports sign-up and sign-in flows, with more components planned for future releases.
-
-> **Customizability:** You have full control over both the CSS and the HTML structure of the components, but you can't change the logic/ordering of how the authentication flow works.
-
 ### Custom flows
 
 Finally, if you need complete control over the authentication flow, Clerk provides low-level primitives that directly wrap our API endpoints. These primitives enable you to build fully custom authentication flows from scratch. Clerk refers to these as ["custom flows"](/docs/guides/development/custom-flows/overview). While this approach offers maximum flexibility, it also requires significant development effort to implement and maintain. Custom flows should only be considered when you have specific requirements that cannot be met using the prebuilt components or Clerk Elements, as you'll need to handle all authentication logic, error states, and edge cases yourself.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/carp-move-clerk-elements/guides/how-clerk-works/overview#levels-of-abstraction

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Removes clerk elements reference from how clerk works

### Deadline

no rush
-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
