### PR TITLE
Clarify testing information for Clerk Billing

### DIFF
--- a/docs/guides/billing/overview.mdx
+++ b/docs/guides/billing/overview.mdx
@@ -5,7 +5,9 @@ description: Clerk Billing is a feature that allows you to create and manage Pla
 
 <Include src="_partials/billing/billing-experimental" />
 
-Clerk Billing allows your customers to purchase recurring Subscriptions to your application. To get started, **choose one or combine both of the following** business models depending on your application's needs.
+Clerk Billing allows your customers to purchase recurring Subscriptions to your application. Clerk Billing only uses Stripe for payment processing. You can see payment and customer information in Stripe. However, Clerk Billing is a separate product from Stripe Billing; Plans and Subscriptions made in Clerk are not synced to Stripe.
+
+To get started, **choose one or combine both of the following** business models depending on your application's needs.
 
 <Cards>
   - [Billing for B2C SaaS](/docs/guides/billing/for-b2c)
@@ -39,11 +41,15 @@ In general, if you created your Stripe account yourself via Stripe, it's indepen
 
 ### Can I see Subscriptions in my Stripe account?
 
-Clerk Billing only uses Stripe for payment processing. You can see payment and customer information in Stripe. However, Clerk Billing is a separate product from Stripe Billing; Plans and Subscriptions made in Clerk are not synced to Stripe.
+No. Clerk Billing is a separate product from Stripe Billing; Plans and Subscriptions made in Clerk are not synced to Stripe.
 
 ### Can I use the same Stripe account for both dev and prod environments?
 
 No. Stripe accounts created for development instances are sandbox/test accounts and cannot be used for production. For a production environment, you must create a separate Stripe account.
+
+### How can I test Clerk Billing flows?
+
+You can use test cards using Stripe's test mode. See [Stripe Testing](https://docs.stripe.com/testing){{ rel: 'noopener noreferrer' }} for a list of test cards and behaviors. This is useful for testing Clerk Billing flows like creating new subscriptions, updating subscriptions, or handling failure scenarios like expired cards or canceled Subscriptions.
 
 ### Does Clerk Billing support refunds?
 
@@ -76,10 +82,6 @@ Yes, you can offer subscribers the option to pay annually, at a discounted month
 ### How does Clerk handle taxes and VAT for international billing?
 
 Clerk Billing does not currently support tax or VAT, but these are planned for future releases.
-
-### How can I test failure scenarios like expired cards or canceled Subscriptions?
-
-You can simulate failures in Stripe test mode using test cards that trigger specific behaviors. See [Stripe Testing](https://docs.stripe.com/testing){{ rel: 'noopener noreferrer' }} for a list of test cards and behaviors.
 
 ### Which countries is Clerk Billing not supported in?
 

--- a/docs/guides/billing/overview.mdx
+++ b/docs/guides/billing/overview.mdx
@@ -49,7 +49,7 @@ No. Stripe accounts created for development instances are sandbox/test accounts 
 
 ### How can I test Clerk Billing flows?
 
-You can use test cards to test Clerk Billing flows like creating new subscriptions, updating subscriptions, or handling failure scenarios like expired cards or canceled Subscriptions. See [Stripe Testing](https://docs.stripe.com/testing){{ rel: 'noopener noreferrer' }} for a list of test cards and behaviors.
+You can use test cards to test Clerk Billing flows like creating new Subscriptions, updating Subscriptions, or handling failure scenarios like expired cards or canceled Subscriptions. See [Stripe Testing](https://docs.stripe.com/testing){{ rel: 'noopener noreferrer' }} for a list of test cards and behaviors.
 
 ### Does Clerk Billing support refunds?
 

--- a/docs/guides/billing/overview.mdx
+++ b/docs/guides/billing/overview.mdx
@@ -49,7 +49,7 @@ No. Stripe accounts created for development instances are sandbox/test accounts 
 
 ### How can I test Clerk Billing flows?
 
-You can use test cards using Stripe's test mode. See [Stripe Testing](https://docs.stripe.com/testing){{ rel: 'noopener noreferrer' }} for a list of test cards and behaviors. This is useful for testing Clerk Billing flows like creating new subscriptions, updating subscriptions, or handling failure scenarios like expired cards or canceled Subscriptions.
+You can use test cards to test Clerk Billing flows like creating new subscriptions, updating subscriptions, or handling failure scenarios like expired cards or canceled Subscriptions. See [Stripe Testing](https://docs.stripe.com/testing){{ rel: 'noopener noreferrer' }} for a list of test cards and behaviors.
 
 ### Does Clerk Billing support refunds?
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/aa-docs-11810/guides/billing/overview

### What does this solve? What changed?

[Team feedback](https://linear.app/clerk/issue/DOCS-11810/update-testing-docs-to-include-info-on-testing-billing) found that it's not clear how to test Clerk Billing. 

This PR 
- Renames the section on testing to be more clear: "How can I test failure scenarios like expired cards or canceled Subscriptions?" --> "How can I test Clerk Billing flows?". Moves the section higher in the FAQ.
- Moves important information on the Clerk + Stripe integration to the introductory paragraph so that it's the first thing users read about Clerk Billing, instead of this information being pushed down into the FAQ section.

### Deadline

- No rush

### Other resources

- [Linear ticket](https://linear.app/clerk/issue/DOCS-11810/update-testing-docs-to-include-info-on-testing-billing)
