### PR TITLE
docs(telemetry): add 'How you are notified' section

### DIFF
--- a/docs/guides/how-clerk-works/security/clerk-telemetry.mdx
+++ b/docs/guides/how-clerk-works/security/clerk-telemetry.mdx
@@ -5,6 +5,14 @@ description: Clerk collects telemetry data from its SDKs about general product a
 
 Clerk collects telemetry data from its SDKs about general product and feature usage. Participation in telemetry collection is optional and users of the product can opt-out at any time.
 
+## How you are notified
+
+Server-side SDKs (for example `@clerk/nextjs`, `@clerk/express`, `@clerk/fastify`, `@clerk/astro`, `@clerk/react-router`, `@clerk/tanstack-react-start`) print a one-time notice in your terminal on the first development run. The notice is skipped in CI and when using a production instance.
+
+Browser-only SDKs do not print a runtime notice. This includes `@clerk/clerk-js` loaded directly, Vite SPAs using `@clerk/clerk-react` without a server runtime, and Chrome extensions. For those setups, this page is the disclosure.
+
+Telemetry is collected only from development instances and is never collected from production.
+
 ## Why is Clerk collecting telemetry data?
 
 While we actively engage with our users and community to gather feedback and inform our product roadmap, the information collected from these efforts only represents a small subset of our users.


### PR DESCRIPTION
clerk/javascript#8549 replaced the postinstall telemetry notice in `@clerk/shared` with a runtime notice gated to Node, non-CI, dev instances. Browser-only setups (`@clerk/clerk-js` direct, Vite SPAs on `@clerk/clerk-react` with no server, Chrome extensions) no longer get any in-band disclosure, so this page is now the authoritative one for them.

Adds a short "How you are notified" section after the intro that spells out the server vs. browser split and restates the dev-instances-only fact. No changes to the `telemetry` prop or opt-out instructions; existing partials and cross-links remain accurate as-is.