### PR TITLE
Update metadata for legacy custom flows

### DIFF
--- a/docs/guides/development/custom-flows/authentication/legacy/application-invitations.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/application-invitations.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sign-up with application invitations
+title: Sign-up with application invitations (Legacy)
 description: Learn how to use the Clerk API to build a custom flow for handling application invitations.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/application-invitations.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/application-invitations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sign-up with application invitations (Legacy)
-description: Learn how to use the Clerk API to build a custom flow for handling application invitations.
+description: Use the legacy Clerk API to build a custom flow for handling application invitations.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/email-links.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-links.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom flow for handling email links
+title: Build a custom flow for handling email links (Legacy)
 description: Learn how to build a custom flow using Clerk's API to handle email links for sign-up, sign-in, and email address verification.
 sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---

--- a/docs/guides/development/custom-flows/authentication/legacy/email-links.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom flow for handling email links (Legacy)
-description: Learn how to build a custom flow using Clerk's API to handle email links for sign-up, sign-in, and email address verification.
+description: Use the legacy Clerk API to build a custom flow for handling email links for sign-up, sign-in, and email address verification.
 sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom sign-in flow with multi-factor authentication
+title: Build a custom sign-in flow with multi-factor authentication (Legacy)
 description: Learn how to build a custom email/password sign-in flow that requires multi-factor authentication (MFA).
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom sign-in flow with multi-factor authentication (Legacy)
-description: Learn how to build a custom email/password sign-in flow that requires multi-factor authentication (MFA).
+description: Use the legacy Clerk API to build a custom email/password sign-in flow that requires multi-factor authentication (MFA).
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/email-password.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-password.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom email/password authentication flow
+title: Build a custom email/password authentication flow (Legacy)
 description: Learn how to build a custom email/password sign-up and sign-in flow using the Clerk API.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/email-password.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-password.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom email/password authentication flow (Legacy)
-description: Learn how to build a custom email/password sign-up and sign-in flow using the Clerk API.
+description: Use the legacy Clerk API to build a custom email/password sign-up and sign-in flow.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/email-sms-otp.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-sms-otp.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom email or phone OTP authentication flow (Legacy)
-description: Learn how to build a custom email or phone one time code (OTP) authentication flow using the Clerk API.
+description: Use the legacy Clerk API to build a custom email or phone one time code (OTP) authentication flow.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/email-sms-otp.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-sms-otp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom email or phone OTP authentication flow
+title: Build a custom email or phone OTP authentication flow (Legacy)
 description: Learn how to build a custom email or phone one time code (OTP) authentication flow using the Clerk API.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/embedded-email-links.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/embedded-email-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Embeddable email links with sign-in tokens (Legacy)
-description: Learn how to build custom embeddable email link sign-in flows to increase user engagement and reduce drop off in transactional emails, SMS's, and more.
+description: Use the legacy Clerk API to build custom embeddable email link sign-in flows to increase user engagement and reduce drop off in transactional emails, SMS's, and more.
 sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/embedded-email-links.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/embedded-email-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Embeddable email links with sign-in tokens (Legacy)
-description: Use the legacy Clerk API to build custom embeddable email link sign-in flows to increase user engagement and reduce drop off in transactional emails, SMS's, and more.
+description: Use the legacy Clerk API to build custom embeddable email link sign-in flows to increase user engagement and reduce drop off in transactional emails, SMSes, and more.
 sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/embedded-email-links.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/embedded-email-links.mdx
@@ -1,5 +1,5 @@
 ---
-title: Embeddable email links with sign-in tokens
+title: Embeddable email links with sign-in tokens (Legacy)
 description: Learn how to build custom embeddable email link sign-in flows to increase user engagement and reduce drop off in transactional emails, SMS's, and more.
 sdk: nextjs, react, nuxt, expressjs, go, ruby, vue, astro, fastify, react-router, js-frontend, chrome-extension, tanstack-react-start
 ---

--- a/docs/guides/development/custom-flows/authentication/legacy/enterprise-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/enterprise-connections.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom flow for authenticating with enterprise connections (Legacy)
-description: Learn how to use the Clerk API to build a custom sign-up and sign-in flow that supports enterprise connections.
+description: Use the legacy Clerk API to build a custom sign-up and sign-in flow that supports enterprise connections.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/enterprise-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/enterprise-connections.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom flow for authenticating with enterprise connections
+title: Build a custom flow for authenticating with enterprise connections (Legacy)
 description: Learn how to use the Clerk API to build a custom sign-up and sign-in flow that supports enterprise connections.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/last-authentication-strategy.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/last-authentication-strategy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom flow for displaying the last authentication method (Legacy)
-description: Learn how to use the Clerk API to build a custom flow for displaying the lastAuthenticationStrategy property and highlighting the last used OAuth provider with a badge.
+description: Use the legacy Clerk API to build a custom flow for displaying the lastAuthenticationStrategy property and highlighting the last used OAuth provider with a badge.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/last-authentication-strategy.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/last-authentication-strategy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom flow for displaying the last authentication method
+title: Build a custom flow for displaying the last authentication method (Legacy)
 description: Learn how to use the Clerk API to build a custom flow for displaying the lastAuthenticationStrategy property and highlighting the last used OAuth provider with a badge.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/legal-acceptance.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/legal-acceptance.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom flow for handling legal acceptance
+title: Build a custom flow for handling legal acceptance (Legacy)
 description: Learn how to use the Clerk API to build a custom user interface for handling legal acceptance.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/legal-acceptance.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/legal-acceptance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom flow for handling legal acceptance (Legacy)
-description: Learn how to use the Clerk API to build a custom user interface for handling legal acceptance.
+description: Use the legacy Clerk API to build a custom user interface for handling legal acceptance.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/oauth-connections.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom flow for authenticating with OAuth connections (Legacy)
-description: Learn how to use the Clerk API to build a custom sign-up and sign-in flow that supports OAuth connections.
+description: Use the legacy Clerk API to build a custom sign-up and sign-in flow that supports OAuth connections.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/oauth-connections.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/oauth-connections.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom flow for authenticating with OAuth connections
+title: Build a custom flow for authenticating with OAuth connections (Legacy)
 description: Learn how to use the Clerk API to build a custom sign-up and sign-in flow that supports OAuth connections.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/passkeys.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/passkeys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom authentication flow using passkeys (Legacy)
-description: Learn how to use the Clerk API to build a custom authentication flow using passkeys.
+description: Use the legacy Clerk API to build a custom authentication flow using passkeys.
 ---
 
 <Include src="_partials/custom-flows-callout" />

--- a/docs/guides/development/custom-flows/authentication/legacy/passkeys.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/passkeys.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build a custom authentication flow using passkeys
+title: Build a custom authentication flow using passkeys (Legacy)
 description: Learn how to use the Clerk API to build a custom authentication flow using passkeys.
 ---
 

--- a/docs/guides/development/custom-flows/authentication/legacy/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/sign-in-or-up.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sign-in-or-up custom flow (Legacy)
-description: Learn how to handle a combined sign-up and sign-in flow in your application.
+description: Use the legacy Clerk API to handle a combined sign-up and sign-in flow in your application.
 search:
   keywords:
     - combined

--- a/docs/guides/development/custom-flows/authentication/legacy/sign-in-or-up.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/sign-in-or-up.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sign-in-or-up custom flow
+title: Sign-in-or-up custom flow (Legacy)
 description: Learn how to handle a combined sign-up and sign-in flow in your application.
 search:
   keywords:


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What changed? 

clarifies which custom flow guides target the legacy Clerk API versus the current API by updating frontmatter on all guides under `/legacy/`:
- titles: append (Legacy) so pages are distinguishable in search results, the sidebar, and browser tabs.
- descriptions: lead with “Use the legacy Clerk API…” so metadata and snippets explicitly signal the older integration surface.

### Why did it change?

Several legacy and current guides cover similar flows (email/password, OAuth, passkeys, etc.) with overlapping titles and descriptions. Without clear labeling, it was easy to land on the wrong guide—especially from search—or assume a single “custom flow” doc applied to all SDK versions.

This change:
- improves SEO
- improves discoverability in-product
- sets expectations before read

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
