### PR TITLE
fix(totp): Remove Duo callout

### DIFF
--- a/docs/_partials/duo-authenticator-app-callout.mdx
+++ b/docs/_partials/duo-authenticator-app-callout.mdx
@@ -1,2 +1,0 @@
-> [!WARNING]
-> If you're using Duo as an authenticator app, please note that Duo generates TOTP codes differently than other authenticator apps. Duo allows a code to be valid for 30 seconds from _the moment it is first displayed_, which may cause frequent `invalid_code` errors if the code is not entered promptly. More information can be found in [Duo's Help Center](https://help.duo.com/s/article/2107).

--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -152,8 +152,6 @@ To configure MFA strategies:
    If you leave this setting disabled, users can choose to enable MFA for their own accounts through their account settings.
 1. Select **Save**.
 
-<Include src="_partials/duo-authenticator-app-callout.mdx" />
-
 If you're building a custom user interface instead of using the [Account Portal](/docs/guides/account-portal/overview) or [prebuilt components](/docs/reference/components/overview), you can use [the Clerk API](/docs/guides/development/custom-flows/authentication/multi-factor-authentication) to build a [custom flow](!custom-flow) that allows users to sign in with MFA.
 
 ### Reset a user's MFA

--- a/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa.mdx
+++ b/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa.mdx
@@ -32,8 +32,6 @@ This guide will walk you through how to build a custom email/password sign-in fl
   1. For the purpose of this guide, toggle on both the **Authenticator application** and **Backup codes** strategies.
   1. Select **Save**.
 
-  <Include src="_partials/duo-authenticator-app-callout.mdx" />
-
   ## Sign-in flow
 
   Signing in to an MFA-enabled account is identical to the regular sign-in process. However, in the case of an MFA-enabled account, a sign-in won't convert until both [first factors](!first-factor-verification) and [second factors](!second-factor-verification) verifications are completed.


### PR DESCRIPTION
### 🔎 Previews:

### What does this solve? What changed?

Following a Product Change discussion, we have expanded our allowed TOTP window to 30 seconds before and after the current 30 second window. This means that Duo Authenticator will work without trouble with Clerk, so we can delete the docs callouts about Duo.

I'm inclined to think it's not necessary for us to go into more detail about our current behavior, we can just clean up the Duo callouts.

### Deadline

No rush

### Other resources

Product change discussion: https://clerkinc.slack.com/archives/C0ADXF5HJBF/p1779292181963009
Backend PR: https://github.com/clerk/clerk_go/pull/19056
