### PR TITLE
chore: Add `fontFamilyMono` to variables

### DIFF
--- a/docs/guides/customizing-clerk/appearance-prop/variables.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/variables.mdx
@@ -185,7 +185,7 @@ The `variables` property is used to adjust the general styles of the component's
   - `fontFamilyMono`
   - `string`
 
-  The monospace font family used for monospaced text within the components. By default, it is set to `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`.
+  The font family used for monospaced text within the components. By default, it is set to `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`.
 
   CSS variable: `--clerk-font-family-mono`
 

--- a/docs/guides/customizing-clerk/appearance-prop/variables.mdx
+++ b/docs/guides/customizing-clerk/appearance-prop/variables.mdx
@@ -182,6 +182,15 @@ The `variables` property is used to adjust the general styles of the component's
 
   ---
 
+  - `fontFamilyMono`
+  - `string`
+
+  The monospace font family used for monospaced text within the components. By default, it is set to `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`.
+
+  CSS variable: `--clerk-font-family-mono`
+
+  ---
+
   - `fontSize`
   - `string` | `{xs: string, sm: string, md: string, lg: string, xl: string}`
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/carp-font-family-mono-variable/nextjs/guides/customizing-clerk/appearance-prop/variables

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- https://github.com/clerk/javascript/pull/8546

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
