### PR TITLE
Regenerate API Errors

### DIFF
--- a/data/api_errors.json
+++ b/data/api_errors.json
@@ -4849,7 +4849,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "instances.go"
   },
@@ -8756,7 +8756,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "users.go"
   },
@@ -8876,7 +8876,7 @@
     "code": "user_quota_exceeded",
     "status": "403",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "users.go"

--- a/data/api_errors.json
+++ b/data/api_errors.json
@@ -180,6 +180,18 @@
     "file": "allowlist_identifiers.go"
   },
   {
+    "name": "AnalyticsUnavailable",
+    "shortMessage": "analytics unavailable",
+    "longMessage": "Analytics data is temporarily unavailable.",
+    "code": "analytics_unavailable",
+    "status": "503",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "analytics.go"
+  },
+  {
     "name": "APIKeysAlreadyEnabled",
     "shortMessage": "API Keys already enabled",
     "longMessage": "API Keys already enabled",
@@ -199,7 +211,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "apikeys.go"
   },
@@ -346,6 +358,32 @@
     "file": "applications.go"
   },
   {
+    "name": "WorkspaceNotConfigured",
+    "description": "WorkspaceNotConfigured is returned when the workspace is missing\nconfiguration required to complete the operation (for example, a role\nor feature that has not yet been provisioned).",
+    "shortMessage": "workspace not configured",
+    "longMessage": "Workspace is not configured for this operation.",
+    "code": "workspace_not_configured",
+    "status": "",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "applications.go"
+  },
+  {
+    "name": "ManagementTokenSubjectNotFound",
+    "description": "ManagementTokenSubjectNotFound is returned when redeeming a management\ntoken whose referenced user no longer exists in the instance.",
+    "shortMessage": "user not found",
+    "longMessage": "The user referenced by this management token no longer exists. Mint a new token.",
+    "code": "management_token_subject_not_found",
+    "status": "404",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "applications.go"
+  },
+  {
     "name": "InvalidPlanForResource",
     "description": "InvalidPlanForResource is returned when an invalid plan is selected for a\nresource.",
     "shortMessage": "Invalid plan",
@@ -428,7 +466,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "applications.go"
   },
@@ -451,30 +489,6 @@
     "shortMessage": "The provided Clerk Secret Key is invalid. Make sure that your Clerk Secret Key is correct.",
     "longMessage": "The provided Clerk Secret Key is invalid. Make sure that your Clerk Secret Key is correct.",
     "code": "clerk_key_invalid",
-    "status": "401",
-    "usage": {
-      "fapi": false,
-      "bapi": true
-    },
-    "file": "auth.go"
-  },
-  {
-    "name": "FailedToVerifyInternalMigrationJWT",
-    "shortMessage": "Failed to verify internal migration JWT.",
-    "longMessage": "Failed to verify internal migration JWT.",
-    "code": "failed_to_verify_internal_migration_jwt",
-    "status": "401",
-    "usage": {
-      "fapi": false,
-      "bapi": true
-    },
-    "file": "auth.go"
-  },
-  {
-    "name": "InternalMigrationJWTMissingInstanceID",
-    "shortMessage": "The provided internal migration JWT is missing the instance ID.",
-    "longMessage": "The provided internal migration JWT is missing the instance ID.",
-    "code": "internal_migration_jwt_missing_instance_id",
     "status": "401",
     "usage": {
       "fapi": false,
@@ -542,6 +556,20 @@
     "status": "403",
     "usage": {
       "fapi": true,
+      "bapi": false
+    },
+    "file": "auth.go"
+  },
+  {
+    "name": "AuthorizationMissingScopes",
+    "description": "AuthorizationMissingScopes signifies that the authorization is missing required scope(s).\nReturns a 403 Forbidden error.",
+    "shortMessage": "Missing authorization scopes",
+    "longMessage": "Missing authorization scopes",
+    "code": "authorization_missing_scopes",
+    "meta": "{\"Scopes\": \"missing\"}",
+    "status": "403",
+    "usage": {
+      "fapi": false,
       "bapi": false
     },
     "file": "auth.go"
@@ -759,7 +787,7 @@
     "status": "403",
     "usage": {
       "fapi": true,
-      "bapi": true
+      "bapi": false
     },
     "file": "auth.go"
   },
@@ -812,7 +840,7 @@
     "status": "409",
     "usage": {
       "fapi": true,
-      "bapi": false
+      "bapi": true
     },
     "file": "auth.go"
   },
@@ -866,6 +894,18 @@
     "file": "awscognito.go"
   },
   {
+    "name": "AwsCognitoUserLambdaValidationFailed",
+    "shortMessage": "AWS Cognito user validation failed.",
+    "longMessage": "The sign-in attempt was rejected by the AWS Cognito user validation Lambda trigger.",
+    "code": "aws_cognito_user_lambda_validation_failed",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "awscognito.go"
+  },
+  {
     "name": "CannotSetUnlimitedSeatsForUserApplication",
     "shortMessage": "not allowed to set unlimited seats",
     "longMessage": "Cannot set unlimited seats for user applications.",
@@ -895,6 +935,19 @@
     "longMessage": "Cannot update user limits on production instances.",
     "code": "cannot_update_user_limits_on_production",
     "status": "400",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "backoffice.go"
+  },
+  {
+    "name": "MissingBackofficePermission",
+    "shortMessage": "missing backoffice permission",
+    "longMessage": "The current user is missing the required backoffice permission(s): \u003cpermList\u003e.",
+    "code": "missing_backoffice_permission",
+    "meta": "{\"Permissions\": \"permissions\"}",
+    "status": "403",
     "usage": {
       "fapi": false,
       "bapi": false
@@ -1091,7 +1144,7 @@
     "status": "409",
     "usage": {
       "fapi": true,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1127,7 +1180,7 @@
     "status": "404",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1139,7 +1192,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1151,7 +1204,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1175,7 +1228,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1199,7 +1252,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1271,7 +1324,7 @@
     "status": "404",
     "usage": {
       "fapi": true,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1283,7 +1336,7 @@
     "status": "409",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1420,6 +1473,18 @@
     "file": "commerce.go"
   },
   {
+    "name": "SeatReductionInCheckoutNotSupported",
+    "shortMessage": "Seat reduction not supported in checkout",
+    "longMessage": "Seats cannot be reduced through checkout.",
+    "code": "seat_reduction_in_checkout_not_supported",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "commerce.go"
+  },
+  {
     "name": "PaymentSourceInUse",
     "shortMessage": "Payment source in use",
     "longMessage": "Payment source is in use, as you have active subscriptions. Please cancel those subscriptions before deleting the payment source.",
@@ -1537,7 +1602,7 @@
     "status": "409",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1561,7 +1626,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1573,7 +1638,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1598,7 +1663,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1611,7 +1676,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1624,7 +1689,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1637,7 +1702,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1649,7 +1714,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1661,7 +1726,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1745,14 +1810,14 @@
     "status": "409",
     "usage": {
       "fapi": true,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
   {
     "name": "PlanAlreadyActive",
     "shortMessage": "Plan already active",
-    "longMessage": "This plan is already active for plan period: \u003cplanPeriod\u003e.",
+    "longMessage": "Plan already active",
     "code": "plan_already_active",
     "status": "409",
     "usage": {
@@ -1854,7 +1919,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1866,7 +1931,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1878,7 +1943,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "commerce.go"
   },
@@ -1994,7 +2059,7 @@
   {
     "name": "PlanSeatLimitExceeded",
     "shortMessage": "Plan seat limit exceeded",
-    "longMessage": "This plan only allows %d seats, but your organization has %d members. Please remove members before switching to this plan.",
+    "longMessage": "Your organization has \u003ccurrentMembersStr\u003e members, but the requested plan would only support \u003cseatLimitStr\u003e members. Please remove members before switching to this plan.",
     "code": "plan_seat_limit_exceeded",
     "meta": "{\"PlanSeatLimit\": planSeatLimit, \"CurrentMembers\": currentMembers}",
     "status": "422",
@@ -2005,9 +2070,46 @@
     "file": "commerce.go"
   },
   {
+    "name": "RequestedSeatsInsufficient",
+    "shortMessage": "Requested seats insufficient",
+    "longMessage": "Your organization has \u003ccurrentMembersStr\u003e members but this checkout only grants \u003cgrantedSeatsStr\u003e seats. Please request at least \u003ccurrentMembersStr\u003e seats or remove members.",
+    "code": "requested_seats_insufficient",
+    "meta": "{\"PlanSeatLimit\": grantedSeats, \"CurrentMembers\": currentMembers}",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "commerce.go"
+  },
+  {
+    "name": "PlanCannotHaveSeats",
+    "shortMessage": "Plan cannot have seats",
+    "longMessage": "The selected plan is not seat-based, but the checkout request included a seat_quantity.",
+    "code": "plan_cannot_have_seats",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "commerce.go"
+  },
+  {
+    "name": "PriceIDInvalidForCheckout",
+    "shortMessage": "Invalid price_id for checkout",
+    "longMessage": "You cannot checkout with that price.",
+    "code": "price_id_invalid_for_checkout",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "commerce.go"
+  },
+  {
     "name": "OrgMemberLimitExceededForPlanChange",
     "shortMessage": "Organization member limit exceeded",
-    "longMessage": "Plan change is not allowed because the organization's %d occupied seats exceed the limit of %d organization memberships.",
+    "longMessage": "Plan change is not allowed because the organization's \u003coccupiedSeatsStr\u003e occupied seats exceed the limit of \u003cmaxAllowedStr\u003e organization memberships.",
     "code": "org_member_limit_exceeded_for_plan_change",
     "status": "422",
     "usage": {
@@ -2185,6 +2287,18 @@
     "file": "commerce.go"
   },
   {
+    "name": "UnitPriceFreeTierAfterPaidTier",
+    "shortMessage": "Free tier cannot follow a paid tier",
+    "longMessage": "Unit price '\u003cunitName\u003e' tier %d is free but a preceding tier is paid. Once a tier is paid, all subsequent tiers must also be paid",
+    "code": "unit_price_free_tier_after_paid_tier",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "commerce.go"
+  },
+  {
     "name": "PayerCreditsDisabled",
     "shortMessage": "Payer credits disabled",
     "longMessage": "The payer credits feature is not enabled for this application",
@@ -2249,13 +2363,109 @@
     "shortMessage": "Insufficient seats",
     "longMessage": "You have reached the seat limit for your current plan.",
     "code": "insufficient_seats",
-    "meta": "{\"Remedy\": \"remedy\"}",
+    "meta": "{\"SeatsQuantity\": \"totalNeeded\"}",
     "status": "402",
     "usage": {
-      "fapi": true,
-      "bapi": false
+      "fapi": false,
+      "bapi": true
     },
     "file": "commerce.go"
+  },
+  {
+    "name": "BillingAnnualOnlyPlansNotEnabled",
+    "shortMessage": "Annual only plans are not enabled",
+    "longMessage": "Annual only plans are not enabled, please enable the update in Clerk dashboard.",
+    "code": "billing_annual_only_plans_not_enabled",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "commerce.go"
+  },
+  {
+    "name": "ConfigVersionConflict",
+    "description": "ConfigVersionConflict returns a 409 error for ETag mismatch",
+    "shortMessage": "Config version conflict",
+    "longMessage": "Config was modified since last read. Re-fetch and retry.",
+    "code": "config_version_conflict",
+    "meta": "{\"current_version\": \"currentVersion\", \"provided_version\": \"providedVersion\"}",
+    "status": "409",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "config.go"
+  },
+  {
+    "name": "UnknownConfigKey",
+    "description": "UnknownConfigKey returns a 400 error with typo suggestions",
+    "shortMessage": "",
+    "longMessage": "Unknown config key '\u003ckey\u003e'",
+    "code": "unknown_config_key",
+    "meta": "\"meta\"",
+    "status": "400",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "config.go"
+  },
+  {
+    "name": "DestructiveOperationNotAllowed",
+    "description": "DestructiveOperationNotAllowed returns a 400 error",
+    "shortMessage": "",
+    "longMessage": "Cannot clear config key '\u003ckey\u003e' without destructive=true",
+    "code": "destructive_operation_not_allowed",
+    "meta": "{\"param_name\": \"key\"}",
+    "status": "400",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "config.go"
+  },
+  {
+    "name": "MissingConfigKeys",
+    "description": "MissingConfigKeys returns a 400 error listing keys that were not included in a PUT request",
+    "shortMessage": "Missing config keys",
+    "longMessage": "PUT requires all config keys to be included. Some keys are missing.",
+    "code": "missing_config_keys",
+    "meta": "{\"MissingKeys\": \"missing\"}",
+    "status": "400",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "config.go"
+  },
+  {
+    "name": "ConfigValidationError",
+    "description": "ConfigValidationError returns a 422 error with schema path",
+    "shortMessage": "",
+    "longMessage": "",
+    "code": "config_validation_error",
+    "meta": "{\"config_key\": \"configKey\", \"param_name\": \"paramName\", \"schema_path\": \"schemaPath\"}",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "config.go"
+  },
+  {
+    "name": "InvalidConfigKeyBody",
+    "description": "InvalidConfigKeyBody returns a 400 error indicating the value for a config\nkey has the wrong shape (e.g. an array of objects where the schema expects\nan array of strings).",
+    "shortMessage": "",
+    "longMessage": "The value for config key '\u003ckey\u003e' does not match the expected schema.",
+    "code": "config_key_body_invalid",
+    "meta": "{\"param_name\": \"key\"}",
+    "status": "400",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "config.go"
   },
   {
     "name": "MissingClaims",
@@ -2413,10 +2623,23 @@
     "file": "domains.go"
   },
   {
+    "name": "FeatureRequiresCustomDomain",
+    "description": "FeatureRequiresCustomDomain signifies an error when a feature is blocked\nbecause the instance only has a provider domain (e.g. vercel.app).",
+    "shortMessage": "custom domain required",
+    "longMessage": "\u003cfeature\u003e requires a custom domain. Add a custom domain to unlock this feature.",
+    "code": "feature_requires_custom_domain",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "domains.go"
+  },
+  {
     "name": "ProviderDomainOperationNotAllowedForAPI",
     "description": "Return this error when an API other than Platform API is used to create/update/delete a provider domain.",
     "shortMessage": "operation not allowed",
-    "longMessage": "The domain (\u003cdomainName\u003e) is a provider domain. Only the Platform API is allowed to be used to manage provider domains.",
+    "longMessage": "*\u003cprovider\u003e domains are not supported for production instances. Please purchase a domain then try again.",
     "code": "provider_domain_operation_not_allowed",
     "status": "403",
     "usage": {
@@ -2477,6 +2700,44 @@
     "file": "email.go"
   },
   {
+    "name": "SelfServeSSODisabled",
+    "shortMessage": "self-serve SSO not enabled",
+    "longMessage": "The self-serve SSO feature is not enabled for this instance.",
+    "code": "self_serve_sso_disabled",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "enterprise_sso.go"
+  },
+  {
+    "name": "SelfServeSSONoActiveOrganization",
+    "description": "SelfServeSSONoActiveOrganization signals that the session has no\nlast_active_organization_id. Self-serve SSO is per-org; an active org context\nis required before any enterprise connection can be created.",
+    "shortMessage": "no active organization",
+    "longMessage": "Self-serve SSO requires an active organization. Switch to an organization before creating an enterprise connection.",
+    "code": "self_serve_sso_no_active_organization",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "enterprise_sso.go"
+  },
+  {
+    "name": "SelfServeSSOOrganizationDisabled",
+    "description": "SelfServeSSOOrganizationDisabled signals that the active organization does\nnot have the self-serve SSO toggle enabled.",
+    "shortMessage": "self-serve SSO not enabled for organization",
+    "longMessage": "Self-serve SSO is not enabled for the active organization.",
+    "code": "self_serve_sso_organization_disabled",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "enterprise_sso.go"
+  },
+  {
     "name": "EnterpriseSSOSignUpConnectionMissing",
     "shortMessage": "No Enterprise Connection for this sign-up",
     "longMessage": "The current sign-up does not have a corresponding Enterprise Connection. Please check the domain of the provided email address.",
@@ -2495,7 +2756,7 @@
     "code": "enterprise_sso_sign_in_connection_missing",
     "status": "422",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "enterprise_sso.go"
@@ -2575,6 +2836,30 @@
     "file": "enterprise_sso.go"
   },
   {
+    "name": "EnterpriseSSOAccountAlreadyConnected",
+    "shortMessage": "Already connected",
+    "longMessage": "An enterprise account is already connected for this connection.",
+    "code": "enterprise_sso_account_already_connected",
+    "status": "400",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "enterprise_sso.go"
+  },
+  {
+    "name": "EnterpriseSSOAccountAlreadyConnectedWithEmail",
+    "shortMessage": "Already connected",
+    "longMessage": "An enterprise account is already connected for this connection email: \u003cemail\u003e",
+    "code": "enterprise_sso_account_already_connected",
+    "status": "400",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "enterprise_sso.go"
+  },
+  {
     "name": "EnterpriseConnectionInvalidType",
     "shortMessage": "Invalid enterprise connection type",
     "longMessage": "The enterprise connection type is not supported.",
@@ -2599,6 +2884,19 @@
     "file": "features.go"
   },
   {
+    "name": "FeatureNotEnabledWithMeta",
+    "shortMessage": "not enabled",
+    "longMessage": "This feature is not enabled on this instance",
+    "code": "feature_not_enabled",
+    "meta": "{\"Name\": \"paramName\"}",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "features.go"
+  },
+  {
     "name": "NotImplemented",
     "shortMessage": "not implemented",
     "longMessage": "Feature `\u003cfeature\u003e` is not available yet",
@@ -2606,7 +2904,7 @@
     "status": "403",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "features.go"
   },
@@ -2738,7 +3036,7 @@
     "status": "404",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "features.go"
   },
@@ -2786,7 +3084,7 @@
     "status": "409",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "features.go"
   },
@@ -2915,6 +3213,20 @@
     "file": "forms.go"
   },
   {
+    "name": "FormAlreadyExistsByProviderManagedDomain",
+    "description": "FormAlreadyExistsByProviderManagedDomain signifies an error when a domain\nalready exists on an app managed by an external provider.",
+    "shortMessage": "",
+    "longMessage": "The \u003cdomain\u003e root domain is already in use by a \u003cproviderName\u003e app. Delete the \u003cproviderName\u003e app or contact \u003cproviderName\u003e support to remove the domain before using it in Clerk.",
+    "code": "form_already_exists",
+    "meta": "{\"Name\": \"param\"}",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "forms.go"
+  },
+  {
     "name": "FormIncorrectCode",
     "description": "FormIncorrectCode signifies an error when the given code is incorrect",
     "shortMessage": "is incorrect",
@@ -3005,7 +3317,7 @@
     "meta": "{\"Name\": \"param\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3133,8 +3445,8 @@
   {
     "name": "FormInvalidPasswordSizeInBytesExceeded",
     "description": "FormInvalidPasswordSizeInBytesExceeded signifies that the size in bytes was exceeded.\nNote that the maximum character length constraint may fail to detect this case,\nif multi-byte characters are included in the password.\nFor example, bcrypt limit https://cs.opensource.google/go/x/crypto/+/refs/tags/v0.8.0:bcrypt/bcrypt.go;l=87",
-    "shortMessage": "Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.",
-    "longMessage": "Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.",
+    "shortMessage": "Your password is too long. Please use a shorter one.",
+    "longMessage": "Your password is too long. Please use a shorter one.",
     "code": "form_password_size_in_bytes_exceeded",
     "meta": "{\"Name\": \"param\"}",
     "status": "422",
@@ -3236,7 +3548,7 @@
     "code": "form_conditional_param_missing",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3292,7 +3604,7 @@
     "meta": "{\"Name\": \"missingParam\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3334,7 +3646,7 @@
     "meta": "{\"Name\": \"notAllowedParam\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3417,7 +3729,7 @@
     "meta": "{\"Name\": \"param\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3498,7 +3810,7 @@
     "meta": "{\"Name\": \"param\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3532,6 +3844,20 @@
     "file": "forms.go"
   },
   {
+    "name": "FormParameterDeprecated",
+    "description": "FormParameterDeprecated signifies an error when a form parameter has been\ndeprecated and is no longer accepted by the endpoint. The resolution argument\ncan describe the recommended replacement (e.g. a different endpoint) and is\nappended to the long message when non-empty.",
+    "shortMessage": "is deprecated",
+    "longMessage": "is deprecated",
+    "code": "form_param_deprecated",
+    "meta": "{\"Name\": \"param\"}",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": true
+    },
+    "file": "forms.go"
+  },
+  {
     "name": "FormUnverifiedIdentification",
     "description": "FormUnverifiedIdentification signifies an error when the identification included in the form is unverified",
     "shortMessage": "is unverified",
@@ -3540,8 +3866,8 @@
     "meta": "{\"Name\": \"param\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "forms.go"
   },
@@ -3775,6 +4101,20 @@
     "file": "forms.go"
   },
   {
+    "name": "FormUsernameCannotBePhoneNumber",
+    "description": "FormUsernameCannotBePhoneNumber signifies an error when the given username\nis in canonical E.164 phone-number format. This is rejected regardless of\nthe configured username character set so that the value remains reserved\nfor the phone-number identifier and avoids ambiguity at sign-in.",
+    "shortMessage": "",
+    "longMessage": "\u003cparameter\u003e cannot be a phone number. Please choose a different username.",
+    "code": "form_username_cannot_be_phone_number",
+    "meta": "{\"Name\": \"param\"}",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": true
+    },
+    "file": "forms.go"
+  },
+  {
     "name": "FormInvalidUsernameCharacter",
     "description": "FormInvalidUsernameCharacter signifies an error when the given username does not match username regex",
     "shortMessage": "",
@@ -3823,7 +4163,7 @@
     "meta": "{\"Name\": \"param\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "forms.go"
@@ -3910,6 +4250,18 @@
     "longMessage": "This device was detected as suspicious and has been blocked. It will no longer be able to perform actions. If you believe this was by mistake, please contact support.",
     "code": "device_blocked",
     "status": "",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "fraud.go"
+  },
+  {
+    "name": "ProtectCheckAlreadyResolved",
+    "shortMessage": "protect check already resolved",
+    "longMessage": "This protect check has already been completed and cannot be resolved again.",
+    "code": "protect_check_already_resolved",
+    "status": "400",
     "usage": {
       "fapi": true,
       "bapi": false
@@ -4007,7 +4359,7 @@
     "code": "requires_assertion",
     "status": "401",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "fraud.go"
@@ -4141,6 +4493,20 @@
     "file": "home_url.go"
   },
   {
+    "name": "HomeURLTakenByProvider",
+    "description": "HomeURLTakenByProvider signifies an error when the root domain of the\nprovided home_url is already used by a provider-managed app.",
+    "shortMessage": "",
+    "longMessage": "The \u003chomeURL\u003e root domain is already in use by a \u003cproviderName\u003e app. Delete the \u003cproviderName\u003e app or contact \u003cproviderName\u003e support to remove the domain before using it in Clerk.",
+    "code": "home_url_taken",
+    "meta": "{\"Name\": \"paramName\"}",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "home_url.go"
+  },
+  {
     "name": "IdentificationNotFound",
     "description": "IdentificationNotFound signifies an error when comm is not found",
     "shortMessage": "Resource not found",
@@ -4233,7 +4599,7 @@
     "code": "primary_identification_not_found",
     "status": "404",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "identifications.go"
@@ -4295,8 +4661,8 @@
     "code": "image_too_large",
     "status": "413",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "images.go"
   },
@@ -4319,8 +4685,8 @@
     "code": "request_body_invalid",
     "status": "400",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "images.go"
   },
@@ -4331,8 +4697,8 @@
     "code": "request_body_invalid",
     "status": "400",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "images.go"
   },
@@ -4412,6 +4778,19 @@
     "file": "instance_settings.go"
   },
   {
+    "name": "EmailProviderMailgunDomainNotVerified",
+    "shortMessage": "Mailgun domain not verified",
+    "longMessage": "Cannot set email_provider to 'mailgun' because the instance's active domain has not been verified in Mailgun.",
+    "code": "email_provider_mailgun_domain_not_verified",
+    "meta": "{\"Name\": \"email_provider\"}",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "instance_settings.go"
+  },
+  {
     "name": "InvalidCaptchaWidgetType",
     "shortMessage": "Invalid captcha widget type",
     "longMessage": "The captcha widget type '\u003cwidgetType\u003e' is invalid. Allowed values: \u003callowedTypes\u003e",
@@ -4419,7 +4798,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "instance_settings.go"
   },
@@ -4431,7 +4810,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "instance_settings.go"
   },
@@ -4696,13 +5075,26 @@
   },
   {
     "name": "Conflict",
-    "description": "409 - conflict",
+    "description": "409 - conflict.\nThis apierror provides very little context and should likely be avoided for\nerrors that will be customer- or end-user-facing. For lock errors, consider\ninstead ResourceBusy().",
     "shortMessage": "Conflict",
     "longMessage": "Conflict",
     "code": "conflict",
     "status": "409",
     "usage": {
       "fapi": false,
+      "bapi": true
+    },
+    "file": "internal.go"
+  },
+  {
+    "name": "ResourceBusy",
+    "description": "409 - resource locked",
+    "shortMessage": "resource busy",
+    "longMessage": "This resource is currently being modified by another request. Please try again.",
+    "code": "resource_locked",
+    "status": "409",
+    "usage": {
+      "fapi": true,
       "bapi": true
     },
     "file": "internal.go"
@@ -4950,6 +5342,54 @@
     "file": "management.go"
   },
   {
+    "name": "NativeMagicLinkApprovalTokenConsumed",
+    "shortMessage": "approval token consumed",
+    "longMessage": "The approval token has already been used.",
+    "code": "approval_token_consumed",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "native_magic_link.go"
+  },
+  {
+    "name": "NativeMagicLinkApprovalTokenExpired",
+    "shortMessage": "approval token expired",
+    "longMessage": "The approval token has expired. Please request a new email link.",
+    "code": "approval_token_expired",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "native_magic_link.go"
+  },
+  {
+    "name": "NativeMagicLinkApprovalTokenInvalid",
+    "shortMessage": "approval token invalid",
+    "longMessage": "The approval token is invalid.",
+    "code": "approval_token_invalid",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "native_magic_link.go"
+  },
+  {
+    "name": "NativeMagicLinkPKCEVerificationFailed",
+    "shortMessage": "PKCE verification failed",
+    "longMessage": "The provided code verifier does not match the prepared code challenge.",
+    "code": "pkce_verification_failed",
+    "status": "422",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "native_magic_link.go"
+  },
+  {
     "name": "GatewayTimeout",
     "description": "GatewayTimeout signifies an error when a 3rd party service takes too long to respond.",
     "shortMessage": "Gateway Timeout",
@@ -4957,8 +5397,8 @@
     "code": "gateway_timeout",
     "status": "504",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "network.go"
   },
@@ -4996,7 +5436,7 @@
     "code": "external_account_email_address_verification_required",
     "status": "400",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "oauth.go"
@@ -5008,7 +5448,7 @@
     "code": "external_account_missing_refresh_token",
     "status": "400",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "oauth.go"
@@ -5421,7 +5861,7 @@
     "status": "400",
     "usage": {
       "fapi": true,
-      "bapi": false
+      "bapi": true
     },
     "file": "organizations.go"
   },
@@ -5432,8 +5872,8 @@
     "code": "organization_minimum_permissions_needed",
     "status": "400",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "organizations.go"
   },
@@ -5580,7 +6020,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "organizations.go"
   },
@@ -5616,8 +6056,8 @@
     "code": "organization_membership_quota_exceeded",
     "status": "403",
     "usage": {
-      "fapi": true,
-      "bapi": false
+      "fapi": false,
+      "bapi": true
     },
     "file": "organizations.go"
   },
@@ -5900,7 +6340,7 @@
     "code": "resource_not_found",
     "status": "404",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "organizations.go"
@@ -6023,8 +6463,8 @@
     "code": "organization_membership_managed_by_scim",
     "status": "409",
     "usage": {
-      "fapi": false,
-      "bapi": false
+      "fapi": true,
+      "bapi": true
     },
     "file": "organizations.go"
   },
@@ -6035,7 +6475,7 @@
     "code": "organization_membership_quota_exceeded_for_sso",
     "status": "403",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "organizations.go"
@@ -6060,7 +6500,7 @@
     "meta": "{\"Name\": \"organization_id\"}",
     "status": "422",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "organizations.go"
@@ -6084,7 +6524,7 @@
     "code": "invitations_not_supported_in_organization",
     "status": "403",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": false
     },
     "file": "organizations.go"
@@ -6286,6 +6726,85 @@
     "file": "passkeys.go"
   },
   {
+    "name": "PlatformAPIUnrecognizedCredential",
+    "description": "PlatformAPIUnrecognizedCredential signifies that the bearer credential does not match any supported Platform API authentication format.",
+    "shortMessage": "Unrecognized credential",
+    "longMessage": "The credential format is not recognized for the Platform API.",
+    "code": "platform_api_unrecognized_credential",
+    "status": "401",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "platform.go"
+  },
+  {
+    "name": "PlatformOAuthAccessTokenInvalid",
+    "description": "PlatformOAuthAccessTokenInvalid signifies that an OAuth access token could not be parsed or verified.",
+    "shortMessage": "Invalid OAuth access token",
+    "longMessage": "The OAuth access token is invalid, malformed, or could not be verified.",
+    "code": "platform_oauth_access_token_invalid",
+    "status": "401",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "platform.go"
+  },
+  {
+    "name": "PlatformOAuthAccessTokenMissingClaims",
+    "description": "PlatformOAuthAccessTokenMissingClaims signifies that a JWT access token is missing required claims.",
+    "shortMessage": "Invalid OAuth access token",
+    "longMessage": "Invalid OAuth access token",
+    "code": "platform_oauth_access_token_missing_claims",
+    "meta": "{\"Claims\": \"cp\"}",
+    "status": "401",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "platform.go"
+  },
+  {
+    "name": "PlatformAPIAuthStrategyNotAllowed",
+    "description": "PlatformAPIAuthStrategyNotAllowed signifies that the endpoint does not accept the authentication strategy used for the request.",
+    "shortMessage": "Authentication method not allowed",
+    "longMessage": "This endpoint does not accept the credential type used. Use an authentication method allowed for this operation.",
+    "code": "platform_api_auth_strategy_not_allowed",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "platform.go"
+  },
+  {
+    "name": "PlatformAPIPolicyViolation",
+    "description": "PlatformAPIPolicyViolation signifies policy or issuer restrictions on OAuth access tokens for the Platform API (HTTP 403).",
+    "shortMessage": "Authentication policy violation",
+    "longMessage": "This request cannot be completed due to a policy restriction.",
+    "code": "authorization_invalid",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "platform.go"
+  },
+  {
+    "name": "PlatformAPIRequestNotAllowed",
+    "description": "PlatformAPIRequestNotAllowed signifies that the Platform API request is forbidden for the authenticated principal or target resource (HTTP 403).",
+    "shortMessage": "Request not allowed",
+    "longMessage": "This Platform API request cannot be completed for the authenticated principal or resource.",
+    "code": "authorization_invalid",
+    "status": "403",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "platform.go"
+  },
+  {
     "name": "InvalidPricingIntervalValue",
     "shortMessage": "invalid interval value",
     "longMessage": "The interval is invalid. It must be one of the following: month, year.",
@@ -6341,7 +6860,7 @@
     "meta": "{\"UnsupportedFeatures\": \"unsupportedFeatures\"}",
     "status": "402",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": true
     },
     "file": "pricing.go"
@@ -6371,11 +6890,47 @@
     "file": "pricing.go"
   },
   {
+    "name": "WorkspaceSeatLimitExceeded",
+    "shortMessage": "Workspace seat limit exceeded",
+    "longMessage": "This plan only allows %d seats, but your workspace has %d members.",
+    "code": "workspace_seat_limit_exceeded",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "pricing.go"
+  },
+  {
     "name": "PlanCannotBeUnassigned",
     "shortMessage": "Plan cannot be unassigned",
     "longMessage": "This plan cannot be unassigned because \u003creason\u003e.",
     "code": "plan_cannot_be_unassigned",
     "status": "409",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "pricing.go"
+  },
+  {
+    "name": "SubscriptionNotMigratable",
+    "shortMessage": "subscription not migratable",
+    "longMessage": "The subscription is not in an active state and cannot be migrated.",
+    "code": "subscription_not_migratable",
+    "status": "409",
+    "usage": {
+      "fapi": false,
+      "bapi": false
+    },
+    "file": "pricing.go"
+  },
+  {
+    "name": "PaymentMethodChargeFailed",
+    "shortMessage": "Payment method unavailable",
+    "longMessage": "The saved payment method could not be charged. Please verify or update it and try again.",
+    "code": "pricing_payment_method_charge_failed",
+    "status": "422",
     "usage": {
       "fapi": false,
       "bapi": false
@@ -6781,6 +7336,19 @@
     "file": "saml.go"
   },
   {
+    "name": "SAMLMetadataMissingFields",
+    "shortMessage": "IdP metadata is missing required fields",
+    "longMessage": "The IdP metadata is missing the following required fields: \u003cfields\u003e",
+    "code": "saml_metadata_missing_fields",
+    "meta": "{\"MissingFields\": \"missingFields\"}",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": true
+    },
+    "file": "saml.go"
+  },
+  {
     "name": "SAMLEmailAddressDomainReserved",
     "shortMessage": "email address domain is used for SAML SSO",
     "longMessage": "You can't use this email address, as SAML SSO is enabled for the specific domain.",
@@ -6805,9 +7373,9 @@
     "file": "saml.go"
   },
   {
-    "name": "SAMLEmailAddressMismatch",
+    "name": "SAMLEmailAddressMismatchWithEmail",
     "shortMessage": "Email address mismatch",
-    "longMessage": "The provided email address differs from the one in the SAML response.",
+    "longMessage": "The provided email address differs from the one in the SAML response (IdP email: \u003cemail\u003e).",
     "code": "saml_email_address_domain_mismatch",
     "status": "400",
     "usage": {
@@ -6839,6 +7407,19 @@
     "status": "409",
     "usage": {
       "fapi": true,
+      "bapi": true
+    },
+    "file": "scim.go"
+  },
+  {
+    "name": "SCIMGroupRoleMappingDisabled",
+    "description": "SCIMGroupRoleMappingDisabled returns an error when attempting to mutate group role\nmappings on a SCIM directory that has role mapping disabled.",
+    "shortMessage": "role mapping disabled",
+    "longMessage": "Role mapping is disabled for this SCIM directory. Enable role mapping to add, edit, or remove mappings.",
+    "code": "feature_not_enabled",
+    "status": "400",
+    "usage": {
+      "fapi": false,
       "bapi": true
     },
     "file": "scim.go"
@@ -7105,7 +7686,7 @@
     "code": "session_creation_not_allowed",
     "status": "409",
     "usage": {
-      "fapi": true,
+      "fapi": false,
       "bapi": false
     },
     "file": "sessions.go"
@@ -7407,7 +7988,7 @@
     "code": "sign_up_if_missing_transfer",
     "status": "404",
     "usage": {
-      "fapi": false,
+      "fapi": true,
       "bapi": false
     },
     "file": "sign_in.go"
@@ -7626,7 +8207,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "sign_up.go"
   },
@@ -7692,6 +8273,20 @@
     "usage": {
       "fapi": true,
       "bapi": false
+    },
+    "file": "sms.go"
+  },
+  {
+    "name": "SMSCountryRemovalRestricted",
+    "description": "SMSCountryRemovalRestricted signals that the caller tried to remove one or more\ntier B-F countries from the SMS blocklist on an instance whose plan lacks the\nphone_code feature. Removing those countries is restricted to prevent SMS pumping abuse on\nfree/dev instances; activating them requires upgrading the plan or contacting support.",
+    "shortMessage": "SMS country removal restricted",
+    "longMessage": "Cannot remove the following countries from the SMS blocklist without an upgraded plan: %v. Contact support to activate these countries.",
+    "code": "sms_country_removal_restricted",
+    "meta": "{\"CountryCodes\": countryCodes}",
+    "status": "422",
+    "usage": {
+      "fapi": false,
+      "bapi": true
     },
     "file": "sms.go"
   },
@@ -7939,7 +8534,7 @@
     "status": "404",
     "usage": {
       "fapi": false,
-      "bapi": true
+      "bapi": false
     },
     "file": "url.go"
   },
@@ -8086,7 +8681,7 @@
     "status": "422",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "user_settings.go"
   },
@@ -8349,6 +8944,18 @@
     "file": "users.go"
   },
   {
+    "name": "UserSCIMManaged",
+    "shortMessage": "user managed by SCIM",
+    "longMessage": "This user is managed by a SCIM directory and cannot be deleted manually.",
+    "code": "user_managed_by_scim",
+    "status": "409",
+    "usage": {
+      "fapi": true,
+      "bapi": true
+    },
+    "file": "users.go"
+  },
+  {
     "name": "VerificationAlreadyVerified",
     "description": "VerificationAlreadyVerified signifies an error when verification has already been verified",
     "shortMessage": "already verified",
@@ -8466,6 +9073,19 @@
     "file": "verification.go"
   },
   {
+    "name": "VerificationLinkTokenStale",
+    "description": "VerificationLinkTokenStale means that the verification link token references\na verification that is no longer current (e.g. the user requested a new\nverification after this link was sent).",
+    "shortMessage": "stale link token",
+    "longMessage": "Verification link token is no longer valid. Please request a new one.",
+    "code": "verification_link_token_stale",
+    "status": "400",
+    "usage": {
+      "fapi": true,
+      "bapi": false
+    },
+    "file": "verification.go"
+  },
+  {
     "name": "VerificationInvalidLinkTokenSource",
     "description": "VerificationInvalidLinkTokenSource means that the provided JWT token from\nthe link has an invalid source type.",
     "shortMessage": "invalid link token source",
@@ -8570,7 +9190,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "webhooks.go"
   },
@@ -8582,7 +9202,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": true
+      "bapi": false
     },
     "file": "webhooks.go"
   },
@@ -8594,7 +9214,7 @@
     "status": "400",
     "usage": {
       "fapi": false,
-      "bapi": false
+      "bapi": true
     },
     "file": "webhooks.go"
   }


### PR DESCRIPTION
## Summary
- Regenerates `data/api_errors.json` from the latest `clerk_go` source via `pkg/apierrors/main.go extract`.
- Same generator the `Clerk Bot` runs in Cloudbuild — this is a manual catch-up since the last automated PR (#3216, 2026-03-19).

## Test plan
- [x] `npm run build` passes (10 pre-existing warnings, none related to api errors)