### PR TITLE
Note current route-protection guidance in Core 2 upgrade guide

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/core-2/nextjs.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-2/nextjs.mdx
@@ -66,6 +66,9 @@ The new version ships with improved design and UX across all of Clerk's [UI comp
 
 ### New Middleware architecture
 
+> [!NOTE]
+> This section describes the Core 2 Middleware migration. Auth checks inside `clerkMiddleware()`, including `createRouteMatcher()`, have since been deprecated. For current guidance on protecting routes, see [Protect pages and routes](/docs/guides/secure/protect-pages).
+
 User and customer feedback about `authMiddleware()` has been clear in that Middleware logic was a often friction point. As such, in v5 you will find a completely new Middleware helper called [`clerkMiddleware()`](/docs/reference/nextjs/clerk-middleware) that should alleviate the issues folks had with `authMiddleware()`.
 
 The primary change from the previous `authMiddleware()` is that `clerkMiddleware()` does not protect any routes by default, instead requiring the developer to add routes they would like to be protected by auth. This is a substantial contrast to the previous `authMiddleware()`, which protected all routes by default, requiring the developer to add exceptions. The API was also substantially simplified, and it has become easier to combine with other Middleware helpers smoothly as well.


### PR DESCRIPTION
Stacked on #3407. The Core 2 Next.js upgrade guide documents the historical `authMiddleware` to `clerkMiddleware` migration, so this just adds a note that middleware-based auth checks have since been deprecated and points readers at the current protect-pages guidance. The historical examples are left as-is on purpose.
