### PR TITLE
chore: Add highlightedPlan prop docs for pricing table

### DIFF
--- a/docs/reference/components/billing/pricing-table.mdx
+++ b/docs/reference/components/billing/pricing-table.mdx
@@ -258,6 +258,13 @@ All props are optional.
 
   ---
 
+  - `highlightedPlan?`
+  - `string`
+
+  The slug of the plan to highlight. When set, the matching plan card will display a "Popular" badge. If the plan already has an active subscription badge, the subscription badge takes priority.
+
+  ---
+
   - `newSubscriptionRedirectUrl?`
   - `string`
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/carp-pricing-table-highlighted-plan-prop/nextjs/reference/components/billing/pricing-table#properties

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- https://github.com/clerk/javascript/pull/8554

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
