### PR TITLE
chore: Add redirects for top docs 404s

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -3228,10 +3228,6 @@
     "destination": "/docs/guides/configure/auth-strategies/social-connections/hugging-face"
   },
   {
-    "source": "/docs/authentication/social-connections/instagram",
-    "destination": "/docs/guides/configure/auth-strategies/social-connections/overview"
-  },
-  {
     "source": "/docs/authentication/social-connections/line",
     "destination": "/docs/guides/configure/auth-strategies/social-connections/line"
   },

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -1464,6 +1464,10 @@
     "destination": "/docs/guides/development/migrating/authjs"
   },
   {
+    "source": "/docs/migrations/nextauth",
+    "destination": "/docs/guides/development/migrating/authjs"
+  },
+  {
     "source": "/docs/guides/force-mfa",
     "destination": "/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication"
   },
@@ -4393,7 +4397,7 @@
   },
   {
     "source": "/docs/remix/reference/components/control",
-    "destination": "/docs/core-2/remix/reference/components/control"
+    "destination": "/docs/core-2/remix/reference/components/overview"
   },
   {
     "source": "/docs/remix/reference/components/user",

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -1468,6 +1468,22 @@
     "destination": "/docs/guides/development/migrating/authjs"
   },
   {
+    "source": "/docs/migrations/auth0",
+    "destination": "/docs/guides/development/migrating/overview"
+  },
+  {
+    "source": "/docs/migrations/supabase",
+    "destination": "/docs/guides/development/migrating/overview"
+  },
+  {
+    "source": "/docs/migrations/firebase",
+    "destination": "/docs/guides/development/migrating/firebase"
+  },
+  {
+    "source": "/docs/migrations/overview",
+    "destination": "/docs/guides/development/migrating/overview"
+  },
+  {
     "source": "/docs/guides/force-mfa",
     "destination": "/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication"
   },

--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -3196,6 +3196,10 @@
     "destination": "/docs/guides/configure/auth-strategies/social-connections/dropbox"
   },
   {
+    "source": "/docs/authentication/social-connections/enstall",
+    "destination": "/docs/guides/configure/auth-strategies/social-connections/overview"
+  },
+  {
     "source": "/docs/authentication/social-connections/facebook",
     "destination": "/docs/guides/configure/auth-strategies/social-connections/facebook"
   },
@@ -3218,6 +3222,10 @@
   {
     "source": "/docs/authentication/social-connections/huggingface",
     "destination": "/docs/guides/configure/auth-strategies/social-connections/hugging-face"
+  },
+  {
+    "source": "/docs/authentication/social-connections/instagram",
+    "destination": "/docs/guides/configure/auth-strategies/social-connections/overview"
   },
   {
     "source": "/docs/authentication/social-connections/line",


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-actually-cicada/authentication/social-connections/enstall
- https://clerk.com/docs/pr/manovotny-actually-cicada/migrations/nextauth
- https://clerk.com/docs/pr/manovotny-actually-cicada/migrations/auth0
- https://clerk.com/docs/pr/manovotny-actually-cicada/migrations/supabase
- https://clerk.com/docs/pr/manovotny-actually-cicada/migrations/firebase
- https://clerk.com/docs/pr/manovotny-actually-cicada/migrations/overview
- https://clerk.com/docs/pr/manovotny-actually-cicada/remix/reference/components/control

### What does this solve? What changed?

A rolling PR collecting redirects from consecutive weekly Docs 404 reports. Each report is triaged the same way; only legit near-misses and structural gaps get a redirect — AI-guessed and truncated paths are skipped.

A recurring root cause: several of these 404s are URLs that **Clerk tooling itself ships** — the JS SDK as a provider `docsUrl`, the CLI as a migration-guide link — pointing at pages that don't exist. Already-released tool versions have those URLs baked in permanently, so the redirects are worth keeping as a permanent stopgap regardless of any upstream fix. See _Other resources_ for the root-cause follow-ups.

> [!NOTE]
> The Instagram 404 (`/docs/authentication/social-connections/instagram`) was pulled out of this PR — it's the only item with an unresolved product question (deprecated upstream API + returns no email), so it shouldn't block these decided fixes. It's now tracked separately in **[DOCS-11818](https://linear.app/clerk/issue/DOCS-11818/instagram-social-connection-sdk-docsurl-404s-decide-document-vs)**.

#### Investigation methodology

- Traced each URL back to whatever emits it (JS SDK, CLI scan, existing redirects) via local repo greps + `gh search code` across the Clerk org
- Verified the live 404 status of each URL (and candidate destinations) against the production site
- Cross-referenced each URL against existing redirects in `redirects/static/docs.json`
- Validated with `build:tsx`, `lint:check-duplicate-redirects`, and `lint:check-redirects` — all checks pass

#### Report 1 — social connection providers

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/authentication/social-connections/enstall` | **Real but private provider** — Enstall is an instance-gated, single-customer OIDC provider (`clerk_go:pkg/oauth/provider/enstall.go` comment: _"implemented for a specific customer… will not be available to other customers, via Dashboard"_; gated by `FLAG_ENSTALL_ALLOWED_INSTANCE_IDS`). The JS SDK still ships this URL as the provider's `docsUrl` (`packages/shared/src/oauth.ts`, `runtime-values.ts`), so real users hit the 404. No docs page exists — and per discussion, none should: the CLI and Platform API already hide Enstall unless it's enabled for the instance. | ✅ Redirect to social-connections overview as a stopgap. Root fix = drop the SDK `docsUrl` for Enstall → **DOCS-11817**. |
| 2 | `/docs/qui` | **Truncation noise** — 3 chars after `/docs/`; almost certainly a truncated display of `/docs/quickstart` / `/docs/quickstarts/*`. Both `/docs/quickstarts` and `/docs/quickstart` already redirect to the right places. The bare truncated path is not a real URL. | Skipped |
| 3 | `/docs/authentication/social-connection-with-instagram` | **AI-guessed** — Old `social-connection-with-*` URL pattern, but Instagram never had a docs page at that path (zero references in clerk org for this exact URL). Likely a model extrapolating from sibling providers (`-with-facebook`, `-with-github`, etc). | Skipped |
| 4 | `/docs/authentication/configuration/si` | **Truncation noise** — Truncated display of `/docs/authentication/configuration/sign-up-sign-in-options` (often with a `#social-connections-o-auth` fragment, as referenced from `clerk/clerk-android` and several blog posts). The full URL already resolves; the bare `/si` prefix is not a real URL. | Skipped |
| 5 | `/docs/authentication/social-connections/instagram` | **Real provider, undocumented** — Instagram is supported across `clerk_go`, `clerk/javascript`, `clerk/dashboard`, `clerk-ios`, and `clerk-android`, and the JS SDK ships this exact URL as its `docsUrl`. But the `clerk_go` implementation uses Meta's deprecated Instagram Basic Display API (`graph.instagram.com/v14.0`) and returns no email (`AllowsUnverifiedEmails: false`), so whether we should document it at all is an open question. | ⏭️ Pulled from this PR — tracked separately in **[DOCS-11818](https://linear.app/clerk/issue/DOCS-11818/instagram-social-connection-sdk-docsurl-404s-decide-document-vs)**. |

#### Report 2 (2026-06-01)

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/migrations/nextauth` | **CLI-emitted, real near-miss** — Clerk CLI's `clerk init` scan (`cli:packages/cli-core/src/commands/init/scan.ts`) ships this URL on `next-auth` detection, but the real guide lives at `/docs/guides/development/migrating/authjs` (titled _"Migrate from Auth.js to Clerk (formerly NextAuth.js)"_). The `/docs/migrations/*` namespace never existed. | ✅ Redirect → `/docs/guides/development/migrating/authjs` |
| 2 | `/docs/core-2/remix/reference/components/control` | **Structural — our own redirect pointed at a dead folder** — `control` is a category folder with no index page (leaf pages like `…/control/authenticate-with-redirect-callback` resolve fine). The existing redirect `/docs/remix/reference/components/control` sent users to this index-less core-2 folder → 404. A static redirect for the core-2 _source_ isn't possible — it's a protected dynamic route (`/docs/core-2/[precomputeCode]/[[...slug]]`), which is why core-2 pages render without local files. | ✅ Repointed the existing `/docs/remix/reference/components/control` redirect → live `/docs/core-2/remix/reference/components/overview`. Direct hits to the bare core-2 path would need a fix in the core-2 renderer (dotcom), not static redirects. |
| 3 | `/docs/migrations/auth0` | **CLI-emitted, same root cause as #1** — emitted on Auth0 detection. Clerk has no dedicated Auth0 migration guide yet, but the migration tool ships a first-class Auth0 transformer, and the generic `migrating/overview` covers the actual import mechanics. | ✅ Redirect → `/docs/guides/development/migrating/overview` (repoint to a dedicated Auth0 guide once **DOCS-11819** lands). |
| 4 | `/docs/authentication/social-connections/instagram` | **Repeat of Report 1 #5** — tracked separately in **[DOCS-11818](https://linear.app/clerk/issue/DOCS-11818/instagram-social-connection-sdk-docsurl-404s-decide-document-vs)**. | ⏭️ Pulled from this PR |
| 5 | `/docs/nextjs/getting-started/quickstart/react` | **AI-guessed / malformed** — quickstart is the leaf (`…/quickstart`, resolves); `/react` appended is not a real page. Zero references in any repo or the CLI. | Skipped |

#### Also closed — the rest of the CLI `/docs/migrations/*` family

The CLI's `scan.ts` emits five `/docs/migrations/*` links; all 404. Beyond `nextauth` (#1) and `auth0` (#3) from the reports, the remaining three are fixed here too so they don't resurface in future weekly reports:

- `/docs/migrations/supabase` → `/docs/guides/development/migrating/overview` _(repoint to a dedicated Supabase guide once **DOCS-11819** lands)_
- `/docs/migrations/firebase` → `/docs/guides/development/migrating/firebase`
- `/docs/migrations/overview` → `/docs/guides/development/migrating/overview`

#### Changes

**Static redirects** (`redirects/static/docs.json`):

- `/docs/authentication/social-connections/enstall` → `/docs/guides/configure/auth-strategies/social-connections/overview`
- `/docs/migrations/nextauth` → `/docs/guides/development/migrating/authjs`
- `/docs/migrations/auth0` → `/docs/guides/development/migrating/overview`
- `/docs/migrations/supabase` → `/docs/guides/development/migrating/overview`
- `/docs/migrations/firebase` → `/docs/guides/development/migrating/firebase`
- `/docs/migrations/overview` → `/docs/guides/development/migrating/overview`
- `/docs/remix/reference/components/control` → `/docs/core-2/remix/reference/components/overview` _(repointed from the index-less `…/components/control`)_

### Deadline

- No rush

### Other resources

- **Enstall — SDK follow-up → [DOCS-11817](https://linear.app/clerk/issue/DOCS-11817/drop-docsurl-for-enstall-oauth-provider-in-clerkjavascript-source-of-a):** Drop (or make optional and remove) the `docsUrl` for `enstall` in `clerk/javascript` so the SDK stops pointing users at a private provider's non-existent docs. Enstall only on the SDK side — `expressen` isn't present in the JS SDK.
- **Instagram — tracked separately → [DOCS-11818](https://linear.app/clerk/issue/DOCS-11818/instagram-social-connection-sdk-docsurl-404s-decide-document-vs):** Pulled from this PR pending a product decision (deprecated Meta Basic Display API + no email returned). The issue captures the full findings and links a Slack thread with the provider owner.
- **Migrating docs re-evaluation → [DOCS-11819](https://linear.app/clerk/issue/DOCS-11819/re-evaluate-the-migrating-docs-fix-stale-overview-add-auth0-and):** The `migrating/overview` page is stale and self-contradictory (its "you cannot migrate Dev→Prod" callout is contradicted by the migration tool's own `clerkTransformer`, which supports exactly that), and there's a content gap — no Auth0 or Supabase guide despite the tool shipping dedicated transformers for both. Ticket covers refreshing the overview and adding the two guides. The auth0/supabase redirects above repoint to those guides once they exist.
- **CLI root cause → [DOCS-11820](https://linear.app/clerk/issue/DOCS-11820/repoint-clerkcli-migration-docsurls-to-docsguidesdevelopmentmigrating):** `clerk/cli:scan.ts` hardcodes all five `/docs/migrations/*` links under a namespace that never existed. Repoint them to `/docs/guides/development/migrating/*`. Blocked by DOCS-11819 (needs the final Auth0/Supabase guide URLs); the redirects in this PR are the stopgap in the meantime.
- Previous 404 redirect PR: [#3359](https://github.com/clerk/clerk-docs/pull/3359)
