### PR TITLE
docs(cli): document clerk deploy command and agent mode

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -63,6 +63,7 @@ Install the CLI globally, or run it directly without installing using `npx clerk
 - **Set up authentication** — `clerk init` detects your framework, installs the SDK, and scaffolds your project with Clerk's authentication setup.
 - **Manage environment variables** — `clerk env pull` pulls your Clerk API keys into your project's env file.
 - **Configure your instance** — `clerk config pull` and `clerk config patch` let you manage your Clerk instance's auth settings as code.
+- **Deploy to production** — `clerk deploy` walks you through promoting a Clerk app from development to production: registering your domain, configuring DNS, and gathering OAuth credentials. Use `clerk deploy status` to verify deploy completeness.
 - **Access the Clerk API** — `clerk api` is an authenticated client for Clerk's [Backend API](/docs/reference/backend/overview). Run `clerk api ls` to explore available endpoints.
 - **Run diagnostics** — `clerk doctor` validates your project's Clerk integration and flags common issues.
 - **Manage applications** — `clerk apps list` and `clerk apps create` let you view and create Clerk applications from the terminal.
@@ -77,6 +78,7 @@ The CLI is designed to work seamlessly with AI coding agents:
 
 - **Automatic agent detection** — The CLI auto-detects agent vs. human mode. Non-TTY environments default to agent mode, or you can set it explicitly with `--mode agent`.
 - **Agent-friendly setup** — `clerk init --prompt` outputs framework-specific integration instructions for your AI agent and exits without modifying the project.
+- **Read-only production status** — `clerk deploy --mode agent` returns a JSON snapshot of your production instance's configuration state so your AI agent can inspect progress and recommend next steps.
 - **Clerk Skills** — Run `clerk skill install` or accept the prompt during `clerk init` to install [Clerk Skills](/docs/guides/ai/skills), giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
 
 ## Frequently asked questions (FAQ)


### PR DESCRIPTION
Companion PR to:

- Clerk Deploy announcement post: https://github.com/clerk/clerk/pull/2602
- CLI v1.5.0 release featuring the deploy command: https://github.com/clerk/cli/releases/tag/v1.5.0

Adds two bullets to the CLI docs page: one for `clerk deploy` under "What you can do," and one for the read-only agent mode under "AI agent integration."

https://clerk.com/docs/pr/nicolas-clerk-deploy-docs/cli