### PR TITLE
Deprecate createRouteMatcher in Nuxt docs in favor of built-in route protection

### DIFF
--- a/docs/guides/secure/protect-pages.nuxt.mdx
+++ b/docs/guides/secure/protect-pages.nuxt.mdx
@@ -17,28 +17,55 @@ The `useAuth()` composable provides access to the current user's authentication 
 
 ## Protect multiple pages
 
-The `createRouteMatcher()` is a Clerk helper function that allows you to protect multiple routes in your Nuxt application. It accepts an array of route patterns and checks if the route the user is trying to visit matches one of the patterns passed to it.
+To protect groups of pages, use Nuxt's built-in [route middleware](https://nuxt.com/docs/4.x/guide/directory-structure/middleware) instead of matching paths yourself. This keeps the page structure as the source of truth, so there's no separate list of paths that can fall out of sync with your routes.
 
-The `createRouteMatcher()` helper returns a function that, when called with the `to` route object from Nuxt's [`defineNuxtRouteMiddleware()`](https://nuxt.com/docs/4.x/api/utils/define-nuxt-route-middleware), will return `true` if the user is trying to access a route that matches one of the patterns provided.
+### Named middleware
 
-### Example
+Create a named middleware that checks the user's authentication status, then opt pages into it with [`definePageMeta()`](https://nuxt.com/docs/4.x/api/utils/define-page-meta). Child routes inherit the middleware applied to their parent, so a single declaration can protect a whole section.
 
-In your `middleware/` directory, create a file named `auth.global.ts` with the following code. This middleware:
-
-- Uses the `isSignedIn` property returned by the [`useAuth()`](/docs/reference/composables/use-auth) composable to check if the user is signed in.
-- Uses the `createRouteMatcher()` helper to check if the user is trying to access a protected route. If they are but they aren't signed in, they are redirected to the sign-in page.
-
-```ts {{ filename: 'app/middleware/auth.global.ts' }}
-// Define the routes you want to protect with `createRouteMatcher()`
-const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/forum(.*)'])
-
-export default defineNuxtRouteMiddleware((to) => {
+```ts {{ filename: 'app/middleware/auth.ts' }}
+export default defineNuxtRouteMiddleware(() => {
   // Use the `useAuth()` composable to access the `isSignedIn` property
   const { isSignedIn } = useAuth()
 
-  // Check if the user is not signed in and is trying to access a protected route
-  // If so, redirect them to the sign-in page
-  if (!isSignedIn.value && isProtectedRoute(to)) {
+  // Redirect the user to the sign-in page if they aren't signed in
+  if (!isSignedIn.value) {
+    return navigateTo('/sign-in')
+  }
+})
+```
+
+```vue {{ filename: 'app/pages/dashboard.vue' }}
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+</script>
+
+<template>
+  <NuxtPage />
+</template>
+```
+
+### Route groups
+
+If you're on Nuxt 4.3 or later, you can group pages with [route groups](https://nuxt.com/docs/4.x/guide/directory-structure/app/pages#route-groups) (a folder wrapped in parentheses) and protect them in a single global middleware. Each route exposes the groups it belongs to on `to.meta.groups`.
+
+```text
+pages/
+  (public)/
+    sign-in.vue
+    pricing.vue
+  (protected)/
+    dashboard.vue
+    settings.vue
+```
+
+```ts {{ filename: 'app/middleware/auth.global.ts' }}
+export default defineNuxtRouteMiddleware((to) => {
+  // Only guard pages in the `protected` route group
+  if (!to.meta.groups?.includes('protected')) return
+
+  const { isSignedIn } = useAuth()
+  if (!isSignedIn.value) {
     return navigateTo('/sign-in')
   }
 })

--- a/docs/reference/nuxt/clerk-middleware.mdx
+++ b/docs/reference/nuxt/clerk-middleware.mdx
@@ -39,7 +39,7 @@ You can protect API routes using either or both of the following:
 - [Authentication-based protection](#authentication-based-protection): Verify if the user is signed in.
 - [Authorization-based protection](#authorization-based-protection): Verify if the user has the required privileges, such as a Role, Permission, Feature, or Plan. Learn more about [authorization checks](/docs/guides/secure/authorization-checks).
 
-You can also [protect multiple routes](#protect-multiple-routes) using the `createRouteMatcher()` helper.
+You can also [protect multiple routes](#protect-multiple-routes) at once.
 
 ### Authentication-based protection
 
@@ -126,59 +126,63 @@ export default clerkMiddleware((event) => {
 
 ### Protect multiple routes
 
-You can protect multiple routes at once by using Clerk's `createRouteMatcher()` helper function. The `createRouteMatcher()` helper accepts an array of route patterns and checks if the route the user is trying to visit matches one of the patterns passed to it.
+You can protect multiple routes at once by matching against a list of path prefixes.
 
-Let's take the [first example](#authentication-based-protection) from this guide and add the `createRouteMatcher()` helper. Instead of only checking `/api/admin/**` routes, the following example checks both `/api/invoices/**` _and_ `/api/admin/**` routes.
+> [!NOTE]
+> Clerk's `createRouteMatcher()` helper is deprecated. Match routes with `event.path` instead, as shown below.
+
+Let's take the [first example](#authentication-based-protection) from this guide and check more than one prefix. Instead of only checking `/api/admin/**` routes, the following example checks both `/api/invoices/**` _and_ `/api/admin/**` routes.
 
 ```ts {{ filename: 'server/middleware/clerk.ts' }}
-+ import { clerkMiddleware, createRouteMatcher } from '@clerk/nuxt/server'
+import { clerkMiddleware } from '@clerk/nuxt/server'
 
-  export default clerkMiddleware((event) => {
-    const { isAuthenticated } = event.context.auth()
--   const isAdminRoute = event.path.startsWith('/api/admin')
-+   const isProtectedRoute = createRouteMatcher(['/api/invoices(.*)', '/api/admin(.*)'])
+export default clerkMiddleware((event) => {
+  const { isAuthenticated } = event.context.auth()
+  const protectedRoutes = ['/api/invoices', '/api/admin']
+  const isProtectedRoute = protectedRoutes.some((route) => event.path.startsWith(route))
 
-    // Check if the user is not signed in
-    // and is trying to access a protected route. If so, throw a 401 error.
-    if (!isAuthenticated && isProtectedRoute(event)) {
-      throw createError({
-        statusCode: 401,
-        statusMessage: 'Unauthorized: User not signed in',
-      })
-    }
-  })
+  // Check if the user is not signed in
+  // and is trying to access a protected route. If so, throw a 401 error.
+  if (!isAuthenticated && isProtectedRoute) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized: User not signed in',
+    })
+  }
+})
 ```
 
 Now, let's add authorization-based protection to the example so that you can see how to combine everything you've learned so far.
 
 ```ts {{ filename: 'server/middleware/clerk.ts' }}
-  import { clerkMiddleware, createRouteMatcher } from '@clerk/nuxt/server'
+import { clerkMiddleware } from '@clerk/nuxt/server'
 
-  export default clerkMiddleware((event) => {
-    const { isAuthenticated } = event.context.auth()
-    const isProtectedRoute = createRouteMatcher(['/api/invoices(.*)', '/api/admin(.*)'])
-+   const canCreateInvoices = has({
-+     permission: 'org:invoices:create',
-+   })
-
-    // Check if the user is not signed in
-    // and is trying to access a protected route. If so, throw a 401 error.
-    if (!isAuthenticated && isProtectedRoute(event)) {
-      throw createError({
-        statusCode: 401,
-        statusMessage: 'Unauthorized: User not signed in',
-      })
-    }
-
-+   // Check if the user doesn't have the required Permission
-+   // and is accessing a protected route. If so, throw a 403 error.
-+   if (!canCreateInvoices && isProtectedRoute(event)) {
-+     throw createError({
-+       statusCode: 403,
-+       statusMessage: 'Unauthorized: Missing Permission to create invoices',
-+     })
-+   }
+export default clerkMiddleware((event) => {
+  const { isAuthenticated, has } = event.context.auth()
+  const protectedRoutes = ['/api/invoices', '/api/admin']
+  const isProtectedRoute = protectedRoutes.some((route) => event.path.startsWith(route))
+  const canCreateInvoices = has({
+    permission: 'org:invoices:create',
   })
+
+  // Check if the user is not signed in
+  // and is trying to access a protected route. If so, throw a 401 error.
+  if (!isAuthenticated && isProtectedRoute) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized: User not signed in',
+    })
+  }
+
+  // Check if the user doesn't have the required Permission
+  // and is accessing a protected route. If so, throw a 403 error.
+  if (!canCreateInvoices && isProtectedRoute) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'Unauthorized: Missing Permission to create invoices',
+    })
+  }
+})
 ```
 
 ## `clerkMiddleware()` options

--- a/docs/reference/nuxt/clerk-middleware.mdx
+++ b/docs/reference/nuxt/clerk-middleware.mdx
@@ -126,10 +126,10 @@ export default clerkMiddleware((event) => {
 
 ### Protect multiple routes
 
-You can protect multiple routes at once by matching against a list of path prefixes.
+You can protect multiple routes at once by matching against a list of path prefixes. This applies to server (API) routes, which have no file-system page tree to inherit protection from, so matching `event.path` here is the right tool. To protect _pages_, use Nuxt's built-in route middleware instead, which keeps your page structure as the source of truth; see [Protect pages and routes](/docs/guides/secure/protect-pages).
 
 > [!NOTE]
-> Clerk's `createRouteMatcher()` helper is deprecated. Match routes with `event.path` instead, as shown below.
+> Clerk's `createRouteMatcher()` helper is no longer recommended. Match routes with `event.path` instead, as shown below.
 
 Let's take the [first example](#authentication-based-protection) from this guide and check more than one prefix. Instead of only checking `/api/admin/**` routes, the following example checks both `/api/invoices/**` _and_ `/api/admin/**` routes.
 

--- a/docs/reference/nuxt/overview.mdx
+++ b/docs/reference/nuxt/overview.mdx
@@ -70,7 +70,7 @@ The `clerkMiddleware()` helper integrates Clerk authentication and authorization
 
 ## Protect pages and API routes
 
-To protect pages, use the `useAuth()` helper to protect a single page, or use it with `defineNuxtRouteMiddleware()` alongside the `createRouteMatcher()` helper to protect multiple pages. [Learn more](/docs/guides/secure/protect-pages).
+To protect pages, use the `useAuth()` helper to protect a single page, or use Nuxt's built-in [route middleware](https://nuxt.com/docs/4.x/guide/directory-structure/middleware) to protect multiple pages. [Learn more](/docs/guides/secure/protect-pages).
 
 To protect API routes (`/api/**`), use the `clerkMiddleware()` helper. [Learn more](/docs/reference/nuxt/clerk-middleware).
 


### PR DESCRIPTION
Stacked on #3405. Moves the Nuxt docs off `createRouteMatcher` to Nuxt's built-in route protection.

`protect-pages.nuxt` now uses named route middleware (`definePageMeta` with file-system inheritance) and route groups (`route.meta.groups`, Nuxt 4.3+) instead of matching paths by hand, and the API-route examples in the middleware reference use `event.path` prefix checks. While rewriting the authorization example I also destructured `has()` from `event.context.auth()`, which was previously referenced but never defined.
