### PR TITLE
Deprecate middleware-based auth gating: shared notice + multi-SDK protect-pages

### DIFF
--- a/docs/_partials/middleware-auth-deprecation.mdx
+++ b/docs/_partials/middleware-auth-deprecation.mdx
@@ -1,0 +1,18 @@
+{/*
+  Single source of truth for the middleware-based auth deprecation notice.
+  Include it wherever the docs still show auth checks inside the `clerkMiddleware()`
+  callback or `createRouteMatcher()`:
+
+    <Include src="_partials/middleware-auth-deprecation" />
+
+  To soften the wording (for example, before the SDK ships `@deprecated`) or to
+  strengthen it later, edit ONLY this file. Keep it framework-neutral so it can be
+  shared across the Next.js, Nuxt, and Astro pages.
+*/}
+
+> [!WARNING]
+> **`createRouteMatcher()` and auth checks inside `clerkMiddleware()` are deprecated.** Verifying authentication or authorization inside the middleware callback (for example, calling `auth.protect()` for routes matched by `createRouteMatcher()`) is no longer recommended. Auth checks in the middleware layer are structurally unsafe: Clerk has to normalize and match URLs exactly the way your framework and host do, and any mismatch (such as percent-encoding or an extra path segment) can become an authorization bypass.
+>
+> Protect access **close to the resource instead**, in the page, route handler, component, or other server-side code that reads the resource. See [Protect pages and routes](/docs/guides/secure/protect-pages).
+>
+> `clerkMiddleware()` itself is not deprecated and is still required. Only auth checks _inside_ the callback are affected.

--- a/docs/_partials/middleware-auth-deprecation.mdx
+++ b/docs/_partials/middleware-auth-deprecation.mdx
@@ -11,7 +11,7 @@
 */}
 
 > [!WARNING]
-> **`createRouteMatcher()` and auth checks inside `clerkMiddleware()` are deprecated.** Verifying authentication or authorization inside the middleware callback (for example, calling `auth.protect()` for routes matched by `createRouteMatcher()`) is no longer recommended. Auth checks in the middleware layer are structurally unsafe: Clerk has to normalize and match URLs exactly the way your framework and host do, and any mismatch (such as percent-encoding or an extra path segment) can become an authorization bypass.
+> **`createRouteMatcher()` and auth checks inside `clerkMiddleware()` are deprecated.** Verifying authentication or authorization inside the middleware callback (for example, calling `auth.protect()` for routes matched by `createRouteMatcher()`) is no longer recommended. To gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes that has to stay in sync as routes, rewrites, and hosting change.
 >
 > Protect access **close to the resource instead**, in the page, route handler, component, or other server-side code that reads the resource. See [Protect pages and routes](/docs/guides/secure/protect-pages).
 >

--- a/docs/_partials/middleware-auth-deprecation.mdx
+++ b/docs/_partials/middleware-auth-deprecation.mdx
@@ -5,14 +5,16 @@
 
     <Include src="_partials/middleware-auth-deprecation" />
 
-  To soften the wording (for example, before the SDK ships `@deprecated`) or to
-  strengthen it later, edit ONLY this file. Keep it framework-neutral so it can be
+  This is the single toggle point for the deprecation wording. Edit ONLY this file.
+  Gate 1 (SDK ships `@deprecated`): change "no longer recommended" to "deprecated".
+  Gate 2 (advisory publishes): add the security reason as a SECOND paragraph on top
+  of the locality one, never replacing it. Keep it framework-neutral so it can be
   shared across the Next.js, Nuxt, and Astro pages.
 */}
 
 > [!WARNING]
-> **`createRouteMatcher()` and auth checks inside `clerkMiddleware()` are deprecated.** Verifying authentication or authorization inside the middleware callback (for example, calling `auth.protect()` for routes matched by `createRouteMatcher()`) is no longer recommended. To gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes that has to stay in sync as routes, rewrites, and hosting change.
+> **Auth checks inside `clerkMiddleware()` (including routes matched by `createRouteMatcher()`) are no longer recommended.** Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
 >
-> Protect access **close to the resource instead**, in the page, route handler, component, or other server-side code that reads the resource. See [Protect pages and routes](/docs/guides/secure/protect-pages).
+> Protect access **close to the resource instead**, in the page, route handler, component, or other server-side code that reads the resource. That code always runs and always knows what it is guarding, so there is no second route model to keep in sync. See [Protect pages and routes](/docs/guides/secure/protect-pages).
 >
-> `clerkMiddleware()` itself is not deprecated and is still required. Only auth checks _inside_ the callback are affected.
+> `clerkMiddleware()` itself is not deprecated and is still required. Keep using it for redirects, headers, and other request handling; only auth checks _inside_ the callback are affected.

--- a/docs/guides/secure/protect-pages.mdx
+++ b/docs/guides/secure/protect-pages.mdx
@@ -1,45 +1,106 @@
 ---
-title: Protect pages in your Nuxt app with Clerk
-description: Learn how to protect the pages in your Clerk + Nuxt application.
-sdk: nuxt
+title: Protect pages and routes
+description: Learn how to protect pages, route handlers, and Server Actions in your Clerk + Next.js application.
+sdk: nextjs
 ---
 
-This guide demonstrates how to protect pages in your Nuxt application.
+This guide demonstrates how to protect pages, route handlers, and Server Actions in your Next.js application by checking authentication **close to the resource being accessed** rather than in your middleware.
 
 > [!TIP]
-> To learn how to protect API routes, see the [dedicated guide](/docs/reference/nuxt/clerk-middleware#protect-api-routes).
+> Protect access where the resource is read, not inside `clerkMiddleware()`. [Auth checks in the middleware layer are no longer recommended](#why-not-protect-in-middleware) because they're difficult to keep in sync with how your framework and host route requests.
 
-## Protect a single page
+To check whether a user is **authorized** (has a specific Role, Permission, Feature, or Plan) in addition to being signed in, see [Authorization checks](/docs/guides/secure/authorization-checks). This guide focuses on **authentication** (whether a user is signed in).
 
-The `useAuth()` composable provides access to the current user's authentication state and methods to manage the active session. It also includes the `isSignedIn` property to check if the active user is signed in, which is helpful for protecting a page.
+## Protect a page
 
-<Include src="_partials/vue-nuxt/use-auth" />
+Use [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) to redirect unauthenticated users to the sign-in route, or use [`auth()`](/docs/reference/nextjs/app-router/auth) and check `isAuthenticated` yourself if you want more control over the response.
 
-## Protect multiple pages
+<CodeBlockTabs options={["auth.protect()", "auth()"]}>
+  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+  import { auth } from '@clerk/nextjs/server'
 
-The `createRouteMatcher()` is a Clerk helper function that allows you to protect multiple routes in your Nuxt application. It accepts an array of route patterns and checks if the route the user is trying to visit matches one of the patterns passed to it.
+  export default async function Page() {
+    // Redirects to the sign-in route if the user is not signed in
+    await auth.protect()
 
-The `createRouteMatcher()` helper returns a function that, when called with the `to` route object from Nuxt's [`defineNuxtRouteMiddleware()`](https://nuxt.com/docs/4.x/api/utils/define-nuxt-route-middleware), will return `true` if the user is trying to access a route that matches one of the patterns provided.
-
-### Example
-
-In your `middleware/` directory, create a file named `auth.global.ts` with the following code. This middleware:
-
-- Uses the `isSignedIn` property returned by the [`useAuth()`](/docs/reference/composables/use-auth) composable to check if the user is signed in.
-- Uses the `createRouteMatcher()` helper to check if the user is trying to access a protected route. If they are but they aren't signed in, they are redirected to the sign-in page.
-
-```ts {{ filename: 'app/middleware/auth.global.ts' }}
-// Define the routes you want to protect with `createRouteMatcher()`
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
-
-export default defineNuxtRouteMiddleware((to) => {
-  // Use the `useAuth()` composable to access the `isSignedIn` property
-  const { isSignedIn } = useAuth()
-
-  // Check if the user is not signed in and is trying to access a protected route
-  // If so, redirect them to the sign-in page
-  if (!isSignedIn.value && isProtectedRoute(to)) {
-    return navigateTo('/sign-in')
+    return <h1>Dashboard</h1>
   }
-})
+  ```
+
+  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+  import { auth } from '@clerk/nextjs/server'
+
+  export default async function Page() {
+    const { isAuthenticated, redirectToSignIn } = await auth()
+
+    if (!isAuthenticated) {
+      // Add custom logic to run before redirecting
+      return redirectToSignIn()
+    }
+
+    return <h1>Dashboard</h1>
+  }
+  ```
+</CodeBlockTabs>
+
+## Protect a route handler
+
+Check `isAuthenticated` from [`auth()`](/docs/reference/nextjs/app-router/auth) and return a `401` if the user isn't signed in.
+
+```tsx {{ filename: 'app/api/me/route.ts' }}
+import { auth } from '@clerk/nextjs/server'
+
+export const GET = async () => {
+  const { isAuthenticated, userId } = await auth()
+
+  if (!isAuthenticated) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  return Response.json({ userId })
+}
 ```
+
+## Protect a Server Action
+
+Verify the user inside the action itself, before running any logic that depends on them being signed in.
+
+```tsx {{ filename: 'app/actions.ts' }}
+'use server'
+import { auth } from '@clerk/nextjs/server'
+
+export async function createPost(formData: FormData) {
+  const { isAuthenticated, userId } = await auth()
+
+  if (!isAuthenticated) {
+    throw new Error('You must be signed in to create a post.')
+  }
+
+  // Add your Server Action logic using the `userId`
+}
+```
+
+## Protect a group of pages
+
+To protect several pages that share a path prefix, add the check to a shared [layout](https://nextjs.org/docs/app/api-reference/file-conventions/layout).
+
+```tsx {{ filename: 'app/dashboard/layout.tsx' }}
+import { auth } from '@clerk/nextjs/server'
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  await auth.protect()
+
+  return <>{children}</>
+}
+```
+
+> [!WARNING]
+> Layouts don't re-render on client-side navigation, so the session isn't re-checked on every route change. Treat a layout check as a convenience for the first load, **not** a security boundary. Always verify authentication (and authorization) in the page, Server Action, route handler, or data-access code that actually reads or mutates protected data. For more information, see the [Next.js docs](https://nextjs.org/docs/app/building-your-application/authentication#layouts-and-auth-checks).
+
+## Why not protect in middleware?
+
+It's tempting to gate routes inside `clerkMiddleware()` with `createRouteMatcher()`, but auth checks in the middleware layer are structurally unsafe. Clerk has to normalize and match the request URL exactly the way your framework and host do, and any mismatch (such as percent-encoding, double-encoding, or an extra path segment) can let a request reach a protected resource without being checked. These mismatches are hard to prevent and can be reintroduced by changes outside your control.
+
+Protecting close to the resource avoids this entire class of bug: the same code that reads or mutates the data also enforces access to it.
+
+`clerkMiddleware()` itself is still required and fully supported. Only auth checks _inside_ the callback are discouraged.

--- a/docs/guides/secure/protect-pages.mdx
+++ b/docs/guides/secure/protect-pages.mdx
@@ -99,7 +99,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
 ## Why not protect in middleware?
 
-It's tempting to gate routes inside `clerkMiddleware()` with `createRouteMatcher()`, but auth checks in the middleware layer are structurally unsafe. Clerk has to normalize and match the request URL exactly the way your framework and host do, and any mismatch (such as percent-encoding, double-encoding, or an extra path segment) can let a request reach a protected resource without being checked. These mismatches are hard to prevent and can be reintroduced by changes outside your control.
+It's tempting to gate routes inside `clerkMiddleware()` with `createRouteMatcher()`, but matching routes there means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. Clerk has to match the request URL the same way your framework and host route it, and keeping those two models in sync is fragile: as routes, rewrites, and hosting change, the matcher can drift from the real routing, and the check can fail to apply where you intend. This drift is hard to prevent and can be reintroduced by changes outside your control.
 
 Protecting close to the resource avoids this entire class of bug: the same code that reads or mutates the data also enforces access to it.
 

--- a/docs/guides/secure/protect-pages.mdx
+++ b/docs/guides/secure/protect-pages.mdx
@@ -97,6 +97,79 @@ export default async function DashboardLayout({ children }: { children: React.Re
 > [!WARNING]
 > Layouts don't re-render on client-side navigation, so the session isn't re-checked on every route change. Treat a layout check as a convenience for the first load, **not** a security boundary. Always verify authentication (and authorization) in the page, Server Action, route handler, or data-access code that actually reads or mutates protected data. For more information, see the [Next.js docs](https://nextjs.org/docs/app/building-your-application/authentication#layouts-and-auth-checks).
 
+## Migrating from middleware checks
+
+If you currently gate routes inside `clerkMiddleware()`, the move is mostly subtractive: relocate the auth check to the resource, then delete it from the callback. `clerkMiddleware()` stays, it's still required, and any non-auth work in your middleware (redirects, headers, geo) stays with it.
+
+### Replace a route matcher with a resource check
+
+Before, the route is matched and checked in the callback:
+
+```tsx {{ filename: 'middleware.ts (before)' }}
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+const isProtected = createRouteMatcher(['/dashboard/:path*'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtected(req)) await auth.protect()
+})
+```
+
+After, the page enforces its own access and the matcher is gone:
+
+```tsx {{ filename: 'middleware.ts (after)' }}
+import { clerkMiddleware } from '@clerk/nextjs/server'
+
+// Keep clerkMiddleware(); it's still required. Just remove the auth gating.
+export default clerkMiddleware()
+```
+
+```tsx {{ filename: 'app/dashboard/page.tsx (after)' }}
+import { auth } from '@clerk/nextjs/server'
+
+export default async function Page() {
+  await auth.protect()
+
+  return <h1>Dashboard</h1>
+}
+```
+
+Once the check lives on the resource, it's safe to delete the matcher and the `auth.protect()` call from the callback.
+
+### Protect a whole subtree
+
+A single matcher like `/dashboard/:path*` covered everything under `/dashboard` in one place. There's no single resource-level equivalent that is also a security boundary (a shared layout is a first-load convenience, not a boundary, see [the warning above](#protect-a-group-of-pages)). Put the boundary in a small shared helper and call it from each protected resource:
+
+```tsx {{ filename: 'app/lib/auth.ts' }}
+import { auth } from '@clerk/nextjs/server'
+
+export async function requireUser() {
+  const { userId } = await auth.protect()
+
+  return userId
+}
+```
+
+Call `requireUser()` at the top of each page and Server Action under the subtree. A layout can still handle the first-load redirect, but the per-resource call is what enforces access. In route handlers, `auth.protect()` responds with a `404` to unauthenticated requests; use the `auth()` and `isAuthenticated` check [shown above](#protect-a-route-handler) if you want to return a `401` instead.
+
+### Migrate "protect everything, allow a few public routes"
+
+If your middleware protects everything and allowlists public routes (the `!isPublicRoute` pattern), migrate in this order:
+
+1. **Add** resource-level checks (or `requireUser()`) to the routes that need them.
+1. **Verify** those routes still require sign-in.
+1. **Then** remove the gating from the middleware callback.
+
+> [!WARNING]
+> Add the resource checks first and remove the middleware gate last. If you remove the gate before the resources protect themselves, every route is briefly public.
+
+### Redirects, onboarding, and Roles
+
+- Cross-cutting redirects (incomplete [session tasks](/docs/guides/configure/session-tasks), [onboarding](/docs/guides/development/add-onboarding-flow)) can stay in middleware as a redirect convenience, as long as the real enforcement also runs at the resource.
+- For authorization (Role, Permission, Feature, or Plan), see [Authorization checks](/docs/guides/secure/authorization-checks).
+
+There's no codemod or lint rule for this yet; it's a manual move you can start today.
+
 ## Why not protect in middleware?
 
 It's tempting to gate routes inside `clerkMiddleware()` with `createRouteMatcher()`, but matching routes there means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. Clerk has to match the request URL the same way your framework and host route it, and keeping those two models in sync is fragile: as routes, rewrites, and hosting change, the matcher can drift from the real routing, and the check can fail to apply where you intend. This drift is hard to prevent and can be reintroduced by changes outside your control.

--- a/docs/guides/secure/protect-pages.nuxt.mdx
+++ b/docs/guides/secure/protect-pages.nuxt.mdx
@@ -1,0 +1,45 @@
+---
+title: Protect pages and routes
+description: Learn how to protect the pages in your Clerk + Nuxt application.
+sdk: nuxt
+---
+
+This guide demonstrates how to protect pages in your Nuxt application.
+
+> [!TIP]
+> To learn how to protect API routes, see the [dedicated guide](/docs/reference/nuxt/clerk-middleware#protect-api-routes).
+
+## Protect a single page
+
+The `useAuth()` composable provides access to the current user's authentication state and methods to manage the active session. It also includes the `isSignedIn` property to check if the active user is signed in, which is helpful for protecting a page.
+
+<Include src="_partials/vue-nuxt/use-auth" />
+
+## Protect multiple pages
+
+The `createRouteMatcher()` is a Clerk helper function that allows you to protect multiple routes in your Nuxt application. It accepts an array of route patterns and checks if the route the user is trying to visit matches one of the patterns passed to it.
+
+The `createRouteMatcher()` helper returns a function that, when called with the `to` route object from Nuxt's [`defineNuxtRouteMiddleware()`](https://nuxt.com/docs/4.x/api/utils/define-nuxt-route-middleware), will return `true` if the user is trying to access a route that matches one of the patterns provided.
+
+### Example
+
+In your `middleware/` directory, create a file named `auth.global.ts` with the following code. This middleware:
+
+- Uses the `isSignedIn` property returned by the [`useAuth()`](/docs/reference/composables/use-auth) composable to check if the user is signed in.
+- Uses the `createRouteMatcher()` helper to check if the user is trying to access a protected route. If they are but they aren't signed in, they are redirected to the sign-in page.
+
+```ts {{ filename: 'app/middleware/auth.global.ts' }}
+// Define the routes you want to protect with `createRouteMatcher()`
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
+
+export default defineNuxtRouteMiddleware((to) => {
+  // Use the `useAuth()` composable to access the `isSignedIn` property
+  const { isSignedIn } = useAuth()
+
+  // Check if the user is not signed in and is trying to access a protected route
+  // If so, redirect them to the sign-in page
+  if (!isSignedIn.value && isProtectedRoute(to)) {
+    return navigateTo('/sign-in')
+  }
+})
+```


### PR DESCRIPTION
First in a stacked series moving Clerk away from middleware-based auth gating (`createRouteMatcher` and auth checks inside `clerkMiddleware`) toward protecting close to the resource. Background: [Deprecate middleware-based auth checks](https://www.notion.so/clerkdev/Deprecate-middleware-based-auth-checks-createRouteMatcher-35f2b9ab44fe80cdbd3ec54460b99cae).

Foundation only: a shared `_partials/middleware-auth-deprecation.mdx` that holds the deprecation wording in one editable place (it's included everywhere downstream), and `protect-pages` reworked into a multi-SDK guide. The new Next.js base covers page, route handler, Server Action, and layout protection, and flags that a layout check isn't a security boundary because layouts don't re-render on soft navigation. The existing Nuxt content moved verbatim to `protect-pages.nuxt.mdx`; it gets rewritten in the Nuxt PR.

One thing worth a look: the partial uses full-strength "deprecated" wording even though the SDK hasn't shipped `@deprecated` yet. It's isolated to that one file so softening it later is a one-line change.
