### PR TITLE
Add redirects for top 404s (huggingface, backend email-address)

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -1824,6 +1824,10 @@
     "destination": "/docs/guides/development/errors/overview"
   },
   {
+    "source": "/docs/reference/backend/types/email-address",
+    "destination": "/docs/reference/backend/types/backend-email-address"
+  },
+  {
     "source": "/docs/reference/backend/types/saml-connection",
     "destination": "/docs/reference/backend/types/backend-saml-connection"
   },
@@ -3210,6 +3214,10 @@
   {
     "source": "/docs/authentication/social-connections/hubspot",
     "destination": "/docs/guides/configure/auth-strategies/social-connections/hubspot"
+  },
+  {
+    "source": "/docs/authentication/social-connections/huggingface",
+    "destination": "/docs/guides/configure/auth-strategies/social-connections/hugging-face"
   },
   {
     "source": "/docs/authentication/social-connections/line",


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-dust-shift/authentication/social-connections/huggingface
- https://clerk.com/docs/pr/manovotny-dust-shift/reference/backend/types/email-address

### What does this solve? What changed?

Investigated the top 5 docs 404s from the last 7 days. Added static redirects for the two legitimate near-misses; the other three are AI-guessed URLs with no canonical destination.

| URL | Verdict | Action |
| --- | --- | --- |
| `/docs/authentication/social-connections/huggingface` | **Legit near-miss** — referenced from `clerk/javascript` (`packages/shared/src/oauth.ts`, `types/runtime-values.ts`) and a 2024 changelog post. Old URL prefix + alternate spelling (file is `hugging-face.mdx`). Other social-connection providers already have analogous redirects; this was a gap. | Added redirect → `/docs/guides/configure/auth-strategies/social-connections/hugging-face` |
| `/docs/authentication/social-connections/instagram` | **No canonical destination** — referenced in `clerk/javascript` source as a `docsUrl`, but no Instagram doc has ever existed and Instagram is not in the social-connections overview. Engineering should either ship an Instagram doc or remove the runtime URL. | No redirect added |
| `/docs/keyless` | **AI-guessed** — "keyless mode" exists as a Clerk feature (see `prompts/nextjs-quickstart.md`) but there is no dedicated `/docs/keyless` page, no historical equivalent, and no external references in the Clerk org. | No redirect added |
| `/docs/nuxt/reference/components/unstyled` | **AI-guessed** — `/docs/reference/components/unstyled/` exists as a parent for four component pages but has no overview page, and the framework-prefixed `/docs/nuxt/...` shape is not a Clerk URL pattern. No external references found. | No redirect added |
| `/docs/reference/backend/types/email-address` | **Legit near-miss** — file was renamed to `backend-email-address.mdx`. Direct parallel of the existing `saml-connection` → `backend-saml-connection` redirect; this was a gap. | Added redirect → `/docs/reference/backend/types/backend-email-address` |

### Deadline

No rush.

### Other resources

- The Instagram 404 likely needs engineering follow-up in `clerk/javascript` rather than a docs redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
