### PR TITLE
Add `clerk init` keyless note to Next.js AI prompt

### DIFF
--- a/prompts/nextjs-quickstart.md
+++ b/prompts/nextjs-quickstart.md
@@ -6,6 +6,8 @@ If a Next.js App Router project does not already exist, first create one using:
 npx create-next-app@latest my-clerk-app --yes
 ```
 
+> **Note:** To create a new Clerk + Next.js app in one step (keyless development keys, no signup required), run `npx clerk init --starter --framework next --keyless`. See the [Clerk CLI](https://github.com/clerk/cli) docs.
+
 Install `@clerk/nextjs@latest`. Create `proxy.ts` with `clerkMiddleware()` from `@clerk/nextjs/server` (in `src/` if it exists, otherwise project root). Add `<ClerkProvider>` inside `<body>` in `app/layout.tsx`. Use `<Show>`, `<UserButton>`, `<SignInButton>`, `<SignUpButton>` from `@clerk/nextjs`.
 
 Latest docs: https://clerk.com/docs/nextjs/getting-started/quickstart


### PR DESCRIPTION
## What

Adds a short note to the Next.js AI prompt — the markdown version served at [`/docs/nextjs/getting-started/quickstart.md`](https://clerk.com/docs/nextjs/getting-started/quickstart.md) — pointing to the Clerk CLI's one-command setup:

```bash
npx clerk init --starter --framework next --keyless
```

The note links to the [Clerk CLI](https://github.com/clerk/cli) docs. All existing manual steps are left unchanged.

## Why

`clerk init --starter --framework next --keyless` scaffolds a new Clerk + Next.js app with temporary development keys and **no signup** — which maps directly onto this prompt's existing keyless-first philosophy ("Do NOT tell users to sign up, create accounts, get API keys"). Surfacing it gives agents and developers a faster path while keeping the manual instructions as the authoritative reference.

## Notes

- **Scope:** only the prompt file (`prompts/nextjs-quickstart.md`) changes. The rendered quickstart page (`quickstart.mdx`) is untouched — this affects the `.md`/LLM version only.
- `--keyless` is only valid when bootstrapping a *new* project, so the note is scoped to new-project creation (where it sits next to the `create-next-app` step).
- Passes the Cursor deeplink length check (`check-prompt-deeplink-length.ts`): **5116 / 8000** chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)