### PR TITLE
(custom-flows/account-updates/forgot-password) Add signOutOfOtherSessions prop usage

### DIFF
--- a/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
+++ b/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
@@ -26,7 +26,7 @@ The password reset flow works as follows:
 1. Users can have an email address or phone number, or both. The user enters their email address or phone number and asks for a password reset code.
 1. Clerk sends an email or SMS to the user, containing a code.
 1. The user enters the code and a new password.
-1. Clerk verifies the code, and if successful, updates the user's password and signs them in.
+1. Clerk verifies the code, and if successful, updates the user's password and signs them in. Because `signOutOfOtherSessions` is set to `true`, the user will be signed out of all other authenticated sessions.
 
 This guide demonstrates how to use Clerk's API to build a custom flow for resetting a user's password. It covers the following scenarios:
 
@@ -92,6 +92,8 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
 
       const { error } = await signIn.resetPasswordEmailCode.submitPassword({
         password,
+        // Optional: sign the user out of all other authenticated sessions
+        signOutOfOtherSessions: true,
       })
       if (error) {
         console.error(JSON.stringify(error, null, 2))
@@ -239,6 +241,8 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
     async function submitNewPassword() {
       const { error } = await signIn.resetPasswordEmailCode.submitPassword({
         password,
+        // Optional: sign the user out of all other authenticated sessions
+        signOutOfOtherSessions: true,
       })
       if (error) {
         console.error(JSON.stringify(error, null, 2))
@@ -539,6 +543,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
         do {
           try await signIn?.resetPassword(
             newPassword: password,
+            // Optional: sign the user out of all other authenticated sessions
             signOutOfOtherSessions: true
           )
 
@@ -627,6 +632,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
             signIn
               .resetPassword(
                 newPassword = password,
+                // Optional: sign the user out of all other authenticated sessions
                 signOutOfOtherSessions = true,
               )
               .onSuccess { updated ->
@@ -840,6 +846,8 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
 
       const { error } = await signIn.resetPasswordPhoneCode.submitPassword({
         password,
+        // Optional: sign the user out of all other authenticated sessions
+        signOutOfOtherSessions: true,
       })
       if (error) {
         console.error(JSON.stringify(error, null, 2))
@@ -989,6 +997,8 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
     async function submitNewPassword() {
       const { error } = await signIn.resetPasswordPhoneCode.submitPassword({
         password,
+        // Optional: sign the user out of all other authenticated sessions
+        signOutOfOtherSessions: true,
       })
       if (error) {
         console.error(JSON.stringify(error, null, 2))
@@ -1287,6 +1297,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
         do {
           try await signIn?.resetPassword(
             newPassword: password,
+            // Optional: sign the user out of all other authenticated sessions
             signOutOfOtherSessions: true
           )
 
@@ -1375,6 +1386,7 @@ This guide demonstrates how to use Clerk's API to build a custom flow for resett
           signIn
             .resetPassword(
               newPassword = password,
+              // Optional: sign the user out of all other authenticated sessions
               signOutOfOtherSessions = true,
             )
             .onSuccess { updated ->

--- a/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
+++ b/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
@@ -26,7 +26,8 @@ The password reset flow works as follows:
 1. Users can have an email address or phone number, or both. The user enters their email address or phone number and asks for a password reset code.
 1. Clerk sends an email or SMS to the user, containing a code.
 1. The user enters the code and a new password.
-1. Clerk verifies the code, and if successful, updates the user's password and signs them in. Because `signOutOfOtherSessions` is set to `true`, the user will be signed out of all other authenticated sessions.
+1. Clerk verifies the code, and if successful, updates the user's password and signs them in. 
+1. If `signOutOfOtherSessions` is `true`, the user is signed out of all other authenticated sessions.
 
 This guide demonstrates how to use Clerk's API to build a custom flow for resetting a user's password. It covers the following scenarios:
 

--- a/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
+++ b/docs/guides/development/custom-flows/account-updates/forgot-password.mdx
@@ -26,7 +26,7 @@ The password reset flow works as follows:
 1. Users can have an email address or phone number, or both. The user enters their email address or phone number and asks for a password reset code.
 1. Clerk sends an email or SMS to the user, containing a code.
 1. The user enters the code and a new password.
-1. Clerk verifies the code, and if successful, updates the user's password and signs them in. 
+1. Clerk verifies the code, and if successful, updates the user's password and signs them in.
 1. If `signOutOfOtherSessions` is `true`, the user is signed out of all other authenticated sessions.
 
 This guide demonstrates how to use Clerk's API to build a custom flow for resetting a user's password. It covers the following scenarios:


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-docs-11739/guides/development/custom-flows/account-updates/forgot-password

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- Adds `signOutOfOtherSessions` prop usage to the custom flow on resetting a user's password. This demonstrates how to sign users out of all other sessions after resetting a password.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

https://linear.app/clerk/issue/DOCS-11739/document-signoutofothersessions-parameter-in-signinresetpassword