### PR TITLE
Revamp organizations/add-members/invitations

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,4 +1,6 @@
 {
-  "setup": ["./scripts/ai/setup.sh"],
+  "setup": [
+    "./scripts/ai/setup.sh"
+  ],
   "teardown": []
 }

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,6 +1,4 @@
 {
-  "setup": [
-    "./scripts/ai/setup.sh"
-  ],
+  "setup": ["./scripts/ai/setup.sh"],
   "teardown": []
 }

--- a/docs/guides/organizations/add-members/invitations.mdx
+++ b/docs/guides/organizations/add-members/invitations.mdx
@@ -9,7 +9,7 @@ Organization invitations let you add new members to your Organization. When you 
 
 By default, only [admins](/docs/guides/organizations/control-access/roles-and-permissions#default-roles) can invite users to an Organization.
 
-This feature requires that [**Email** is enabled](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#email), as Clerk uses the user's email address to send the invitation. If you don't want to enable **Email** for your application, you can bypass the invitation flow completely and add users directly to the Organization by using the [`createOrganizationMembership()`](/docs/reference/backend/organization/create-organization-membership) method.
+This feature requires that [**Email** is enabled](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#email), as Clerk uses the user's email address to send the invitation. If you don't want to enable **Email** for your application, you can bypass the invitation flow completely and add existing users directly to the Organization with the [`createOrganizationMembership()`](/docs/reference/backend/organization/create-organization-membership) method. Because this method requires the user's ID, the user must already have a Clerk account.
 
 ## When to use invitations
 
@@ -33,7 +33,7 @@ To create an Organization invitation on the client-side, see the [dedicated guid
 
 ### Server-side
 
-To create Organization invitations on the server-side, use the Backend API by either calling the endpoint directly or using [`clerkClient`](/docs/reference/backend/overview). `clerkClient` is a wrapper around the Backend API that makes it easier to interact with the API.
+To create Organization invitations on the server-side, use the Backend API by either calling the endpoint directly or using [`clerkClient`](/docs/reference/backend/overview). `clerkClient` is a wrapper around the Backend API that makes it easier to interact with the API. If you receive a `429` response, respect the `Retry-After` header before retrying.
 
 Use the following tabs to see examples for each method.
 
@@ -89,7 +89,7 @@ When you create an invitation, you can specify a `redirect_url` parameter. This 
   <Tab>
     The following example demonstrates how to set the `redirect_url` parameter on the `POST /v1/organizations/{organization_id}/invitations` endpoint.
 
-    ```bash
+    ```bash {{ filename: 'terminal' }}
     curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations' \
       -X POST \
       -H 'Authorization: Bearer {{secret}}' \
@@ -99,7 +99,7 @@ When you create an invitation, you can specify a `redirect_url` parameter. This 
   </Tab>
 
   <Tab>
-    The [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) and [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) methods accept a `redirectUrl` parameter.
+    [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) accepts a `redirectUrl` parameter. For [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk), set `redirectUrl` on each invitation object in the `params` array.
   </Tab>
 </Tabs>
 
@@ -116,7 +116,7 @@ You can also add metadata to an invitation when creating the invitation through 
   <Tab>
     The following example demonstrates how to set the `public_metadata` parameter on the `POST /v1/organizations/{organization_id}/invitations` endpoint.
 
-    ```bash
+    ```bash {{ filename: 'terminal' }}
     curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations' \
       -X POST \
       -H 'Authorization: Bearer {{secret}}' \
@@ -126,7 +126,7 @@ You can also add metadata to an invitation when creating the invitation through 
   </Tab>
 
   <Tab>
-    The [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) and [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) methods accept a `publicMetadata` parameter.
+    [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) accepts a `publicMetadata` parameter. For [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk), set `publicMetadata` on each invitation object in the `params` array.
   </Tab>
 </Tabs>
 

--- a/docs/guides/organizations/add-members/invitations.mdx
+++ b/docs/guides/organizations/add-members/invitations.mdx
@@ -9,9 +9,7 @@ Organization invitations let you add new members to your Organization. When you 
 
 By default, only [admins](/docs/guides/organizations/control-access/roles-and-permissions#default-roles) can invite users to an Organization.
 
-This feature requires that [**Email** is enabled](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#email), as Clerk uses the user's email address to send the invitation. You can still disable **Email** as a sign-in option if you do not want users to be able to sign-in with their email address.
-
-To configure your application's **Email** settings, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page in the Clerk Dashboard.
+This feature requires that [**Email** is enabled](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#email), as Clerk uses the user's email address to send the invitation. If you don't want to enable **Email** for your application, you can bypass the invitation flow completely and add users directly to the Organization by using the [`createOrganizationMembership()`](/docs/reference/backend/organization/create-organization-membership) method.
 
 ## When to use invitations
 
@@ -27,26 +25,21 @@ If you want to streamline enrollment for users with company email addresses, con
 
 Clerk's [prebuilt components](/docs/reference/components/overview) and [Account Portal pages](/docs/guides/account-portal/overview) manage all Organization invitation flows, including creating, managing, and accepting invitations.
 
-However, if you want to build custom flows, see the following sections.
+However, if you want to build [custom flows](!custom-flow), see the following sections.
 
 ### Client-side
 
-To create an Organization invitation on the client-side, see the [dedicated guide](/docs/guides/development/custom-flows/organizations/manage-organization-invitations). Note that this uses the [`organizations.inviteMember()`](/docs/reference/objects/organization#invite-member) method, which does not let you specify a redirect URL; it will always redirect to the Account Portal sign-in page. If you want to specify a redirect URL, you must create the invitation on the server-side.
+To create an Organization invitation on the client-side, see the [dedicated guide](/docs/guides/development/custom-flows/organizations/manage-organization-invitations). Note that this uses the [`organizations.inviteMember()`](/docs/reference/objects/organization#invite-member) method, which does not let you specify a redirect URL; the invitation links will always redirect to the Account Portal sign-in page. If you want to specify a redirect URL, you must create the invitation on the server-side.
 
 ### Server-side
 
-To create Organization invitations on the server-side, use the [Backend API](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations){{ target: '_blank' }} either by using a cURL command or [`clerkClient`](/docs/reference/backend/overview). `clerkClient` is a wrapper around the Backend API that makes it easier to interact with the API.
-
-To invite multiple users in one request, use the [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) method.
-
-> [!CAUTION]
-> Organization invitation creation endpoints are [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests). `POST /v1/organizations/{organization_id}/invitations` allows **250 requests per hour** per application instance, and `POST /v1/organizations/{organization_id}/invitations/bulk` allows **50 requests per hour** per application instance. If you receive a `429`, respect the `Retry-After` header before retrying.
+To create Organization invitations on the server-side, use the Backend API by either calling the endpoint directly or using [`clerkClient`](/docs/reference/backend/overview). `clerkClient` is a wrapper around the Backend API that makes it easier to interact with the API.
 
 Use the following tabs to see examples for each method.
 
 <Tabs items={["cURL", "clerkClient"]}>
   <Tab>
-    The following example demonstrates how to create an Organization invitation using cURL.
+    The following example demonstrates how to send a single Organization invitation using the [`POST /v1/organizations/{organization_id}/invitations` endpoint](/docs/reference/backend-api/tag/organization-invitations/POST/organizations/%7Borganization_id%7D/invitations){{ target: '_blank' }}. This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **250 requests per hour** per application instance.
 
     <SignedIn>
       - Your [Secret Key](!secret-key) is already injected into the code snippet.
@@ -71,50 +64,71 @@ Use the following tabs to see examples for each method.
     -H 'Content-Type: application/json' \
     -d '{ "inviter_user_id": "user_123", "email_address": "email@example.com", "role": "org:member" }'
     ```
+
+    The following example demonstrates how to send multiple Organization invitations in one request using the [`POST /v1/organizations/{organization_id}/invitations/bulk` endpoint](/docs/reference/backend-api/tag/organization-invitations/POST/organizations/%7Borganization_id%7D/invitations/bulk){{ target: '_blank' }}. This endpoint is **limited to a maximum of 10 invitations per API call**. If you need to send more invitations, please make multiple requests. This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **50 requests per hour** per application instance.
+
+    ```bash {{ filename: 'terminal' }}
+    curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations/bulk' \
+    -X POST \
+    -H 'Authorization: Bearer {{secret}}' \
+    -H 'Content-Type: application/json' \
+    -d '[{ "inviter_user_id": "user_123", "email_address": "email123@example.com", "role": "org:member" }, { "inviter_user_id": "user_456", "email_address": "email456@example.com", "role": "org:member" }]'
+    ```
   </Tab>
 
   <Tab>
-    To use [`clerkClient`](/docs/reference/backend/overview) to create an invitation, see the [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) reference documentation.
+    To use [`clerkClient`](/docs/reference/backend/overview) to send a single invitation, see the [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) reference documentation. To invite multiple users in one request, see the [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) reference documentation.
   </Tab>
 </Tabs>
-
-For an example of the response, see the [Backend API reference](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations){{ target: '_blank' }}.
 
 ### Redirect URL
 
 When you create an invitation, you can specify a `redirect_url` parameter. This parameter tells Clerk where to redirect the user when they visit the invitation link.
 
-The following example demonstrates how to use cURL to create an invitation with the `redirect_url` set to `https://www.example.com/accept-invitation`.
+<Tabs items={["cURL", "clerkClient"]}>
+  <Tab>
+    The following example demonstrates how to set the `redirect_url` parameter on the `POST /v1/organizations/{organization_id}/invitations` endpoint.
 
-```bash
-curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations' \
-  -X POST \
-  -H 'Authorization: Bearer {{secret}}' \
-  -H 'Content-Type: application/json' \
-  -d '{ "inviter_user_id": "user_123", "email_address": "email@example.com", "role": "org:member", "redirect_url": "https://www.example.com/accept-invitation" }'
-```
+    ```bash
+    curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations' \
+      -X POST \
+      -H 'Authorization: Bearer {{secret}}' \
+      -H 'Content-Type: application/json' \
+      -d '{ "inviter_user_id": "user_123", "email_address": "email@example.com", "role": "org:member", "redirect_url": "https://www.example.com/accept-invitation" }'
+    ```
+  </Tab>
+
+  <Tab>
+    The [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) and [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) methods accept a `redirectUrl` parameter.
+  </Tab>
+</Tabs>
 
 Once the user visits the invitation link, they will be redirected to the page you specified. On that page, you must handle the authentication flow in your code. You can either embed the [`<SignIn />`](/docs/reference/components/authentication/sign-in) component or, if the prebuilt component doesn't meet your needs or you require more control over the logic, you can build a [custom flow](/docs/guides/development/custom-flows/organizations/accept-organization-invitations).
 
 > [!TIP]
->
 > To test redirect URLs in your development environment, pass your port. For example, `http://localhost:3000/accept-invitation`.
 
 ### Invitation metadata
 
-You can also add metadata to an invitation when creating the invitation through the Backend API. Once the invited user signs up using the invitation link, Clerk stores the **invitation** metadata (`OrganizationInvitation.publicMetadata`) in the Organization **membership's** metadata (`OrganizationMembership.publicMetadata`). For more details on Organization membership metadata, see the [OrganizationMembership](/docs/reference/types/organization-membership) reference.
+You can also add metadata to an invitation when creating the invitation through the Backend API. Once the invited user signs up using the invitation link, Clerk stores the **invitation** metadata (`OrganizationInvitation.publicMetadata`) in the Organization **membership's** metadata (`OrganizationMembership.publicMetadata`). For more details on Organization membership metadata, see the [`OrganizationMembership`](/docs/reference/types/organization-membership) reference.
 
-To add metadata to an invitation, add the `public_metadata` parameter when creating the invitation.
+<Tabs items={["cURL", "clerkClient"]}>
+  <Tab>
+    The following example demonstrates how to set the `public_metadata` parameter on the `POST /v1/organizations/{organization_id}/invitations` endpoint.
 
-The following example demonstrates how to use cURL to create an invitation with metadata.
+    ```bash
+    curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations' \
+      -X POST \
+      -H 'Authorization: Bearer {{secret}}' \
+      -H 'Content-Type: application/json' \
+      -d '{ "inviter_user_id": "user_123", "email_address": "email@example.com", "role": "org:member", "public_metadata": {"department": "marketing"} }'
+    ```
+  </Tab>
 
-```bash
-curl 'https://api.clerk.com/v1/organizations/{org_123}/invitations' \
-  -X POST \
-  -H 'Authorization: Bearer {{secret}}' \
-  -H 'Content-Type: application/json' \
-  -d '{ "inviter_user_id": "user_123", "email_address": "email@example.com", "role": "org:member", "public_metadata": {"department": "marketing"} }'
-```
+  <Tab>
+    The [`createOrganizationInvitation()`](/docs/reference/backend/organization/create-organization-invitation) and [`createOrganizationInvitationBulk()`](/docs/reference/backend/organization/create-organization-invitation-bulk) methods accept a `publicMetadata` parameter.
+  </Tab>
+</Tabs>
 
 ## Revoke an invitation
 
@@ -126,13 +140,13 @@ To revoke an invitation client-side, see the [dedicated guide](/docs/guides/deve
 
 ### Server-side
 
-To revoke an invitation server-side, use the [Backend API](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations/\{invitation_id}/revoke){{ target: '_blank' }}. either by using a cURL command or [`clerkClient`](/docs/reference/backend/overview). `clerkClient` is a wrapper around the Backend API that makes it easier to interact with the API.
+To revoke an invitation server-side, use the Backend API by either calling the endpoint directly or using [`clerkClient`](/docs/reference/backend/overview). `clerkClient` is a wrapper around the Backend API that makes it easier to interact with the API.
 
 Use the following tabs to see examples for each method.
 
 <Tabs items={["cURL", "clerkClient"]}>
   <Tab>
-    The following example demonstrates how to revoke an invitation using cURL.
+    The following example demonstrates how to revoke an invitation using the [`POST /v1/organizations/{organization_id}/invitations/{invitation_id}/revoke` endpoint](/docs/reference/backend-api/tag/organization-invitations/POST/organizations/%7Borganization_id%7D/invitations/%7Binvitation_id%7D/revoke){{ target: '_blank' }}.
 
     <SignedIn>
       - Your [Secret Key](!secret-key) is already injected into the code snippet.

--- a/docs/reference/backend/organization/create-organization-invitation-bulk.mdx
+++ b/docs/reference/backend/organization/create-organization-invitation-bulk.mdx
@@ -8,7 +8,6 @@ description: Use the createOrganizationInvitationBulk() method to create multipl
 Creates multiple [`OrganizationInvitation`](/docs/reference/backend/types/backend-organization-invitation)s in bulk for new users to join an Organization.
 
 > [!CAUTION]
->
 > This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **50 requests per hour** per application instance.
 
 ```ts
@@ -31,12 +30,14 @@ function createOrganizationInvitationBulk(
   ---
 
   - `params`
-  - [`CreateBulkOrganizationInvitationParams[]`](#create-bulk-organization-invitation-params)
+  - [`CreateBulkOrganizationInvitationParams`](#create-bulk-organization-invitation-params)
 
-  An array of objects, each representing a single invitation.
+  An array of objects, each representing a single invitation. Accepts up to 10 invitations per request.
 </Properties>
 
 ### `CreateBulkOrganizationInvitationParams`
+
+`CreateBulkOrganizationInvitationParams` is an array of objects, with each object accepting the following parameters:
 
 <Properties>
   - `inviterUserId`
@@ -101,4 +102,4 @@ const response = await clerkClient.organizations.createOrganizationInvitationBul
 
 ## Backend API (BAPI) endpoint
 
-This method in the SDK is a wrapper around the BAPI endpoint `POST/organizations/{organization_id}/invitations/bulk`. See the [BAPI reference](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations/bulk){{ target: '_blank' }} for more information.
+This method in the SDK is a wrapper around the BAPI endpoint `POST/organizations/{organization_id}/invitations/bulk`. See the [BAPI reference](/docs/reference/backend-api/tag/organization-invitations/POST/organizations/%7Borganization_id%7D/invitations/bulk){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/organization/create-organization-invitation-bulk.mdx
+++ b/docs/reference/backend/organization/create-organization-invitation-bulk.mdx
@@ -14,7 +14,7 @@ Creates multiple [`OrganizationInvitation`](/docs/reference/backend/types/backen
 function createOrganizationInvitationBulk(
   organizationId: string,
   params: CreateBulkOrganizationInvitationParams,
-): Promise<OrganizationInvitation>
+): Promise<OrganizationInvitation[]>
 ```
 
 ## Parameters
@@ -72,6 +72,20 @@ function createOrganizationInvitationBulk(
   - [`OrganizationInvitationPublicMetadata`](/docs/reference/types/metadata#organization-invitation-public-metadata)
 
   Metadata that can be read from both the Frontend API and [Backend API](/docs/reference/backend-api){{ target: '_blank' }}, but can be set only from the Backend API.
+
+  ---
+
+  - `privateMetadata?`
+  - [`OrganizationInvitationPrivateMetadata`](/docs/reference/types/metadata#organization-invitation-private-metadata)
+
+  Metadata that can be read and set only from the [Backend API](/docs/reference/backend-api){{ target: '_blank' }}.
+
+  ---
+
+  - `expiresInDays?`
+  - `number`
+
+  The number of days the invitation will be valid for. By default, the invitation expires after 30 days.
 </Properties>
 
 ## Example

--- a/docs/reference/backend/organization/create-organization-invitation.mdx
+++ b/docs/reference/backend/organization/create-organization-invitation.mdx
@@ -8,7 +8,6 @@ description: Use the createOrganizationInvitation() method to create an invitati
 Creates an [`OrganizationInvitation`](/docs/reference/backend/types/backend-organization-invitation) for new users to join an Organization.
 
 > [!CAUTION]
->
 > This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **250 requests per hour** per application instance.
 
 ```ts
@@ -84,4 +83,4 @@ const response = await clerkClient.organizations.createOrganizationInvitation({
 
 ## Backend API (BAPI) endpoint
 
-This method in the SDK is a wrapper around the BAPI endpoint `POST/organizations/{organization_id}/invitations`. See the [BAPI reference](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations){{ target: '_blank' }} for more information.
+This method in the SDK is a wrapper around the BAPI endpoint `POST/organizations/{organization_id}/invitations`. See the [BAPI reference](/docs/reference/backend-api/tag/organization-invitations/POST/organizations/%7Borganization_id%7D/invitations){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/organization/create-organization-invitation.mdx
+++ b/docs/reference/backend/organization/create-organization-invitation.mdx
@@ -58,6 +58,20 @@ function createOrganizationInvitation(
   - [`OrganizationInvitationPublicMetadata`](/docs/reference/types/metadata#organization-invitation-public-metadata)
 
   Metadata that can be read from both the Frontend API and [Backend API](/docs/reference/backend-api){{ target: '_blank' }}, but can be set only from the Backend API.
+
+  ---
+
+  - `privateMetadata?`
+  - [`OrganizationInvitationPrivateMetadata`](/docs/reference/types/metadata#organization-invitation-private-metadata)
+
+  Metadata that can be read and set only from the [Backend API](/docs/reference/backend-api){{ target: '_blank' }}.
+
+  ---
+
+  - `expiresInDays?`
+  - `number`
+
+  The number of days the invitation will be valid for. By default, the invitation expires after 30 days.
 </Properties>
 
 ## Example

--- a/docs/reference/backend/organization/revoke-organization-invitation.mdx
+++ b/docs/reference/backend/organization/revoke-organization-invitation.mdx
@@ -56,4 +56,4 @@ const response = await clerkClient.organizations.revokeOrganizationInvitation({
 
 ## Backend API (BAPI) endpoint
 
-This method in the SDK is a wrapper around the BAPI endpoint `POST/organizations/{organization_id}/invitations/{invitation_id}/revoke`. See the [BAPI reference](/docs/reference/backend-api/tag/organization-invitations/post/organizations/\{organization_id}/invitations/\{invitation_id}/revoke){{ target: '_blank' }} for more information.
+This method in the SDK is a wrapper around the BAPI endpoint `POST/organizations/{organization_id}/invitations/{invitation_id}/revoke`. See the [BAPI reference](/docs/reference/backend-api/tag/organization-invitations/POST/organizations/%7Borganization_id%7D/invitations/%7Binvitation_id%7D/revoke){{ target: '_blank' }} for more information.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-docs-11769/guides/organizations/add-members/invitations

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

Sending organization invitations requires emails. This PR adds a solution for users that don't want to enable **Email** for their application:
> If you don't want to enable **Email** for your application, you can bypass the invitation flow completely and add users directly to the Organization by using the [`createOrganizationMembership()`](/docs/reference/backend/organization/create-organization-membership) method.

This PR also revamps the page by adding links to the BAPI reference, splitting up information visually using `<Tabs>` for cURL versus clerkClient examples, and overall using more explicit language in the copy.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->

https://linear.app/clerk/issue/DOCS-11769/document-workaround-for-org-invites-with-google-only-auth-skip
