### PR TITLE
Add custom OAuth consent page docs

### DIFF
--- a/docs/_partials/components/oauth-consent-custom-flow-examples.mdx
+++ b/docs/_partials/components/oauth-consent-custom-flow-examples.mdx
@@ -1,0 +1,373 @@
+<Tabs items={["Next.js", "React", "React Router", "TanStack React Start"]}>
+  <Tab>
+    ```tsx {{ filename: 'app/oauth-consent/custom-consent-form.tsx' }}
+    'use client'
+
+    import { useClerk, useOAuthConsent } from '@clerk/nextjs'
+    import { useSearchParams } from 'next/navigation'
+
+    function getRedirectHostname(redirectUri: string) {
+      try {
+        return new URL(redirectUri).hostname
+      } catch {
+        return ''
+      }
+    }
+
+    export function CustomConsentForm() {
+      const clerk = useClerk()
+      const searchParams = useSearchParams()
+
+      const clientId = searchParams.get('client_id') ?? ''
+      const redirectUri = searchParams.get('redirect_uri') ?? ''
+      const scope = searchParams.get('scope') ?? undefined
+      const redirectHostname = getRedirectHostname(redirectUri)
+
+      const { data, isLoading, error } = useOAuthConsent({
+        oauthClientId: clientId,
+        scope,
+      })
+
+      if (!clientId || !redirectUri) {
+        return <p>Missing OAuth consent parameters.</p>
+      }
+
+      if (isLoading) {
+        return <p>Loading consent request...</p>
+      }
+
+      if (error || !data) {
+        return <p>Unable to load consent request.</p>
+      }
+
+      return (
+        <form method="POST" action={clerk.oauthApplication.buildConsentActionUrl({ clientId })}>
+          <h1>{data.oauthApplicationName} wants access to your account</h1>
+
+          {data.oauthApplicationLogoUrl && (
+            <img src={data.oauthApplicationLogoUrl} alt={`${data.oauthApplicationName} logo`} />
+          )}
+
+          <p>
+            Review the requested permissions before continuing. After you allow or deny access, you will
+            be redirected to <strong>{redirectHostname}</strong>.
+          </p>
+
+          <details>
+            <summary>View full redirect URL</summary>
+            <code>{redirectUri}</code>
+          </details>
+
+          <ul>
+            {data.scopes.map((scope) => (
+              <li key={scope.scope}>{scope.description || scope.scope}</li>
+            ))}
+          </ul>
+
+          {Array.from(searchParams.entries()).map(([key, value], index) => (
+            <input key={`${key}:${index}`} type="hidden" name={key} value={value} />
+          ))}
+
+          <button type="submit" name="consented" value="false">
+            Deny
+          </button>
+          <button type="submit" name="consented" value="true">
+            Allow
+          </button>
+        </form>
+      )
+    }
+    ```
+
+    ```tsx {{ filename: 'app/oauth-consent/page.tsx' }}
+    import { Show } from '@clerk/nextjs'
+    import { CustomConsentForm } from './custom-consent-form'
+
+    export const metadata = {
+      referrer: 'strict-origin-when-cross-origin',
+    }
+
+    export default function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <CustomConsentForm />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'src/OAuthConsentPage.tsx' }}
+    import { Show, useClerk, useOAuthConsent } from '@clerk/react'
+
+    function getConsentSearchParams() {
+      if (typeof window === 'undefined') {
+        return new URLSearchParams()
+      }
+
+      return new URLSearchParams(window.location.search)
+    }
+
+    function getRedirectHostname(redirectUri: string) {
+      try {
+        return new URL(redirectUri).hostname
+      } catch {
+        return ''
+      }
+    }
+
+    function CustomConsentForm() {
+      const clerk = useClerk()
+      const searchParams = getConsentSearchParams()
+
+      const clientId = searchParams.get('client_id') ?? ''
+      const redirectUri = searchParams.get('redirect_uri') ?? ''
+      const scope = searchParams.get('scope') ?? undefined
+      const redirectHostname = getRedirectHostname(redirectUri)
+
+      const { data, isLoading, error } = useOAuthConsent({
+        oauthClientId: clientId,
+        scope,
+      })
+
+      if (!clientId || !redirectUri) {
+        return <p>Missing OAuth consent parameters.</p>
+      }
+
+      if (isLoading) {
+        return <p>Loading consent request...</p>
+      }
+
+      if (error || !data) {
+        return <p>Unable to load consent request.</p>
+      }
+
+      return (
+        <form method="POST" action={clerk.oauthApplication.buildConsentActionUrl({ clientId })}>
+          <h1>{data.oauthApplicationName} wants access to your account</h1>
+
+          {data.oauthApplicationLogoUrl && (
+            <img src={data.oauthApplicationLogoUrl} alt={`${data.oauthApplicationName} logo`} />
+          )}
+
+          <p>
+            Review the requested permissions before continuing. After you allow or deny access, you will
+            be redirected to <strong>{redirectHostname}</strong>.
+          </p>
+
+          <details>
+            <summary>View full redirect URL</summary>
+            <code>{redirectUri}</code>
+          </details>
+
+          <ul>
+            {data.scopes.map((scope) => (
+              <li key={scope.scope}>{scope.description || scope.scope}</li>
+            ))}
+          </ul>
+
+          {Array.from(searchParams.entries()).map(([key, value], index) => (
+            <input key={`${key}:${index}`} type="hidden" name={key} value={value} />
+          ))}
+
+          <button type="submit" name="consented" value="false">
+            Deny
+          </button>
+          <button type="submit" name="consented" value="true">
+            Allow
+          </button>
+        </form>
+      )
+    }
+
+    export function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <CustomConsentForm />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'app/routes/oauth-consent.tsx' }}
+    import { Show, useClerk, useOAuthConsent } from '@clerk/react-router'
+    import { useLocation } from 'react-router'
+
+    function getRedirectHostname(redirectUri: string) {
+      try {
+        return new URL(redirectUri).hostname
+      } catch {
+        return ''
+      }
+    }
+
+    function CustomConsentForm() {
+      const clerk = useClerk()
+      const { search } = useLocation()
+      const searchParams = new URLSearchParams(search)
+
+      const clientId = searchParams.get('client_id') ?? ''
+      const redirectUri = searchParams.get('redirect_uri') ?? ''
+      const scope = searchParams.get('scope') ?? undefined
+      const redirectHostname = getRedirectHostname(redirectUri)
+
+      const { data, isLoading, error } = useOAuthConsent({
+        oauthClientId: clientId,
+        scope,
+      })
+
+      if (!clientId || !redirectUri) {
+        return <p>Missing OAuth consent parameters.</p>
+      }
+
+      if (isLoading) {
+        return <p>Loading consent request...</p>
+      }
+
+      if (error || !data) {
+        return <p>Unable to load consent request.</p>
+      }
+
+      return (
+        <form method="POST" action={clerk.oauthApplication.buildConsentActionUrl({ clientId })}>
+          <h1>{data.oauthApplicationName} wants access to your account</h1>
+
+          {data.oauthApplicationLogoUrl && (
+            <img src={data.oauthApplicationLogoUrl} alt={`${data.oauthApplicationName} logo`} />
+          )}
+
+          <p>
+            Review the requested permissions before continuing. After you allow or deny access, you will
+            be redirected to <strong>{redirectHostname}</strong>.
+          </p>
+
+          <details>
+            <summary>View full redirect URL</summary>
+            <code>{redirectUri}</code>
+          </details>
+
+          <ul>
+            {data.scopes.map((scope) => (
+              <li key={scope.scope}>{scope.description || scope.scope}</li>
+            ))}
+          </ul>
+
+          {Array.from(searchParams.entries()).map(([key, value], index) => (
+            <input key={`${key}:${index}`} type="hidden" name={key} value={value} />
+          ))}
+
+          <button type="submit" name="consented" value="false">
+            Deny
+          </button>
+          <button type="submit" name="consented" value="true">
+            Allow
+          </button>
+        </form>
+      )
+    }
+
+    export default function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <CustomConsentForm />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'app/routes/oauth-consent.tsx' }}
+    import { Show, useClerk, useOAuthConsent } from '@clerk/tanstack-react-start'
+    import { createFileRoute, useLocation } from '@tanstack/react-router'
+
+    export const Route = createFileRoute('/oauth-consent')({
+      component: OAuthConsentPage,
+    })
+
+    function getRedirectHostname(redirectUri: string) {
+      try {
+        return new URL(redirectUri).hostname
+      } catch {
+        return ''
+      }
+    }
+
+    function CustomConsentForm() {
+      const clerk = useClerk()
+      const location = useLocation()
+      const searchParams = new URLSearchParams(location.searchStr)
+
+      const clientId = searchParams.get('client_id') ?? ''
+      const redirectUri = searchParams.get('redirect_uri') ?? ''
+      const scope = searchParams.get('scope') ?? undefined
+      const redirectHostname = getRedirectHostname(redirectUri)
+
+      const { data, isLoading, error } = useOAuthConsent({
+        oauthClientId: clientId,
+        scope,
+      })
+
+      if (!clientId || !redirectUri) {
+        return <p>Missing OAuth consent parameters.</p>
+      }
+
+      if (isLoading) {
+        return <p>Loading consent request...</p>
+      }
+
+      if (error || !data) {
+        return <p>Unable to load consent request.</p>
+      }
+
+      return (
+        <form method="POST" action={clerk.oauthApplication.buildConsentActionUrl({ clientId })}>
+          <h1>{data.oauthApplicationName} wants access to your account</h1>
+
+          {data.oauthApplicationLogoUrl && (
+            <img src={data.oauthApplicationLogoUrl} alt={`${data.oauthApplicationName} logo`} />
+          )}
+
+          <p>
+            Review the requested permissions before continuing. After you allow or deny access, you will
+            be redirected to <strong>{redirectHostname}</strong>.
+          </p>
+
+          <details>
+            <summary>View full redirect URL</summary>
+            <code>{redirectUri}</code>
+          </details>
+
+          <ul>
+            {data.scopes.map((scope) => (
+              <li key={scope.scope}>{scope.description || scope.scope}</li>
+            ))}
+          </ul>
+
+          {Array.from(searchParams.entries()).map(([key, value], index) => (
+            <input key={`${key}:${index}`} type="hidden" name={key} value={value} />
+          ))}
+
+          <button type="submit" name="consented" value="false">
+            Deny
+          </button>
+          <button type="submit" name="consented" value="true">
+            Allow
+          </button>
+        </form>
+      )
+    }
+
+    function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <CustomConsentForm />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/_partials/components/oauth-consent-examples.mdx
+++ b/docs/_partials/components/oauth-consent-examples.mdx
@@ -1,0 +1,114 @@
+<Tabs items={["Next.js", "React", "React Router", "TanStack React Start", "Astro", "Vue", "Nuxt"]}>
+  <Tab>
+    ```tsx {{ filename: 'app/oauth-consent/page.tsx' }}
+    import { OAuthConsent, Show } from '@clerk/nextjs'
+
+    export const metadata = {
+      referrer: 'strict-origin-when-cross-origin',
+    }
+
+    export default function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <OAuthConsent />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'src/OAuthConsentPage.tsx' }}
+    import { OAuthConsent, Show } from '@clerk/react'
+
+    export function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <OAuthConsent />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'app/routes/oauth-consent.tsx' }}
+    import { OAuthConsent, Show } from '@clerk/react-router'
+
+    export default function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <OAuthConsent />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```tsx {{ filename: 'app/routes/oauth-consent.tsx' }}
+    import { OAuthConsent, Show } from '@clerk/tanstack-react-start'
+    import { createFileRoute } from '@tanstack/react-router'
+
+    export const Route = createFileRoute('/oauth-consent')({
+      component: OAuthConsentPage,
+    })
+
+    function OAuthConsentPage() {
+      return (
+        <Show when="signed-in">
+          <OAuthConsent />
+        </Show>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```astro {{ filename: 'src/pages/oauth-consent.astro' }}
+    ---
+    import { OAuthConsent, Show } from '@clerk/astro/components'
+    ---
+
+    <head>
+      <meta name="referrer" content="strict-origin-when-cross-origin" />
+    </head>
+
+    <Show when="signed-in">
+      <OAuthConsent />
+    </Show>
+    ```
+  </Tab>
+
+  <Tab>
+    ```vue {{ filename: 'src/pages/OAuthConsentPage.vue' }}
+    <script setup lang="ts">
+    import { OAuthConsent, Show } from '@clerk/vue'
+    </script>
+
+    <template>
+      <Show when="signed-in">
+        <OAuthConsent />
+      </Show>
+    </template>
+    ```
+  </Tab>
+
+  <Tab>
+    ```vue {{ filename: 'pages/oauth-consent.vue' }}
+    <script setup lang="ts">
+    import { OAuthConsent, Show } from '@clerk/nuxt/components'
+
+    useHead({
+      meta: [{ name: 'referrer', content: 'strict-origin-when-cross-origin' }],
+    })
+    </script>
+
+    <template>
+      <Show when="signed-in">
+        <OAuthConsent />
+      </Show>
+    </template>
+    ```
+  </Tab>
+</Tabs>

--- a/docs/guides/configure/auth-strategies/oauth/custom-consent-page.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/custom-consent-page.mdx
@@ -1,0 +1,148 @@
+---
+title: Customize the OAuth consent page
+description: Learn how to configure a custom OAuth consent page, and how to avoid common consent phishing and token grant risks.
+---
+
+Clerk strongly recommends using the default OAuth consent page hosted by the [Account Portal](/docs/guides/account-portal/overview). OAuth consent is a security boundary: it is where a signed-in user decides whether an OAuth [client](!oauth-client) can receive [OAuth access tokens](!oauth-access-token) and access the requested data. A custom page can weaken that boundary if it hides the requesting application, misstates the requested scopes, buries the deny action, auto-approves access, or trains users to trust an unfamiliar consent surface.
+
+Only customize the OAuth consent page when you have a specific product requirement that the Account Portal cannot satisfy. If you customize it, the safest approach is to host a page on your own application domain and render Clerk's prebuilt [`<OAuthConsent />`](/docs/reference/components/authentication/oauth-consent) component. This keeps Clerk's consent logic, scope rendering, organization selection, form submission, and denial handling intact while letting you control the route, page styling, and surrounding page.
+
+> [!CAUTION]
+> Consent phishing is a real OAuth attack pattern. Attackers can trick users into granting a malicious app access to their account data without stealing their password. Microsoft describes consent phishing as an attack where users grant permissions to malicious cloud applications, and notes that MFA or password resets do not remediate illicit consent grants because the user authorized the app itself. See Microsoft's guidance on [protecting against consent phishing](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/protect-against-consent-phishing) and [detecting illicit consent grants](https://learn.microsoft.com/en-us/defender-office-365/detect-and-remediate-illicit-consent-grants).
+
+## Before you start
+
+Custom consent pages apply to Clerk's OAuth provider flows, where Clerk acts as the authorization service for OAuth applications that request access to user data through Clerk.
+
+> [!NOTE]
+> If you're new to OAuth terminology, start with the [OAuth terminology guide](/docs/guides/configure/auth-strategies/oauth/overview#key-terminology).
+
+Before customizing the page:
+
+- Keep the consent screen enabled for every OAuth application. Without consent, a signed-in user who visits a valid authorization URL can grant access without seeing the request.
+- Use narrow [scopes](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#scopes). OAuth security guidance recommends restricting access tokens to the minimum required privileges, and Google recommends choosing the most narrowly focused scopes possible. See [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) and Google's guide to [configuring OAuth consent and choosing scopes](https://developers.google.com/workspace/guides/configure-oauth-consent).
+- Treat OAuth application branding as user-facing security information. App names, logos, client URLs, and redirect domains help users decide whether to grant access.
+- Verify the route in development and production before enabling it for real users. A broken custom consent page can block OAuth authorization flows.
+
+## What the consent page must show
+
+A safe consent page must give users enough information to make an informed decision. At minimum, show:
+
+- The OAuth application's name.
+- The OAuth application's logo, if one is available.
+- The OAuth application's public URL, if one is available.
+- The [resource service](!oauth-resource-service) receiving the access request.
+- The signed-in user who is granting access.
+- Every requested scope that requires consent, using clear descriptions.
+- The redirect destination the user will return to after allowing or denying access.
+- Equally visible **Allow** and **Deny** actions.
+
+The redirect destination presentation is security-sensitive. The prebuilt consent page shows a short domain derived from the `redirect_uri`, and lets the user expand it to view the full URL. This makes it harder for an attacker to hide the real root domain inside a very long URL with many subdomains or path segments. If you build your own UI, do not show only a truncated full URL. Show a clear domain summary, provide a way to view the full `redirect_uri`, and make sure the root domain cannot be pushed out of view by long subdomains.
+
+If you use the prebuilt component, do not hide the requested scopes, redirect warning, deny action, or application identity with `appearance` overrides. If you build a custom flow, include equivalent warning copy near the allow/deny controls. For example: "`<OAuth app name>` will be able to access `<application name>` and redirect you to `<redirect domain>`. Review the requested permissions before continuing."
+
+## Recommended implementation
+
+Use Clerk's prebuilt [`<OAuthConsent />`](/docs/reference/components/authentication/oauth-consent) component on your custom consent route. The component reads the OAuth authorization parameters from the current URL, loads consent metadata for the signed-in user, renders the requested scopes, and submits the user's decision to Clerk.
+
+For example, create a route that renders `<OAuthConsent />`:
+
+<Include src="_partials/components/oauth-consent-examples" />
+
+The [`<Show />`](/docs/reference/components/control/show) component renders the consent screen only for signed-in users. In a normal OAuth authorization flow, Clerk redirects signed-out users to sign-in before sending them to the consent page. If users can visit your custom consent route directly, handle signed-out users the same way you handle any other protected route in your app.
+
+If your framework does not support route metadata, set the same referrer policy with a `<meta>` tag or equivalent framework API:
+
+```tsx
+<meta name="referrer" content="strict-origin-when-cross-origin" />
+```
+
+The referrer policy is required because the consent form posts to Clerk's [Frontend API URL](!frontend-api-url). Without it, some cross-origin form submissions can send `Origin: null`, causing Clerk to reject the request.
+
+You can style `<OAuthConsent />` with the standard [`appearance`](/docs/guides/customizing-clerk/appearance-prop/overview) prop, but keep the security content intact. The Account Portal consent page is built from Clerk's prebuilt consent component, so using `appearance` is the safer option when your goal is visual customization. Use a fully custom flow only when the prebuilt component cannot support your required layout or interaction.
+
+## Configure the custom route
+
+After you create and deploy the route, configure Clerk to send users to it during OAuth flows that require consent.
+
+<Steps>
+  ### Open path settings
+
+  In the [Clerk Dashboard](https://dashboard.clerk.com), open your application, select the relevant instance, and navigate to **Configure** > **Paths**.
+
+  ### Set the OAuth consent location
+
+  In the **OAuth consent** section, choose your custom location:
+
+  - For a development instance, enter a path on the development host, such as `/oauth-consent`.
+  - For a production instance, enter an `https://` URL on your application domain, such as `https://example.com/oauth-consent`.
+
+  Clerk only accepts production OAuth consent URLs that use HTTPS and belong to the same registrable domain as your instance domain, such as `example.com` or a subdomain of `example.com`.
+
+  ### Keep OAuth application consent enabled
+
+  Navigate to [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) and confirm that the consent screen is enabled for every OAuth application that can use the custom route.
+
+  If [dynamic client registration](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#dynamic-client-registration) is enabled, Clerk enforces the consent screen and does not allow it to be disabled.
+
+  ### Test an authorization request
+
+  Start an OAuth authorization flow for one of your OAuth applications. If the user is signed out, Clerk redirects to sign-in first, then redirects to your custom consent route with the original OAuth parameters. After the user allows or denies access, Clerk continues the OAuth flow and redirects back to the OAuth client's `redirect_uri`.
+</Steps>
+
+## Build a custom flow
+
+Building a [custom flow](!custom-flow) from low-level APIs is riskier than using `<OAuthConsent />`. Only do this if you need a layout or interaction that the prebuilt component cannot support.
+
+The custom flow needs to do the same work as the prebuilt component:
+
+1. Read `client_id`, `redirect_uri`, `scope`, `state`, `nonce`, `code_challenge`, `code_challenge_method`, and any other OAuth authorization parameters from the incoming URL.
+1. Load consent metadata for the signed-in user with `useOAuthConsent()` or `Clerk.oauthApplication.getConsentInfo()`.
+1. Display the returned OAuth application name, logo URL, application URL, client ID, and scopes without changing their meaning.
+1. Display the redirect destination safely. Show a short domain summary, and let the user inspect the full `redirect_uri`.
+1. Preserve and forward the original OAuth authorization parameters when submitting the decision.
+1. Submit a form with `method="POST"` to the URL returned by `Clerk.oauthApplication.buildConsentActionUrl({ clientId })`.
+1. Use a submit field named `consented`, with `value="true"` for allow and `value="false"` for deny.
+1. Include `organization_id` when the user grants access for a specific organization.
+1. Preserve the user's ability to deny access. A denial returns an OAuth `access_denied` response to the OAuth client.
+
+Do not construct the [Frontend API URL](!frontend-api-url) by hand. Use `buildConsentActionUrl()` so Clerk can include the current session and development browser parameters that are required for the request.
+
+The following examples show the minimum shape of a custom consent page. They intentionally keep the UI plain so you can see the OAuth-specific requirements.
+
+<Include src="_partials/components/oauth-consent-custom-flow-examples" />
+
+These examples display the full redirect hostname and an expandable full URL. For a production custom flow, use a public-suffix-aware approach for root-domain summaries, handle IP addresses and localhost explicitly, and test long redirect URIs to make sure the real destination remains visible.
+
+These examples also do not implement organization selection. If an OAuth application can request `user:org:read`, use `<OAuthConsent />` or add an organization selector that submits the selected `organization_id` with the allow action.
+
+The low-level `useOAuthConsent()` examples in this guide are available for Clerk's React-based SDKs. For Astro, Vue, and Nuxt, use the prebuilt `<OAuthConsent />` component unless you are prepared to build directly against [ClerkJS](/docs/reference/javascript/overview) and maintain the consent flow yourself.
+
+## Security checklist
+
+Before shipping a custom consent page, verify the following:
+
+- The page is served over HTTPS in production.
+- The page is on your application domain or subdomain, not on an unrelated domain.
+- The page cannot be framed by untrusted sites. Use appropriate `Content-Security-Policy` `frame-ancestors` or equivalent headers.
+- The page does not include third-party scripts that can read OAuth parameters or alter the consent form.
+- The page displays the requesting OAuth application's identity and requested scopes before the user can allow access.
+- The **Deny** action is visible and works.
+- The page never grants consent automatically.
+- The page forwards the original OAuth parameters unchanged.
+- The page uses `strict-origin-when-cross-origin` referrer policy.
+- The OAuth application requests only the scopes it needs.
+- Your team can audit OAuth applications and revoke suspicious grants if needed.
+
+## Prefer appearance for visual changes
+
+If your main goal is to change colors, fonts, spacing, or logos, use the [`appearance`](/docs/guides/customizing-clerk/appearance-prop/overview) prop with `<OAuthConsent />` instead of building a custom flow. This keeps Clerk's consent behavior, redirect destination presentation, organization selection, form submission, and future security updates intact.
+
+Only build a low-level custom flow if:
+
+- The prebuilt component cannot support your required layout or interaction.
+- You can maintain the route as a security-sensitive surface.
+- You can show the requesting OAuth application's identity, requested scopes, and redirect destination clearly.
+- You can preserve an equally visible deny action.
+
+Do not build a custom flow to hide scopes, hide redirect destinations, remove the deny action, or auto-approve trusted clients. Instead, model trust through OAuth application configuration, narrow scopes, and administrative review. Custom consent pages should make the consent decision clearer, not easier to miss.

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -83,6 +83,8 @@ The consent screen is enabled by default for all OAuth apps. You can enable or d
 
 > [!IMPORTANT]
 > Enabling the consent screen for all OAuth apps is **strongly recommended**. Without a consent screen, any logged-in user who visits an OAuth authorization URL automatically grants access to any requested scopes. The consent screen acts as a critical security checkpoint, preventing malicious apps from silently gaining access to user accounts.
+>
+> If you need to host the consent page on your own application domain, see [Customize the OAuth consent page](/docs/guides/configure/auth-strategies/oauth/custom-consent-page). Clerk strongly recommends using the default [Account Portal](/docs/guides/account-portal/overview) consent page unless you have a specific product requirement that it cannot satisfy.
 
 ## Token expiration and management
 

--- a/docs/guides/configure/auth-strategies/oauth/scoped-access.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/scoped-access.mdx
@@ -69,6 +69,8 @@ This guide provides step-by-step instructions on how to build OAuth scoped acces
   > The consent screen uses the scopes passed in the authorization request to inform the user exactly what they're granting access to, and to whom.
   >
   > By default, the consent screen is shown for all newly created OAuth apps, but this can be disabled in each app's settings [in the Clerk Dashboard](https://dashboard.clerk.com/~/oauth-applications), although not recommended. Learn more about [how Clerk's OAuth consent screen works](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#consent-screen-management).
+  >
+  > If you need to host the consent page yourself, see [Customize the OAuth consent page](/docs/guides/configure/auth-strategies/oauth/custom-consent-page). Clerk strongly recommends using the default [Account Portal](/docs/guides/account-portal/overview) consent page unless you have a specific product requirement that it cannot satisfy.
 
   Once you have accepted, you'll be redirected to the OAuth callback route, the `redirect_uri` specified earlier. This process will exchange the authorization code for an [access token](!oauth-access-token), and return the access token and refresh token as a JSON response, similar to this:
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -363,6 +363,10 @@
                                 "href": "/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth"
                               },
                               {
+                                "title": "Customize the OAuth consent page",
+                                "href": "/docs/guides/configure/auth-strategies/oauth/custom-consent-page"
+                              },
+                              {
                                 "title": "Use OAuth for Single Sign-On (SSO)",
                                 "href": "/docs/guides/configure/auth-strategies/oauth/single-sign-on"
                               },
@@ -3626,6 +3630,10 @@
                         {
                           "title": "`<GoogleOneTap />`",
                           "href": "/docs/reference/components/authentication/google-one-tap"
+                        },
+                        {
+                          "title": "`<OAuthConsent />`",
+                          "href": "/docs/reference/components/authentication/oauth-consent"
                         },
                         {
                           "title": "`<TaskChooseOrganization />`",

--- a/docs/reference/components/authentication/oauth-consent.mdx
+++ b/docs/reference/components/authentication/oauth-consent.mdx
@@ -1,0 +1,43 @@
+---
+title: '`<OAuthConsent />` component'
+description: Clerk's <OAuthConsent /> component renders a consent screen for OAuth provider flows.
+sdk: astro, nextjs, nuxt, react, react-router, tanstack-react-start, vue
+---
+
+The `<OAuthConsent />` component renders a consent screen for Clerk OAuth provider flows. It loads consent metadata for the signed-in user, displays the OAuth application's identity and requested [scopes](/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#scopes), and submits the user's allow or deny decision to Clerk.
+
+Use this component when you need to host the OAuth consent page on your own route. For setup instructions and security guidance, see [Customize the OAuth consent page](/docs/guides/configure/auth-strategies/oauth/custom-consent-page).
+
+> [!IMPORTANT]
+> The `<OAuthConsent />` component requires a signed-in user. In a normal OAuth authorization flow, Clerk redirects signed-out users to sign-in before sending them to the consent page. If users can visit your custom consent route directly, handle signed-out users the same way you handle any other protected route in your app.
+
+## Example
+
+The following example renders `<OAuthConsent />` on a custom consent route.
+
+<Include src="_partials/components/oauth-consent-examples" />
+
+The `strict-origin-when-cross-origin` referrer policy is required because the consent form posts to Clerk's [Frontend API URL](!frontend-api-url). Without it, some cross-origin form submissions can send `Origin: null`, causing Clerk to reject the request.
+
+## Properties
+
+<Properties>
+  - `appearance?`
+  - <code>[Appearance](/docs/guides/customizing-clerk/appearance-prop/overview) | undefined</code>
+
+  An object used to style the component. Do not use `appearance` overrides to hide scopes, redirect warnings, deny actions, or application identity.
+
+  ---
+
+  - `oauthClientId?`
+  - `string`
+
+  Overrides the OAuth client ID. Defaults to the `client_id` query parameter from the current URL.
+
+  ---
+
+  - `scope?`
+  - `string`
+
+  Overrides the OAuth scope. Defaults to the `scope` query parameter from the current URL.
+</Properties>


### PR DESCRIPTION
## Summary

Adds documentation for configuring a custom OAuth consent page, with a strong recommendation to use the default Account Portal page or Clerk prebuilt OAuthConsent component instead of a fully custom flow. The guide explains the phishing and token-grant risks, redirect URI presentation requirements, safe route configuration, and low-level custom-flow responsibilities when a custom implementation is unavoidable.

## Changes in this repo

Adds a new custom OAuth consent page guide, an OAuthConsent component reference page, framework-specific prebuilt and custom-flow snippets, navigation entries, and cross-links from existing OAuth docs.

## Preview links

New pages:

- [Customize the OAuth consent page](https://clerk.com/docs/pr/je-docs-oauth-custom-consent-page/guides/configure/auth-strategies/oauth/custom-consent-page)
- [`<OAuthConsent />` component reference](https://clerk.com/docs/pr/je-docs-oauth-custom-consent-page/nextjs/reference/components/authentication/oauth-consent)

Changed sections:

- [How Clerk implements OAuth: Consent screen management](https://clerk.com/docs/pr/je-docs-oauth-custom-consent-page/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth#consent-screen-management)
- [Use OAuth for scoped access: Finished](https://clerk.com/docs/pr/je-docs-oauth-custom-consent-page/guides/configure/auth-strategies/oauth/scoped-access#finished)
