### PR TITLE
Fix Android quickstart

### DIFF
--- a/docs/getting-started/quickstart.android.mdx
+++ b/docs/getting-started/quickstart.android.mdx
@@ -226,13 +226,13 @@ sdk: android
     }
 
     fun verify(code: String) {
-        val inProgressSignUp = Clerk.signUp ?: return
+        val inProgressSignUp = Clerk.auth.currentSignUp ?: return
+
         viewModelScope.launch {
-            inProgressSignUp.attemptVerification(SignUp.AttemptVerificationParams.EmailCode(code))
+            inProgressSignUp
+                .attemptVerification(SignUp.AttemptVerificationParams.EmailCode(code))
                 .onSuccess { _uiState.value = SignUpUiState.Success }
                 .onFailure {
-                    // See https://clerk.com/docs/guides/development/custom-flows/error-handling
-                    // for more info on error handling
                     Log.e("SignUpViewModel", it.errorMessage, it.throwable)
                 }
         }
@@ -480,7 +480,7 @@ sdk: android
 
   Finally, provide users with a way to sign out of your app.
 
-  In your `MainViewModel`, add a `signOut` function that calls `Clerk.signOut()`.
+  In your `MainViewModel`, add a `signOut` function that calls `Clerk.auth.signOut()`.
 
   ```kotlin {{ filename: 'app/src/main/java/com/example/myclerkapp/MainViewModel.kt', mark: [14, [7, 9], [31, 41]], collapsible: true }}
   package com.example.myclerkapp
@@ -515,7 +515,7 @@ sdk: android
 
     fun signOut() {
         viewModelScope.launch() {
-            Clerk.signOut()
+            Clerk.auth.signOut()
             .onSuccess { _uiState.value = MainUiState.SignedOut }
             .onFailure {
                 // See https://clerk.com/docs/guides/development/custom-flows/error-handling

--- a/docs/getting-started/quickstart.android.mdx
+++ b/docs/getting-started/quickstart.android.mdx
@@ -233,6 +233,8 @@ sdk: android
                 .attemptVerification(SignUp.AttemptVerificationParams.EmailCode(code))
                 .onSuccess { _uiState.value = SignUpUiState.Success }
                 .onFailure {
+                    // See https://clerk.com/docs/guides/development/custom-flows/error-handling
+                    // for more info on error handling
                     Log.e("SignUpViewModel", it.errorMessage, it.throwable)
                 }
         }


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-fix-android-quickstart/ios/getting-started/quickstart

### What does this solve? What changed?

When testing this [PR](https://github.com/clerk/clerk-docs/pull/3384/) adding new org components, I noticed the Android quickstart had some outdated code. This PR adds the correct methods. 

### Deadline

ASAP. 

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
