### PR TITLE
Deprecate middleware auth gating across Next.js reference and guides

### DIFF
--- a/docs/guides/ai/mcp/build-mcp-server.mdx
+++ b/docs/guides/ai/mcp/build-mcp-server.mdx
@@ -285,23 +285,7 @@ sdk: nextjs, expressjs
          export { handler as GET, corsHandler as OPTIONS }
          ```
        </CodeBlockTabs>
-    1. Your `.well-known` endpoints must be **publicly accessible** for MCP clients to discover OAuth metadata. When protecting routes, consider these paths and ensure they are not protected. For example, if you're using [`clerkMiddleware()` to protect all routes](/docs/reference/nextjs/clerk-middleware#protect-all-routes), you can exclude the `.well-known` endpoints like this:
-
-       <Include src="_partials/nextjs/nextjs-15-callout" />
-
-       ```ts {{ filename: 'proxy.ts' }}
-       import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
-
-       const isPublicRoute = createRouteMatcher([
-         '/.well-known/oauth-authorization-server(.*)',
-         '/.well-known/oauth-protected-resource(.*)',
-       ])
-
-       export default clerkMiddleware(async (auth, req) => {
-         if (isPublicRoute(req)) return // Allow public access to .well-known endpoints
-         await auth.protect() // Protect all other routes
-       })
-       ```
+    1. Your `.well-known` endpoints must be **publicly accessible** for MCP clients to discover OAuth metadata. By default, `clerkMiddleware()` doesn't protect any routes, so these endpoints are already public, and the MCP route protects itself (as shown above). Avoid gating routes in your middleware; protecting each resource directly keeps the `.well-known` endpoints accessible without special-casing them.
   </If>
 
   <If sdk="expressjs">

--- a/docs/guides/configure/session-tasks.mdx
+++ b/docs/guides/configure/session-tasks.mdx
@@ -48,8 +48,8 @@ Your sign-up/sign-in flow should handle session tasks, but if a user's authentic
 The following methods are available to redirect users to the appropriate task page when they have pending session tasks:
 
 - [The `taskUrls` option](#using-the-task-urls-option): Protect your entire application
-- [Middleware](#using-middleware-based-redirects): Protect your entire application, route groups, or individual routes
-- [The `<RedirectToTasks />` component](#using-the-redirect-to-tasks-control-component): Protect routes
+- [The `<RedirectToTasks />` component](#using-the-redirect-to-tasks-control-component) (recommended): Protect routes, route groups (in a layout), or individual pages
+- [Middleware](#using-middleware-based-redirects): No longer recommended
 
 ### Using the `taskUrls` option
 
@@ -65,6 +65,8 @@ export default function Page() {
 
 ### Using middleware-based redirects
 
+<Include src="_partials/middleware-auth-deprecation" />
+
 <If sdk="nextjs">
   If you'd like to simply redirect users to the sign-in page if they are signed-out, you can [use `auth.protect()`](#using-auth-protect). If you'd like to have more control over what your app does based on user authentication status, you can [use the `isAuthenticated` property](#using-is-authenticated).
 </If>
@@ -79,7 +81,7 @@ export default function Page() {
   ```tsx {{ filename: 'proxy.ts', mark: [[6, 8]] }}
   import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
+  const isProtectedRoute = createRouteMatcher(['/dashboard/:path*', '/forum/:path*'])
 
   export default clerkMiddleware(async (auth, req) => {
     // pending users won't be able to access protected routes
@@ -108,7 +110,7 @@ When using the `isAuthenticated` property in middleware to protect routes, it wi
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
 
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
+const isProtectedRoute = createRouteMatcher(['/dashboard/:path*', '/forum/:path*'])
 
 export default clerkMiddleware(async (auth, req: NextRequest) => {
   // The `Auth` object gives you access to properties like `isAuthenticated`

--- a/docs/guides/dashboard/dns-domains/satellite-domains.mdx
+++ b/docs/guides/dashboard/dns-domains/satellite-domains.mdx
@@ -327,15 +327,12 @@ When `satelliteAutoSync` is `false` (the default), you must ensure your sign-in 
           ```
         </CodeBlockTabs>
 
-        And the middleware associated with your satellite domain should look like this:
+        And the middleware associated with your satellite domain should look like this. To require authentication, protect access [close to the resource](/docs/guides/secure/protect-pages) rather than gating routes in the middleware:
 
         <Include src="_partials/nextjs/nextjs-15-callout" />
 
         ```ts {{ filename: 'proxy.ts' }}
-        import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
-
-        // Set the homepage as a public route
-        const isPublicRoute = createRouteMatcher(['/'])
+        import { clerkMiddleware } from '@clerk/nextjs/server'
 
         // Set the necessary options for a satellite application
         const options = {
@@ -354,10 +351,7 @@ When `satelliteAutoSync` is `false` (the default), you must ensure your sign-in 
           // satelliteAutoSync: true,
         }
 
-        export default clerkMiddleware(async (auth, req) => {
-          if (isPublicRoute(req)) return // if it's a public route, do nothing
-          await auth.protect() // for any other route, require auth
-        }, options)
+        export default clerkMiddleware(options)
 
         export const config = {
           matcher: [

--- a/docs/guides/dashboard/dns-domains/satellite-domains.mdx
+++ b/docs/guides/dashboard/dns-domains/satellite-domains.mdx
@@ -327,7 +327,7 @@ When `satelliteAutoSync` is `false` (the default), you must ensure your sign-in 
           ```
         </CodeBlockTabs>
 
-        And the middleware associated with your satellite domain should look like this. To require authentication, protect access [close to the resource](/docs/guides/secure/protect-pages) rather than gating routes in the middleware:
+        And the middleware associated with your satellite domain should look like this. To require authentication, protect access [close to the resource](/docs/guides/secure/protect-pages) rather than gating routes in the middleware, which keeps the check in sync with your routes:
 
         <Include src="_partials/nextjs/nextjs-15-callout" />
 

--- a/docs/guides/development/add-onboarding-flow.mdx
+++ b/docs/guides/development/add-onboarding-flow.mdx
@@ -60,6 +60,8 @@ declare global {
 
 ## Configure your Middleware to read session data
 
+<Include src="_partials/middleware-auth-deprecation" />
+
 [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) allows you to configure access to your routes with fine grained control. It also allows you to retrieve claims directly from the session and redirect your user accordingly.
 
 The following example demonstrates how to use `clerkMiddleware()` to redirect users based on their onboarding status. If the user is signed in and has not completed onboarding, they will be redirected to the onboarding page.
@@ -108,6 +110,9 @@ export const config = {
   ],
 }
 ```
+
+> [!WARNING]
+> The middleware above is a convenient place to redirect users, but it is **not** a security boundary. Middleware can be bypassed and doesn't re-run on client-side navigation, so enforce both authentication and the `onboardingComplete` check **at the resource**: in the page, layout, route handler, or Server Action that reads or mutates onboarding-gated data. See [Protect pages and routes](/docs/guides/secure/protect-pages).
 
 ### Create a layout for the `/onboarding` route
 

--- a/docs/guides/development/add-onboarding-flow.mdx
+++ b/docs/guides/development/add-onboarding-flow.mdx
@@ -112,7 +112,7 @@ export const config = {
 ```
 
 > [!WARNING]
-> The middleware above is a convenient place to redirect users, but it is **not** a security boundary. Middleware can be bypassed and doesn't re-run on client-side navigation, so enforce both authentication and the `onboardingComplete` check **at the resource**: in the page, layout, route handler, or Server Action that reads or mutates onboarding-gated data. See [Protect pages and routes](/docs/guides/secure/protect-pages).
+> The middleware above is a convenient place to redirect users, but it is **not** a security boundary. It doesn't re-run on client-side navigation, and the routes it matches are a separate model from your actual routes, so it can't be the thing that enforces access. Enforce both authentication and the `onboardingComplete` check **at the resource**: in the page, layout, route handler, or Server Action that reads or mutates onboarding-gated data. See [Protect pages and routes](/docs/guides/secure/protect-pages).
 
 ### Create a layout for the `/onboarding` route
 

--- a/docs/guides/development/custom-sign-in-or-up-page.mdx
+++ b/docs/guides/development/custom-sign-in-or-up-page.mdx
@@ -27,7 +27,11 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
 
   By default, `clerkMiddleware()` makes all routes public. **This step is specifically for applications that have configured `clerkMiddleware()` to make [all routes protected](/docs/reference/nextjs/clerk-middleware#protect-all-routes).** If you have not configured `clerkMiddleware()` to protect all routes, you can skip this step.
 
+  <Include src="_partials/middleware-auth-deprecation" />
+
   <Include src="_partials/nextjs/nextjs-15-callout" />
+
+  If you protect access [close to the resource](/docs/guides/secure/protect-pages) instead of gating routes in `clerkMiddleware()`, you don't need to mark the sign-in route public. This step only applies if you're still protecting all routes in your middleware.
 
   To make the sign-in route public:
 
@@ -38,7 +42,7 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
   ```tsx {{ filename: 'proxy.ts' }}
   import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isPublicRoute = createRouteMatcher(['/sign-in(.*)'])
+  const isPublicRoute = createRouteMatcher(['/sign-in/:path*'])
 
   export default clerkMiddleware(async (auth, req) => {
     if (!isPublicRoute(req)) {

--- a/docs/guides/development/custom-sign-up-page.mdx
+++ b/docs/guides/development/custom-sign-up-page.mdx
@@ -27,6 +27,8 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
 
   By default, `clerkMiddleware()` makes all routes public. **This step is specifically for applications that have configured `clerkMiddleware()` to make [all routes protected](/docs/reference/nextjs/clerk-middleware#protect-all-routes).** If you have not configured `clerkMiddleware()` to protect all routes, you can skip this step.
 
+  <Include src="_partials/middleware-auth-deprecation" />
+
   <Include src="_partials/nextjs/nextjs-15-callout" />
 
   To make the sign-up route public:
@@ -39,8 +41,8 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
 
   // prettier-ignore
   const isPublicRoute = createRouteMatcher([
-    '/sign-in(.*)',
-    '/sign-up(.*)'
+    '/sign-in/:path*',
+    '/sign-up/:path*'
   ])
 
   export default clerkMiddleware(async (auth, req) => {

--- a/docs/guides/development/geo-blocking.mdx
+++ b/docs/guides/development/geo-blocking.mdx
@@ -8,7 +8,7 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
 
 <Tabs items={["Vercel", "Render"]}>
   <Tab>
-    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using [Vercel's `geolocation()` function](https://vercel.com/guides/geo-ip-headers-geolocation-vercel-functions). If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. To require authentication, protect the resource itself rather than gating it in the middleware; see [Protect pages and routes](/docs/guides/secure/protect-pages).
+    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using [Vercel's `geolocation()` function](https://vercel.com/guides/geo-ip-headers-geolocation-vercel-functions). If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. To require authentication, protect the resource itself rather than gating it in the middleware, which keeps the check next to the data it guards and in sync with your routes; see [Protect pages and routes](/docs/guides/secure/protect-pages).
 
     <Include src="_partials/nextjs/nextjs-15-callout" />
 
@@ -51,7 +51,7 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
   </Tab>
 
   <Tab>
-    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using Render's `cf-ipcountry` header. If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. To require authentication, protect the resource itself rather than gating it in the middleware; see [Protect pages and routes](/docs/guides/secure/protect-pages).
+    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using Render's `cf-ipcountry` header. If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. To require authentication, protect the resource itself rather than gating it in the middleware, which keeps the check next to the data it guards and in sync with your routes; see [Protect pages and routes](/docs/guides/secure/protect-pages).
 
     <Include src="_partials/nextjs/nextjs-15-callout" />
 

--- a/docs/guides/development/geo-blocking.mdx
+++ b/docs/guides/development/geo-blocking.mdx
@@ -8,7 +8,7 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
 
 <Tabs items={["Vercel", "Render"]}>
   <Tab>
-    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using [Vercel's `geolocation()` function](https://vercel.com/guides/geo-ip-headers-geolocation-vercel-functions). If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. If that route is protected, the middleware also checks if the user is authenticated.
+    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using [Vercel's `geolocation()` function](https://vercel.com/guides/geo-ip-headers-geolocation-vercel-functions). If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. To require authentication, protect the resource itself rather than gating it in the middleware; see [Protect pages and routes](/docs/guides/secure/protect-pages).
 
     <Include src="_partials/nextjs/nextjs-15-callout" />
 
@@ -17,9 +17,8 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
     import { geolocation } from '@vercel/functions'
     import { NextResponse } from 'next/server'
 
-    // Define your protected and blocked routes
-    const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
-    const isBlockRoute = createRouteMatcher(['/block(.*)'])
+    // Define the blocked routes
+    const isBlockRoute = createRouteMatcher(['/block/:path*'])
 
     // Define the countries you want to allow
     const allowedCountries = ['US']
@@ -36,9 +35,6 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
       if (country && !allowedCountries.includes(country)) {
         return NextResponse.redirect(new URL('/block', req.url))
       }
-
-      // Protect routes based on authentication status
-      if (isProtectedRoute(req)) await auth.protect()
     })
 
     export const config = {
@@ -55,7 +51,7 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
   </Tab>
 
   <Tab>
-    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using Render's `cf-ipcountry` header. If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. If that route is protected, the middleware also checks if the user is authenticated.
+    The following example shows how to implement geo blocking in your [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) using Render's `cf-ipcountry` header. If a user visits any route that is not a `/block` route, the middleware checks the client's country and redirects to the `/block` route if the country is not allowed. To require authentication, protect the resource itself rather than gating it in the middleware; see [Protect pages and routes](/docs/guides/secure/protect-pages).
 
     <Include src="_partials/nextjs/nextjs-15-callout" />
 
@@ -63,8 +59,7 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
     import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
     import { NextResponse } from 'next/server'
 
-    const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
-    const isBlockRoute = createRouteMatcher(['/block(.*)'])
+    const isBlockRoute = createRouteMatcher(['/block/:path*'])
 
     const allowedCountries = ['US']
 
@@ -80,9 +75,6 @@ While Clerk does not provide a geo blocking feature, deployment platforms, such 
       if (country && !allowedCountries.includes(country)) {
         return NextResponse.redirect(new URL('/block', req.url))
       }
-
-      // Protect routes based on authentication status
-      if (isProtectedRoute(req)) await auth.protect()
     })
 
     export const config = {

--- a/docs/guides/secure/basic-rbac.mdx
+++ b/docs/guides/secure/basic-rbac.mdx
@@ -96,13 +96,34 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
 
   To protect the `/admin` route, choose **one** of the two following methods:
 
-  1. **Middleware**: Apply Role-based access control globally at the route level. This method restricts access to all routes matching `/admin` before the request reaches the actual page.
-  1. **Page-level Role check**: Apply Role-based access control directly in the `/admin` page component. This method protects this specific page. To protect other pages in the admin dashboard, apply this protection to each route.
+  1. **Page-level Role check (recommended)**: Apply Role-based access control directly in the `/admin` page component. This method protects this specific page. To protect other pages in the admin dashboard, apply this protection to each route.
+  1. **Middleware**: Apply Role-based access control at the route level, before the request reaches the page. This approach is no longer recommended.
 
   > [!IMPORTANT]
   > You only need to follow **one** of the following methods to secure your `/admin` route.
 
-  ### Option 1: Protect the `/admin` route using middleware
+  ### Option 1: Protect the `/admin` route at the page-level
+
+  1. Add the following code to the `app/admin/page.tsx` file. The `checkRole()` function checks if the user has the `admin` Role. If they don't, it redirects them to the home page.
+
+  ```tsx {{ filename: 'app/admin/page.tsx' }}
+  import { checkRole } from '@/utils/roles'
+  import { redirect } from 'next/navigation'
+
+  export default async function AdminDashboard() {
+    // Protect the page from users who are not admins
+    const isAdmin = await checkRole('admin')
+    if (!isAdmin) {
+      redirect('/')
+    }
+
+    return <p>This is the protected admin dashboard restricted to users with the `admin` Role.</p>
+  }
+  ```
+
+  ### Option 2: Protect the `/admin` route using middleware
+
+  <Include src="_partials/middleware-auth-deprecation" />
 
   <Include src="_partials/nextjs/nextjs-15-callout" />
 
@@ -112,7 +133,7 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
   import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
   import { NextResponse } from 'next/server'
 
-  const isAdminRoute = createRouteMatcher(['/admin(.*)'])
+  const isAdminRoute = createRouteMatcher(['/admin/:path*'])
 
   export default clerkMiddleware(async (auth, req) => {
     // Protect all routes starting with `/admin`
@@ -131,25 +152,6 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
       // Always run for Clerk-specific frontend API routes
       '/__clerk/(.*)',
     ],
-  }
-  ```
-
-  ### Option 2: Protect the `/admin` route at the page-level
-
-  1. Add the following code to the `app/admin/page.tsx` file. The `checkRole()` function checks if the user has the `admin` Role. If they don't, it redirects them to the home page.
-
-  ```tsx {{ filename: 'app/admin/page.tsx' }}
-  import { checkRole } from '@/utils/roles'
-  import { redirect } from 'next/navigation'
-
-  export default async function AdminDashboard() {
-    // Protect the page from users who are not admins
-    const isAdmin = await checkRole('admin')
-    if (!isAdmin) {
-      redirect('/')
-    }
-
-    return <p>This is the protected admin dashboard restricted to users with the `admin` Role.</p>
   }
   ```
 

--- a/docs/guides/secure/basic-rbac.mdx
+++ b/docs/guides/secure/basic-rbac.mdx
@@ -170,7 +170,7 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
     const client = await clerkClient()
 
     // Check that the user trying to set the Role is an admin
-    if (!checkRole('admin')) {
+    if (!(await checkRole('admin'))) {
       return { message: 'Not Authorized' }
     }
 
@@ -187,6 +187,11 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
 
   export async function removeRole(formData: FormData) {
     const client = await clerkClient()
+
+    // Check that the user trying to remove the Role is an admin
+    if (!(await checkRole('admin'))) {
+      return { message: 'Not Authorized' }
+    }
 
     try {
       const res = await client.users.updateUserMetadata(formData.get('id') as string, {
@@ -248,7 +253,7 @@ This guide assumes that you're using Next.js App Router, but you can adapt the c
   export default async function AdminDashboard(params: {
     searchParams: Promise<{ search?: string }>
   }) {
-    if (!checkRole('admin')) {
+    if (!(await checkRole('admin'))) {
       redirect('/')
     }
 

--- a/docs/guides/secure/best-practices/csp-headers.mdx
+++ b/docs/guides/secure/best-practices/csp-headers.mdx
@@ -45,20 +45,11 @@ The `default` configuration will apply the following CSP directives:
 <Include src="_partials/nextjs/nextjs-15-callout" />
 
 ```ts {{ filename: 'proxy.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { clerkMiddleware } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
-
-export default clerkMiddleware(
-  async (auth, request) => {
-    if (!isPublicRoute(request)) {
-      await auth.protect()
-    }
-  },
-  {
-    contentSecurityPolicy: {},
-  },
-)
+export default clerkMiddleware({
+  contentSecurityPolicy: {},
+})
 ```
 
 ### `strict` configuration
@@ -72,22 +63,13 @@ When using the `strict` configuration, Clerk will:
 The middleware will handle passing the nonce to the `<ClerkProvider>` automatically, so you don't need to manually set the `nonce` prop when using server components.
 
 ```ts {{ filename: 'proxy.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { clerkMiddleware } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
-
-export default clerkMiddleware(
-  async (auth, request) => {
-    if (!isPublicRoute(request)) {
-      await auth.protect()
-    }
+export default clerkMiddleware({
+  contentSecurityPolicy: {
+    strict: true,
   },
-  {
-    contentSecurityPolicy: {
-      strict: true,
-    },
-  },
-)
+})
 ```
 
 > [!IMPORTANT]
@@ -133,26 +115,17 @@ You can customize your Content Security Policy (CSP) by adding your own directiv
 In the following example, the `connect-src` directive is configured to include `api.example.com` and `analytics.example.com`, and the `img-src` directive is configured to include `images.example.com`.
 
 ```ts {{ filename: 'proxy.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { clerkMiddleware } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
-
-export default clerkMiddleware(
-  async (auth, request) => {
-    if (!isPublicRoute(request)) {
-      await auth.protect()
-    }
-  },
-  {
-    contentSecurityPolicy: {
-      strict: true,
-      directives: {
-        'connect-src': ['api.example.com', 'analytics.example.com'],
-        'img-src': ['images.example.com'],
-      },
+export default clerkMiddleware({
+  contentSecurityPolicy: {
+    strict: true,
+    directives: {
+      'connect-src': ['api.example.com', 'analytics.example.com'],
+      'img-src': ['images.example.com'],
     },
   },
-)
+})
 ```
 
 ## Manual CSP configuration

--- a/docs/reference/nextjs/app-router/auth.mdx
+++ b/docs/reference/nextjs/app-router/auth.mdx
@@ -131,7 +131,7 @@ The `auth()` helper returns the `redirectToSignIn()` method, which you can use t
 
 #### Example
 
-The following example shows how to use `redirectToSignIn()` to redirect the user to the sign-in page if they are not authenticated. It's also common to use `redirectToSignIn()` in `clerkMiddleware()` to protect entire routes; see [the `clerkMiddleware()` docs](/docs/reference/nextjs/clerk-middleware) for more information.
+The following example shows how to use `redirectToSignIn()` to redirect the user to the sign-in page if they are not authenticated. Check authentication close to the resource like this rather than gating routes in `clerkMiddleware()`; see [Protect pages and routes](/docs/guides/secure/protect-pages) for more information.
 
 ```tsx {{ filename: 'app/page.tsx' }}
 import { auth } from '@clerk/nextjs/server'

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -42,8 +42,8 @@ By default, `clerkMiddleware` will not protect any routes. All routes are public
 
 The `createRouteMatcher()` helper returns a function that, if called with the `req` object from the Middleware, will return `true` if the user is trying to access a route that matches one of the routes passed to `createRouteMatcher()`.
 
-> [!WARNING]
-> Avoid the `(.*)` wildcard when matching paths. Because `.` doesn't match newline characters, a request with an encoded newline can slip past a `(.*)` matcher while still resolving to the route, which creates an authorization bypass. Use the `:path*` form instead, which safely matches an entire subtree. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
+> [!NOTE]
+> Prefer the `:path*` form when matching a subtree of routes. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
 
 In the following example, `createRouteMatcher()` sets all `/dashboard` and `/forum` routes as protected routes.
 

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -36,14 +36,19 @@ By default, `clerkMiddleware` will not protect any routes. All routes are public
 
 ## `createRouteMatcher()`
 
+<Include src="_partials/middleware-auth-deprecation" />
+
 `createRouteMatcher()` is a Clerk helper function that allows you to protect multiple routes. `createRouteMatcher()` accepts an array of routes and checks if the route the user is trying to visit matches one of the routes passed to it. The paths provided to this helper can be in the same format as the paths provided to the Next Middleware matcher.
 
 The `createRouteMatcher()` helper returns a function that, if called with the `req` object from the Middleware, will return `true` if the user is trying to access a route that matches one of the routes passed to `createRouteMatcher()`.
 
+> [!WARNING]
+> Avoid the `(.*)` wildcard when matching paths. Because `.` doesn't match newline characters, a request with an encoded newline can slip past a `(.*)` matcher while still resolving to the route, which creates an authorization bypass. Use the `:path*` form instead, which safely matches an entire subtree. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
+
 In the following example, `createRouteMatcher()` sets all `/dashboard` and `/forum` routes as protected routes.
 
 ```tsx
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
+const isProtectedRoute = createRouteMatcher(['/dashboard/:path*', '/forum/:path*'])
 ```
 
 ## Protect routes
@@ -68,7 +73,7 @@ There are two methods that you can use:
   ```tsx {{ filename: 'proxy.ts' }}
   import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
+  const isProtectedRoute = createRouteMatcher(['/dashboard/:path*', '/forum/:path*'])
 
   export default clerkMiddleware(async (auth, req) => {
     if (isProtectedRoute(req)) await auth.protect()
@@ -89,7 +94,7 @@ There are two methods that you can use:
   ```tsx {{ filename: 'proxy.ts' }}
   import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-  const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
+  const isProtectedRoute = createRouteMatcher(['/dashboard/:path*', '/forum/:path*'])
 
   export default clerkMiddleware(async (auth, req) => {
     const { isAuthenticated, redirectToSignIn } = await auth()
@@ -128,7 +133,7 @@ There are two methods that you can use:
     ```tsx {{ filename: 'proxy.ts' }}
     import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-    const isProtectedRoute = createRouteMatcher(['/admin(.*)'])
+    const isProtectedRoute = createRouteMatcher(['/admin/:path*'])
 
     export default clerkMiddleware(async (auth, req) => {
       // Restrict admin routes to users with specific Permissions
@@ -158,7 +163,7 @@ There are two methods that you can use:
     ```tsx {{ filename: 'proxy.ts' }}
     import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-    const isProtectedRoute = createRouteMatcher(['/admin(.*)'])
+    const isProtectedRoute = createRouteMatcher(['/admin/:path*'])
 
     export default clerkMiddleware(async (auth, req) => {
       const { has, redirectToSignIn } = await auth()
@@ -189,6 +194,9 @@ There are two methods that you can use:
 
 ## Protect multiple groups of routes
 
+> [!WARNING]
+> This pattern is deprecated. Protect access close to the resource instead. See [Protect pages and routes](/docs/guides/secure/protect-pages).
+
 You can use more than one `createRouteMatcher()` in your application if you have two or more groups of routes.
 
 The following example uses the [`has()`](/docs/reference/backend/types/auth-object#has) method from the `auth()` helper.
@@ -198,9 +206,9 @@ The following example uses the [`has()`](/docs/reference/backend/types/auth-obje
 ```tsx {{ filename: 'proxy.ts' }}
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isTenantRoute = createRouteMatcher(['/organization-selector(.*)', '/orgid/(.*)'])
+const isTenantRoute = createRouteMatcher(['/organization-selector/:path*', '/orgid/:path*'])
 
-const isTenantAdminRoute = createRouteMatcher(['/orgId/(.*)/memberships', '/orgId/(.*)/domain'])
+const isTenantAdminRoute = createRouteMatcher(['/orgId/:id/memberships', '/orgId/:id/domain'])
 
 export default clerkMiddleware(async (auth, req) => {
   // Restrict admin routes to users with specific Permissions
@@ -227,6 +235,9 @@ export const config = {
 
 ## Protect all routes
 
+> [!WARNING]
+> This pattern is deprecated. Protect access close to the resource instead. See [Protect pages and routes](/docs/guides/secure/protect-pages).
+
 To protect all routes in your application and define specific routes as public, you can use any of the above methods and simply invert the `if` condition.
 
 <Include src="_partials/nextjs/link-prefetch-callout" />
@@ -234,7 +245,7 @@ To protect all routes in your application and define specific routes as public, 
 ```tsx {{ filename: 'proxy.ts' }}
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
+const isPublicRoute = createRouteMatcher(['/sign-in/:path*', '/sign-up/:path*'])
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
@@ -256,6 +267,9 @@ export const config = {
 
 ## Protect routes based on token types
 
+> [!WARNING]
+> This pattern is deprecated. For API and machine routes, check the token type in the route handler itself with [`auth({ acceptsToken })`](/docs/reference/nextjs/app-router/auth) instead of gating in the middleware. See [Verifying OAuth access tokens](/docs/guides/development/verifying-oauth-access-tokens).
+
 You can protect routes based on token types by checking if the request includes the required token (e.g. OAuth token, API key, machine token or session token). This ensures that only requests with the appropriate token type can access the route.
 
 The following example uses the [`protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) method from the `auth()` helper. Requests without the required token will return an appropriate error:
@@ -267,11 +281,11 @@ The following example uses the [`protect()`](/docs/reference/nextjs/app-router/a
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
 // Create route matchers to identify which token type each route should require
-const isOAuthAccessible = createRouteMatcher(['/oauth(.*)'])
-const isApiKeyAccessible = createRouteMatcher(['/api(.*)'])
-const isMachineTokenAccessible = createRouteMatcher(['/m2m(.*)'])
-const isUserAccessible = createRouteMatcher(['/user(.*)'])
-const isAccessibleToAnyValidToken = createRouteMatcher(['/any(.*)'])
+const isOAuthAccessible = createRouteMatcher(['/oauth/:path*'])
+const isApiKeyAccessible = createRouteMatcher(['/api/:path*'])
+const isMachineTokenAccessible = createRouteMatcher(['/m2m/:path*'])
+const isUserAccessible = createRouteMatcher(['/user/:path*'])
+const isAccessibleToAnyValidToken = createRouteMatcher(['/any/:path*'])
 
 export default clerkMiddleware(async (auth, req) => {
   // Check if the request matches each route and enforce the corresponding token type
@@ -328,7 +342,7 @@ If you would like to set up debugging for your development environment only, you
 You can combine other Middleware with Clerk's Middleware by returning the second Middleware from `clerkMiddleware()`.
 
 ```js {{ filename: 'proxy.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { clerkMiddleware } from '@clerk/nextjs/server'
 import createMiddleware from 'next-intl/middleware'
 
 import { AppConfig } from './utils/AppConfig'
@@ -339,11 +353,7 @@ const intlMiddleware = createMiddleware({
   defaultLocale: AppConfig.defaultLocale,
 })
 
-const isProtectedRoute = createRouteMatcher(['dashboard/(.*)'])
-
 export default clerkMiddleware(async (auth, req) => {
-  if (isProtectedRoute(req)) await auth.protect()
-
   return intlMiddleware(req)
 })
 

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -43,7 +43,7 @@ By default, `clerkMiddleware` will not protect any routes. All routes are public
 The `createRouteMatcher()` helper returns a function that, if called with the `req` object from the Middleware, will return `true` if the user is trying to access a route that matches one of the routes passed to `createRouteMatcher()`.
 
 > [!NOTE]
-> Prefer the `:path*` form when matching a subtree of routes. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
+> When matching a subtree of routes, prefer the `:path*` form: it maps directly to how the router matches path segments. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
 
 In the following example, `createRouteMatcher()` sets all `/dashboard` and `/forum` routes as protected routes.
 


### PR DESCRIPTION
Stacked on #3404. Applies the deprecation across the Next.js reference and the guides that taught middleware gating.

The reference page is kept-but-wrapped: each auth-gating section keeps its existing anchor but gains the deprecation notice, token-type gating now points to `auth({ acceptsToken })` at the route, and the Combine-Middleware example loses its `auth.protect()` line. In the guides, `basic-rbac` now leads with the page-level check, `session-tasks` elevates `<RedirectToTasks />`, `geo-blocking` and `satellite-domains` keep their middleware but drop the auth tail, the custom sign-in/up steps are framed as legacy, the CSP examples drop the auth gating that was never relevant to CSP, and the MCP guide stops special-casing `.well-known`.

Load-bearing bit to scrutinize: every surviving `createRouteMatcher` example moves from `/foo(.*)` to `/foo/:path*`. The `(.*)` form misses encoded newlines (a bypass) and over-matches `/foobar`; `/:path*` fixes both. Verified against the SDK's path-to-regexp.
