### PR TITLE
docs(ai): add tool calls, agents, and agent orchestration to Vercel AI SDK guide

### DIFF
--- a/docs/guides/ai/vercel-ai-sdk/agent-orchestration.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/agent-orchestration.mdx
@@ -4,13 +4,12 @@ description: Use Clerk machines to gate which agents can invoke which inside a r
 sdk: nextjs
 ---
 
-When you need to orchestrate agents inside a workflow context, you can use Clerk [machines](/docs/guides/development/machine-auth/overview) to keep the boundaries between them explicit. This page shows how to use M2M authentication for cross-agent communication.
+This page expands on [Agent configuration](/docs/guides/ai/vercel-ai-sdk/agents) and applies the same machine-identity pattern to agent-to-agent collaboration. When you need agents to call each other inside a workflow, use [machine scopes](/docs/guides/development/machine-auth/overview) to keep the boundaries between them explicit. This page shows how to use M2M authentication for cross-agent communication.
 
-## When to use machines with agents
+## When to use M2M for agents
 
 Represent each agent as a Clerk machine when you want any of the following:
 
-- A first-class identity per agent in Clerk, managed alongside your users and organizations.
 - A controlled list of which agents are allowed to communicate and the ability to manage those rules at runtime.
 - Short-lived, scoped tokens for cross-agent calls instead of shared long-lived secrets.
 - A clear failure signal when an unauthorized agent tries to invoke another.
@@ -19,7 +18,7 @@ If none of these apply, skip machines and let your agents call each other direct
 
 ## Setup agent machines
 
-For this guide, wire up two agents: a `parent-agent` that delegates work, and a `research-agent` (subagent) that performs the work. Create both machines and scope `parent-agent` to invoke `research-agent`. To configure an individual machine's model, tools, or role through token claims, see [Agents](/docs/guides/ai/vercel-ai-sdk/agents).
+For this guide, wire up two agents: a `research-agent` that delegates work, and a `summarizer-agent` (subagent) that performs the work. Create both machines and scope `research-agent` to invoke `summarizer-agent`.
 
 You can do this in the [Clerk Dashboard](https://dashboard.clerk.com/~/machines/configure), from your coding agent or terminal with the [Clerk CLI](/docs/cli):
 
@@ -30,28 +29,28 @@ You can do this in the [Clerk Dashboard](https://dashboard.clerk.com/~/machines/
     Create the two machines:
 
     ```
-    Create two machines in my Clerk app named "parent-agent" and "research-agent".
+    Create two machines in my Clerk app named "research-agent" and "summarizer-agent".
     ```
 
     Then scope them:
 
     ```
-    Add "research-agent" to "parent-agent"'s scopes so parent-agent can invoke research-agent.
+    Add "summarizer-agent" to "research-agent"'s scopes so research-agent can invoke summarizer-agent.
     ```
   </Tab>
 
   <Tab>
-    Create `research-agent` first (its ID is needed to scope `parent-agent`):
+    Create `summarizer-agent` first (its ID is needed to scope `research-agent`):
 
     ```bash {{ filename: 'terminal', prompt: '$' }}
-    clerk api /machines -d '{"name":"research-agent"}' --yes
+    clerk api /machines -d '{"name":"summarizer-agent"}' --yes
     ```
 
-    Then create `parent-agent` with `research-agent` in its scopes:
+    Then create `research-agent` with `summarizer-agent` in its scopes:
 
     ```bash {{ filename: 'terminal', prompt: '$' }}
     clerk api /machines \
-      -d '{"name":"parent-agent","scoped_machines":["<research_machine_id>"]}' \
+      -d '{"name":"research-agent","scoped_machines":["<summarizer_machine_id>"]}' \
       --yes
     ```
   </Tab>
@@ -62,10 +61,10 @@ You can do this in the [Clerk Dashboard](https://dashboard.clerk.com/~/machines/
 
     const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY! })
 
-    const research = await clerk.machines.create({ name: 'research-agent' })
-    const parent = await clerk.machines.create({
-      name: 'parent-agent',
-      scopedMachines: [research.id],
+    const summarizer = await clerk.machines.create({ name: 'summarizer-agent' })
+    const research = await clerk.machines.create({
+      name: 'research-agent',
+      scopedMachines: [summarizer.id],
     })
     ```
   </Tab>
@@ -74,19 +73,19 @@ You can do this in the [Clerk Dashboard](https://dashboard.clerk.com/~/machines/
 Then add each machine's Secret Key to the environment where your workflow runs:
 
 ```env {{ filename: '.env' }}
-PARENT_AGENT_MACHINE_SECRET_KEY=ak_...
 RESEARCH_AGENT_MACHINE_SECRET_KEY=ak_...
+SUMMARIZER_AGENT_MACHINE_SECRET_KEY=ak_...
 ```
 
 See [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens) for the full configuration reference.
 
 ## Run a subagent with M2M auth
 
-The parent mints a token with its machine secret. The tool verifies that token against the subagent's machine secret before invoking the [subagent](https://ai-sdk.dev/v7/docs/agents/subagents).
+The research agent mints a token with its machine secret. The tool verifies that token against the summarizer's machine secret before invoking the [subagent](https://ai-sdk.dev/v7/docs/agents/subagents).
 
-`research-agent` accepts tokens from `parent-agent` only because `research-agent` is in `parent-agent`'s scopes. Remove the scope, and the next token fails verification.
+`summarizer-agent` accepts tokens from `research-agent` only because `summarizer-agent` is in `research-agent`'s scopes. Remove the scope, and the next token fails verification.
 
-Set up a shared Clerk client module for the parent and the tool wrapper, then implement the tool and workflow files. The tool wrapper and the workflow file are version-specific:
+Set up a shared Clerk client module for the research agent and the tool wrapper, then implement the tool and workflow files. The tool wrapper and the workflow file are version-specific:
 
 <Tabs items={["AI SDK v6", "AI SDK v7"]}>
   <Tab>
@@ -97,12 +96,12 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
         ```ts {{ filename: 'lib/clerk.ts' }}
         import { createClerkClient } from '@clerk/nextjs/server'
 
-        export const parentClerk = createClerkClient({
-          machineSecretKey: process.env.PARENT_AGENT_MACHINE_SECRET_KEY!,
+        export const researchAgentClerk = createClerkClient({
+          machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
         })
 
-        export const subagentClerk = createClerkClient({
-          machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
+        export const summarizerAgentClerk = createClerkClient({
+          machineSecretKey: process.env.SUMMARIZER_AGENT_MACHINE_SECRET_KEY!,
         })
         ```
       </Tab>
@@ -111,14 +110,14 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
         ```ts {{ filename: 'lib/ai/tools.ts' }}
         import { generateText, tool } from 'ai'
         import { z } from 'zod'
-        import { subagentClerk } from '@/lib/clerk'
+        import { summarizerAgentClerk } from '@/lib/clerk'
 
-        export const researchTool = tool({
-          description: 'Delegate a research task to the research subagent.',
+        export const summarizeTool = tool({
+          description: 'Delegate a summarization task to the summarizer subagent.',
           inputSchema: z.object({ task: z.string() }),
           execute: async ({ task }, { experimental_context, abortSignal }) => {
             const { token } = experimental_context as { token: string }
-            await subagentClerk.m2m.verify({ token })
+            await summarizerAgentClerk.m2m.verify({ token })
 
             const result = await generateText({
               model: 'openai/gpt-5',
@@ -134,18 +133,18 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
       <Tab>
         ```ts {{ filename: 'workflows/research.ts' }}
         import { generateText, stepCountIs } from 'ai'
-        import { parentClerk } from '@/lib/clerk'
-        import { researchTool } from '@/lib/ai/tools'
+        import { researchAgentClerk } from '@/lib/clerk'
+        import { summarizeTool } from '@/lib/ai/tools'
 
-        // Inside the workflow step that runs the parent:
-        const { token } = await parentClerk.m2m.createToken({
+        // Inside the workflow step that runs the research agent:
+        const { token } = await researchAgentClerk.m2m.createToken({
           secondsUntilExpiration: 60 * 5,
         })
 
         const result = await generateText({
           model: 'openai/gpt-5',
-          prompt: 'Research the latest news on the topic.',
-          tools: { research: researchTool },
+          prompt: 'Research the latest news on the topic and summarize key findings.',
+          tools: { summarize: summarizeTool },
           experimental_context: { token },
           stopWhen: stepCountIs(10),
         })
@@ -162,12 +161,12 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
         ```ts {{ filename: 'lib/clerk.ts' }}
         import { createClerkClient } from '@clerk/nextjs/server'
 
-        export const parentClerk = createClerkClient({
-          machineSecretKey: process.env.PARENT_AGENT_MACHINE_SECRET_KEY!,
+        export const researchAgentClerk = createClerkClient({
+          machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
         })
 
-        export const subagentClerk = createClerkClient({
-          machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
+        export const summarizerAgentClerk = createClerkClient({
+          machineSecretKey: process.env.SUMMARIZER_AGENT_MACHINE_SECRET_KEY!,
         })
         ```
       </Tab>
@@ -176,15 +175,15 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
         ```ts {{ filename: 'lib/ai/tools.ts' }}
         import { ToolLoopAgent, tool } from 'ai'
         import { z } from 'zod'
-        import { subagentClerk } from '@/lib/clerk'
+        import { summarizerAgentClerk } from '@/lib/clerk'
 
-        export function createResearchTool<TAgent extends ToolLoopAgent>(subagent: TAgent) {
+        export function createSummarizerTool<TAgent extends ToolLoopAgent>(subagent: TAgent) {
           return tool({
-            description: 'Delegate a research task to the research subagent.',
+            description: 'Delegate a summarization task to the summarizer subagent.',
             inputSchema: z.object({ task: z.string() }),
             contextSchema: z.custom<{ token: string }>(),
             execute: async ({ task }, { context, abortSignal }) => {
-              await subagentClerk.m2m.verify({ token: context.token })
+              await summarizerAgentClerk.m2m.verify({ token: context.token })
 
               const result = await subagent.generate({
                 prompt: task,
@@ -200,29 +199,29 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
       <Tab>
         ```ts {{ filename: 'workflows/research.ts' }}
         import { ToolLoopAgent, stepCountIs } from 'ai'
-        import { parentClerk } from '@/lib/clerk'
-        import { createResearchTool } from '@/lib/ai/tools'
+        import { researchAgentClerk } from '@/lib/clerk'
+        import { createSummarizerTool } from '@/lib/ai/tools'
 
-        const researchSubagent = new ToolLoopAgent({
+        const summarizerSubagent = new ToolLoopAgent({
           model: 'openai/gpt-5',
-          instructions: 'You are a research agent. Summarize your findings.',
+          instructions: 'You are a summarization agent. Be concise.',
         })
 
-        const mainAgent = new ToolLoopAgent({
+        const researchAgent = new ToolLoopAgent({
           model: 'openai/gpt-5',
-          instructions: 'You delegate research tasks to specialized subagents.',
-          tools: { research: createResearchTool(researchSubagent) },
+          instructions: 'You orchestrate research by delegating summarization to specialized subagents.',
+          tools: { summarize: createSummarizerTool(summarizerSubagent) },
           stopWhen: stepCountIs(10),
         })
 
-        // Inside the workflow step that runs the parent:
-        const { token } = await parentClerk.m2m.createToken({
+        // Inside the workflow step that runs the research agent:
+        const { token } = await researchAgentClerk.m2m.createToken({
           secondsUntilExpiration: 60 * 5,
         })
 
-        const result = await mainAgent.generate({
-          prompt: 'Research the latest news on the topic.',
-          toolsContext: { research: { token } },
+        const result = await researchAgent.generate({
+          prompt: 'Research the latest news on the topic and summarize key findings.',
+          toolsContext: { summarize: { token } },
         })
         ```
       </Tab>
@@ -232,7 +231,7 @@ Set up a shared Clerk client module for the parent and the tool wrapper, then im
 
 ## Decouple agents at runtime
 
-Because each agent is a separate Clerk machine, you can revoke a parent's access to its subagent at any time without redeploying. Remove `research-agent` from `parent-agent`'s Scopes, and the next token the parent mints fails the subagent's `verify()` check.
+Because each agent is a separate Clerk machine, you can revoke the research agent's access to the summarizer at any time without redeploying. Remove `summarizer-agent` from `research-agent`'s Scopes, and the next token the research agent mints fails the summarizer's `verify()` check.
 
 You can manage scopes from the Clerk Dashboard or programmatically through the Clerk client using [`machines.createScope()`](/docs/reference/backend/machines/create-scope) or [`machines.deleteScope()`](/docs/reference/backend/machines/delete-scope).
 
@@ -247,7 +246,7 @@ The pattern above is applicable to most resumable workflow runners. Below are so
 
 ## Next steps
 
-- [Agents](/docs/guides/ai/vercel-ai-sdk/agents): configure each agent machine's model, tools, and role through M2M token claims.
+- [Agent configuration](/docs/guides/ai/vercel-ai-sdk/agents): configure each agent machine's model, tools, and role through M2M token claims.
 - [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens): full reference for configuring machines, scopes, and token claims.
 - [Token formats](/docs/guides/development/machine-auth/token-formats): when to choose JWT M2M tokens (verifiable without a network call) over opaque ones.
 - [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls): permission-gated tools inside a single agent's loop.

--- a/docs/guides/ai/vercel-ai-sdk/agent-orchestration.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/agent-orchestration.mdx
@@ -1,0 +1,253 @@
+---
+title: Agent orchestration
+description: Use Clerk machines to gate which agents can invoke which inside a resumable workflow.
+sdk: nextjs
+---
+
+When you need to orchestrate agents inside a workflow context, you can use Clerk [machines](/docs/guides/development/machine-auth/overview) to keep the boundaries between them explicit. This page shows how to use M2M authentication for cross-agent communication.
+
+## When to use machines with agents
+
+Represent each agent as a Clerk machine when you want any of the following:
+
+- A first-class identity per agent in Clerk, managed alongside your users and organizations.
+- A controlled list of which agents are allowed to communicate and the ability to manage those rules at runtime.
+- Short-lived, scoped tokens for cross-agent calls instead of shared long-lived secrets.
+- A clear failure signal when an unauthorized agent tries to invoke another.
+
+If none of these apply, skip machines and let your agents call each other directly.
+
+## Setup agent machines
+
+For this guide, wire up two agents: a `parent-agent` that delegates work, and a `research-agent` (subagent) that performs the work. Create both machines and scope `parent-agent` to invoke `research-agent`. To configure an individual machine's model, tools, or role through token claims, see [Agents](/docs/guides/ai/vercel-ai-sdk/agents).
+
+You can do this in the [Clerk Dashboard](https://dashboard.clerk.com/~/machines/configure), from your coding agent or terminal with the [Clerk CLI](/docs/cli):
+
+<Tabs items={["Agent Prompt", "Clerk CLI", "Backend API"]}>
+  <Tab>
+    Use these prompts with an agent when you have the [Clerk CLI](/docs/cli) installed.
+
+    Create the two machines:
+
+    ```
+    Create two machines in my Clerk app named "parent-agent" and "research-agent".
+    ```
+
+    Then scope them:
+
+    ```
+    Add "research-agent" to "parent-agent"'s scopes so parent-agent can invoke research-agent.
+    ```
+  </Tab>
+
+  <Tab>
+    Create `research-agent` first (its ID is needed to scope `parent-agent`):
+
+    ```bash {{ filename: 'terminal', prompt: '$' }}
+    clerk api /machines -d '{"name":"research-agent"}' --yes
+    ```
+
+    Then create `parent-agent` with `research-agent` in its scopes:
+
+    ```bash {{ filename: 'terminal', prompt: '$' }}
+    clerk api /machines \
+      -d '{"name":"parent-agent","scoped_machines":["<research_machine_id>"]}' \
+      --yes
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts
+    import { createClerkClient } from '@clerk/nextjs/server'
+
+    const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY! })
+
+    const research = await clerk.machines.create({ name: 'research-agent' })
+    const parent = await clerk.machines.create({
+      name: 'parent-agent',
+      scopedMachines: [research.id],
+    })
+    ```
+  </Tab>
+</Tabs>
+
+Then add each machine's Secret Key to the environment where your workflow runs:
+
+```env {{ filename: '.env' }}
+PARENT_AGENT_MACHINE_SECRET_KEY=ak_...
+RESEARCH_AGENT_MACHINE_SECRET_KEY=ak_...
+```
+
+See [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens) for the full configuration reference.
+
+## Run a subagent with M2M auth
+
+The parent mints a token with its machine secret. The tool verifies that token against the subagent's machine secret before invoking the [subagent](https://ai-sdk.dev/v7/docs/agents/subagents).
+
+`research-agent` accepts tokens from `parent-agent` only because `research-agent` is in `parent-agent`'s scopes. Remove the scope, and the next token fails verification.
+
+Set up a shared Clerk client module for the parent and the tool wrapper, then implement the tool and workflow files. The tool wrapper and the workflow file are version-specific:
+
+<Tabs items={["AI SDK v6", "AI SDK v7"]}>
+  <Tab>
+    In v6, the tool verifies the M2M token and runs the subagent inline via a nested [`generateText`](https://ai-sdk.dev/docs/ai-sdk-core/agents) call. Context flows through `experimental_context`.
+
+    <Tabs items={["lib/clerk.ts", "lib/ai/tools.ts", "workflows/research.ts"]}>
+      <Tab>
+        ```ts {{ filename: 'lib/clerk.ts' }}
+        import { createClerkClient } from '@clerk/nextjs/server'
+
+        export const parentClerk = createClerkClient({
+          machineSecretKey: process.env.PARENT_AGENT_MACHINE_SECRET_KEY!,
+        })
+
+        export const subagentClerk = createClerkClient({
+          machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
+        })
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'lib/ai/tools.ts' }}
+        import { generateText, tool } from 'ai'
+        import { z } from 'zod'
+        import { subagentClerk } from '@/lib/clerk'
+
+        export const researchTool = tool({
+          description: 'Delegate a research task to the research subagent.',
+          inputSchema: z.object({ task: z.string() }),
+          execute: async ({ task }, { experimental_context, abortSignal }) => {
+            const { token } = experimental_context as { token: string }
+            await subagentClerk.m2m.verify({ token })
+
+            const result = await generateText({
+              model: 'openai/gpt-5',
+              prompt: task,
+              abortSignal,
+            })
+            return result.text
+          },
+        })
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'workflows/research.ts' }}
+        import { generateText, stepCountIs } from 'ai'
+        import { parentClerk } from '@/lib/clerk'
+        import { researchTool } from '@/lib/ai/tools'
+
+        // Inside the workflow step that runs the parent:
+        const { token } = await parentClerk.m2m.createToken({
+          secondsUntilExpiration: 60 * 5,
+        })
+
+        const result = await generateText({
+          model: 'openai/gpt-5',
+          prompt: 'Research the latest news on the topic.',
+          tools: { research: researchTool },
+          experimental_context: { token },
+          stopWhen: stepCountIs(10),
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Tab>
+
+  <Tab>
+    In v7, the subagent is a `ToolLoopAgent`. The tool factory takes it and wraps the verify + delegate logic. Context flows through `toolsContext`.
+
+    <Tabs items={["lib/clerk.ts", "lib/ai/tools.ts", "workflows/research.ts"]}>
+      <Tab>
+        ```ts {{ filename: 'lib/clerk.ts' }}
+        import { createClerkClient } from '@clerk/nextjs/server'
+
+        export const parentClerk = createClerkClient({
+          machineSecretKey: process.env.PARENT_AGENT_MACHINE_SECRET_KEY!,
+        })
+
+        export const subagentClerk = createClerkClient({
+          machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
+        })
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'lib/ai/tools.ts' }}
+        import { ToolLoopAgent, tool } from 'ai'
+        import { z } from 'zod'
+        import { subagentClerk } from '@/lib/clerk'
+
+        export function createResearchTool<TAgent extends ToolLoopAgent>(subagent: TAgent) {
+          return tool({
+            description: 'Delegate a research task to the research subagent.',
+            inputSchema: z.object({ task: z.string() }),
+            contextSchema: z.custom<{ token: string }>(),
+            execute: async ({ task }, { context, abortSignal }) => {
+              await subagentClerk.m2m.verify({ token: context.token })
+
+              const result = await subagent.generate({
+                prompt: task,
+                abortSignal,
+              })
+              return result.text
+            },
+          })
+        }
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'workflows/research.ts' }}
+        import { ToolLoopAgent, stepCountIs } from 'ai'
+        import { parentClerk } from '@/lib/clerk'
+        import { createResearchTool } from '@/lib/ai/tools'
+
+        const researchSubagent = new ToolLoopAgent({
+          model: 'openai/gpt-5',
+          instructions: 'You are a research agent. Summarize your findings.',
+        })
+
+        const mainAgent = new ToolLoopAgent({
+          model: 'openai/gpt-5',
+          instructions: 'You delegate research tasks to specialized subagents.',
+          tools: { research: createResearchTool(researchSubagent) },
+          stopWhen: stepCountIs(10),
+        })
+
+        // Inside the workflow step that runs the parent:
+        const { token } = await parentClerk.m2m.createToken({
+          secondsUntilExpiration: 60 * 5,
+        })
+
+        const result = await mainAgent.generate({
+          prompt: 'Research the latest news on the topic.',
+          toolsContext: { research: { token } },
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Tab>
+</Tabs>
+
+## Decouple agents at runtime
+
+Because each agent is a separate Clerk machine, you can revoke a parent's access to its subagent at any time without redeploying. Remove `research-agent` from `parent-agent`'s Scopes, and the next token the parent mints fails the subagent's `verify()` check.
+
+You can manage scopes from the Clerk Dashboard or programmatically through the Clerk client using [`machines.createScope()`](/docs/reference/backend/machines/create-scope) or [`machines.deleteScope()`](/docs/reference/backend/machines/delete-scope).
+
+## Inside a workflow
+
+The pattern above is applicable to most resumable workflow runners. Below are some common providers:
+
+- [Vercel Workflow](https://vercel.com/docs/workflow)
+- [Upstash Workflow](https://upstash.com/docs/workflow)
+- [Inngest](https://www.inngest.com/docs/learn/inngest-functions)
+- [Cloudflare Workflows](https://developers.cloudflare.com/workflows/)
+
+## Next steps
+
+- [Agents](/docs/guides/ai/vercel-ai-sdk/agents): configure each agent machine's model, tools, and role through M2M token claims.
+- [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens): full reference for configuring machines, scopes, and token claims.
+- [Token formats](/docs/guides/development/machine-auth/token-formats): when to choose JWT M2M tokens (verifiable without a network call) over opaque ones.
+- [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls): permission-gated tools inside a single agent's loop.

--- a/docs/guides/ai/vercel-ai-sdk/agents.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/agents.mdx
@@ -1,24 +1,18 @@
 ---
-title: Agents
+title: Agent configuration
 description: Represent AI services as Clerk machines and configure them at runtime through M2M token claims.
 sdk: nextjs
 ---
 
-A Clerk machine is an identity for an AI service. In a real AI app, that service is often an agent, but the same pattern applies to a standalone tool or a runnable workflow. Clerk is the source of truth for identity and the allowed relationships between these services. Your backend is the source of truth for each service's configuration, projected onto each minted M2M token as `claims`.
+A Clerk machine is an identity for an AI service. In a real AI application, that service is often an agent, but the same pattern applies to a standalone tool or a runnable workflow. Use Clerk as the source of truth for identity and the allowed relationships between these services.
 
 ## What a machine can represent
 
-- **An agent**, for example a research agent that delegates to subagents.
-- **A standalone tool**, like a code-execution service or a vector-search service that other agents invoke.
-- **A runnable workflow**, a long-running batch job orchestrated by an upstream caller.
+- **An agent**, for example an orchestration agent that delegates to subagents.
+- **A standalone tool**, like a code-execution service or a memory layer that other agents interact with.
+- **A runnable workflow**, a long-running job involving multiple agents.
 
-The rest of this page uses an agent as the example. The pattern applies equally to the other shapes.
-
-## Separation of concerns
-
-- **Clerk owns**: identity ([`machines.create`](/docs/reference/backend/machines/create)), scopes and allowed relationships ([`machines.createScope`](/docs/reference/backend/machines/create-scope), [`machines.deleteScope`](/docs/reference/backend/machines/delete-scope)), token issuance, and verification.
-- **Your backend owns**: per-machine configuration (model, allowed tools, role, budgets). Clerk doesn't persist this for machines yet.
-- **The M2M token is the carrier**: the parent reads your backend's config, attaches it as `claims`, mints, and hands it off. The agent runtime verifies the token and reads the claims back.
+The following sections use agent as the example.
 
 ## Set up the agent machine
 
@@ -30,36 +24,75 @@ RESEARCH_AGENT_MACHINE_SECRET_KEY=ak_...
 
 ## Configure the agent through organization metadata
 
-Store a map from machine ID to model name on a Clerk organization's `publicMetadata`:
+Store an array of agent configurations on a Clerk organization's `publicMetadata`:
 
 ```ts
 // organization.publicMetadata
 {
-  agents: {
-    mch_research: 'openai/gpt-5',
-    mch_summarizer: 'openai/gpt-4o-mini',
-  },
+  agents: [
+    {
+      machineId: 'mch_research',
+      model: 'openai/gpt-5',
+      instructions: 'You are a research assistant. Cite sources.',
+    },
+    {
+      machineId: 'mch_summarizer',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'Summarize the input in three sentences.',
+    },
+  ],
 }
 ```
 
-Read it from the parent before minting:
+> [!WARNING]
+> Organization metadata is bounded (~8KB). In a real-world application, persist agent configurations in a more durable storage layer (your application database, a config service, etc.).
 
-```ts
-import { auth, clerkClient } from '@clerk/nextjs/server'
+Look up the matching entry and mint the token from a server action. The action takes the organization ID and machine ID as arguments, so it can be called from places that don't have a Clerk session (background jobs, workflow runners, internal cron):
 
-const { orgId } = await auth()
-const client = await clerkClient()
-const org = await client.organizations.getOrganization({ organizationId: orgId })
-const model = (org.publicMetadata.agents as Record<string, string>)[machineId]
+<Tabs items={["app/actions.ts", "lib/clerk.ts"]}>
+  <Tab>
+    ```ts {{ filename: 'app/actions.ts' }}
+    'use server'
 
-const { token } = await parentClerk.m2m.createToken({
-  claims: { model },
-  secondsUntilExpiration: 60 * 5,
-})
-```
+    import { clerkClient } from '@clerk/nextjs/server'
+    import { researchAgentClerk } from '@/lib/clerk'
 
-> [!NOTE]
-> Organization metadata is bounded (~8KB) and not indexed for queries. Fine for a handful of machines per org, with the upside that an admin can edit it from the Dashboard. For richer configs (allowed tools, role, budgets), reach for your application database. See [Beyond model](#beyond-model-richer-configs) below.
+    export type AgentConfig = {
+      machineId: string
+      model: string
+      instructions: string
+    }
+
+    export async function generateAgentTokenForOrg(
+      organizationId: string,
+      machineId: string,
+    ) {
+      const client = await clerkClient()
+      const org = await client.organizations.getOrganization({ organizationId })
+      const config = (org.publicMetadata.agents as AgentConfig[]).find(
+        (a) => a.machineId === machineId,
+      )
+
+      const { token } = await researchAgentClerk.m2m.createToken({
+        claims: { model: config.model, instructions: config.instructions },
+        secondsUntilExpiration: 60 * 5,
+      })
+
+      return token
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts {{ filename: 'lib/clerk.ts' }}
+    import { createClerkClient } from '@clerk/nextjs/server'
+
+    export const researchAgentClerk = createClerkClient({
+      machineSecretKey: process.env.RESEARCH_AGENT_MACHINE_SECRET_KEY!,
+    })
+    ```
+  </Tab>
+</Tabs>
 
 ## Read claims at the agent runtime
 
@@ -67,52 +100,19 @@ After verifying the M2M token, configure the agent from the claims:
 
 ```ts
 import { ToolLoopAgent } from 'ai'
+import type { AgentConfig } from '@/app/actions'
 
-const verified = await agentClerk.m2m.verify({ token: context.token })
-const { model } = verified.claims as { model: string }
+const verified = await researchAgentClerk.m2m.verify({ token: context.token })
+const { model, instructions } = verified.claims as AgentConfig
 
 const agent = new ToolLoopAgent({
   model,
-  instructions: 'You are a research assistant.',
+  instructions,
   tools: { /* ... */ },
 })
 ```
 
-Claims are arbitrary `Record<string, unknown>`. Clerk verifies the signature, not the shape. Parse defensively (with [zod](https://zod.dev) or similar) before passing to the agent runtime.
-
-## Update config without redeploying
-
-Edit the organization metadata from the Clerk Dashboard or via [`organizations.updateOrganization()`](/docs/reference/backend/organization/update-organization). The next token your backend mints carries the new model. The agent runtime picks it up on its next invocation, no restart required.
-
-## Beyond model: richer configs
-
-For richer per-machine configuration, use your application database as the source of truth. Keep a small `agent_configs` table keyed by `machineId`:
-
-```sql
-CREATE TABLE agent_configs (
-  machine_id TEXT PRIMARY KEY,
-  model TEXT NOT NULL,
-  allowed_tools TEXT[] NOT NULL,
-  role TEXT NOT NULL
-);
-```
-
-The mint step reads from the table instead of `publicMetadata`:
-
-```ts
-const config = await db.agentConfigs.findUnique({ where: { machineId } })
-
-const { token } = await parentClerk.m2m.createToken({
-  claims: {
-    model: config.model,
-    allowedTools: config.allowedTools,
-    role: config.role,
-  },
-  secondsUntilExpiration: 60 * 5,
-})
-```
-
-The claim shape grows, the verify-and-read pattern doesn't.
+Claims are arbitrary `Record<string, unknown>`. Parse defensively (with zod or similar) before passing to the agent runtime.
 
 ## Next steps
 

--- a/docs/guides/ai/vercel-ai-sdk/agents.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/agents.mdx
@@ -1,0 +1,121 @@
+---
+title: Agents
+description: Represent AI services as Clerk machines and configure them at runtime through M2M token claims.
+sdk: nextjs
+---
+
+A Clerk machine is an identity for an AI service. In a real AI app, that service is often an agent, but the same pattern applies to a standalone tool or a runnable workflow. Clerk is the source of truth for identity and the allowed relationships between these services. Your backend is the source of truth for each service's configuration, projected onto each minted M2M token as `claims`.
+
+## What a machine can represent
+
+- **An agent**, for example a research agent that delegates to subagents.
+- **A standalone tool**, like a code-execution service or a vector-search service that other agents invoke.
+- **A runnable workflow**, a long-running batch job orchestrated by an upstream caller.
+
+The rest of this page uses an agent as the example. The pattern applies equally to the other shapes.
+
+## Separation of concerns
+
+- **Clerk owns**: identity ([`machines.create`](/docs/reference/backend/machines/create)), scopes and allowed relationships ([`machines.createScope`](/docs/reference/backend/machines/create-scope), [`machines.deleteScope`](/docs/reference/backend/machines/delete-scope)), token issuance, and verification.
+- **Your backend owns**: per-machine configuration (model, allowed tools, role, budgets). Clerk doesn't persist this for machines yet.
+- **The M2M token is the carrier**: the parent reads your backend's config, attaches it as `claims`, mints, and hands it off. The agent runtime verifies the token and reads the claims back.
+
+## Set up the agent machine
+
+For this guide, create a single machine for a `research-agent` and add its Secret Key to your environment. The [Setup agent machines](/docs/guides/ai/vercel-ai-sdk/agent-orchestration#setup-agent-machines) section of the orchestration guide shows the Dashboard, CLI, and SDK options. The rest of this page assumes the machine ID is `mch_research`.
+
+```env {{ filename: '.env' }}
+RESEARCH_AGENT_MACHINE_SECRET_KEY=ak_...
+```
+
+## Configure the agent through organization metadata
+
+Store a map from machine ID to model name on a Clerk organization's `publicMetadata`:
+
+```ts
+// organization.publicMetadata
+{
+  agents: {
+    mch_research: 'openai/gpt-5',
+    mch_summarizer: 'openai/gpt-4o-mini',
+  },
+}
+```
+
+Read it from the parent before minting:
+
+```ts
+import { auth, clerkClient } from '@clerk/nextjs/server'
+
+const { orgId } = await auth()
+const client = await clerkClient()
+const org = await client.organizations.getOrganization({ organizationId: orgId })
+const model = (org.publicMetadata.agents as Record<string, string>)[machineId]
+
+const { token } = await parentClerk.m2m.createToken({
+  claims: { model },
+  secondsUntilExpiration: 60 * 5,
+})
+```
+
+> [!NOTE]
+> Organization metadata is bounded (~8KB) and not indexed for queries. Fine for a handful of machines per org, with the upside that an admin can edit it from the Dashboard. For richer configs (allowed tools, role, budgets), reach for your application database. See [Beyond model](#beyond-model-richer-configs) below.
+
+## Read claims at the agent runtime
+
+After verifying the M2M token, configure the agent from the claims:
+
+```ts
+import { ToolLoopAgent } from 'ai'
+
+const verified = await agentClerk.m2m.verify({ token: context.token })
+const { model } = verified.claims as { model: string }
+
+const agent = new ToolLoopAgent({
+  model,
+  instructions: 'You are a research assistant.',
+  tools: { /* ... */ },
+})
+```
+
+Claims are arbitrary `Record<string, unknown>`. Clerk verifies the signature, not the shape. Parse defensively (with [zod](https://zod.dev) or similar) before passing to the agent runtime.
+
+## Update config without redeploying
+
+Edit the organization metadata from the Clerk Dashboard or via [`organizations.updateOrganization()`](/docs/reference/backend/organization/update-organization). The next token your backend mints carries the new model. The agent runtime picks it up on its next invocation, no restart required.
+
+## Beyond model: richer configs
+
+For richer per-machine configuration, use your application database as the source of truth. Keep a small `agent_configs` table keyed by `machineId`:
+
+```sql
+CREATE TABLE agent_configs (
+  machine_id TEXT PRIMARY KEY,
+  model TEXT NOT NULL,
+  allowed_tools TEXT[] NOT NULL,
+  role TEXT NOT NULL
+);
+```
+
+The mint step reads from the table instead of `publicMetadata`:
+
+```ts
+const config = await db.agentConfigs.findUnique({ where: { machineId } })
+
+const { token } = await parentClerk.m2m.createToken({
+  claims: {
+    model: config.model,
+    allowedTools: config.allowedTools,
+    role: config.role,
+  },
+  secondsUntilExpiration: 60 * 5,
+})
+```
+
+The claim shape grows, the verify-and-read pattern doesn't.
+
+## Next steps
+
+- [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls): gate which tools the agent can use per call, including v7's `toolApproval`.
+- [Agent orchestration](/docs/guides/ai/vercel-ai-sdk/agent-orchestration): verify-and-delegate between machines in a resumable workflow.
+- [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens): full reference for claims and token lifecycle.

--- a/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls.mdx
@@ -1,0 +1,300 @@
+---
+title: Authorizing tool calls
+description: Authorize every tool the model can invoke against the signed-in user's Clerk permissions.
+sdk: nextjs
+---
+
+<TutorialHero
+  beforeYouStart={[
+    {
+      title: "Get started with Clerk and the Vercel AI SDK",
+      link: "/docs/guides/ai/vercel-ai-sdk/getting-started",
+      icon: "nextjs",
+    },
+  ]}
+/>
+
+For tool-calling, authentication isn't always enough. Sometimes you need to restrict tool invocations from unauthorized callers. This page covers authorization patterns for tool-calling.
+
+## Restrict tool usage with `has`
+
+Use [`has()`](/docs/guides/secure/authorization-checks) to check whether the caller has a given [permission](/docs/guides/organizations/control-access/roles-and-permissions), [plan](/docs/guides/billing/overview), or [feature](/docs/guides/secure/features). Share the helper with your tools via the AI SDK's tool context, then check it inside `execute` and return a helpful message for the model when the caller doesn't have access.
+
+<Tabs items={["Permission", "Plan", "Feature Flag"]}>
+  <Tab>
+    <Tabs items={["AI SDK v6", "AI SDK v7"]}>
+      <Tab>
+        ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+        import type { auth } from '@clerk/nextjs/server'
+        import { tool } from 'ai'
+        import { z } from 'zod'
+
+        type Auth = Awaited<ReturnType<typeof auth>>
+
+        const archiveProject = tool({
+          description: 'Archive a project in the current workspace.',
+          inputSchema: z.object({ projectId: z.string() }),
+          execute: async ({ projectId }, { experimental_context }) => {
+            const { has } = experimental_context as Pick<Auth, 'has'>
+
+            if (!has({ permission: 'org:project:archive' })) {
+              return { error: 'Not authorized to archive projects.' }
+            }
+
+            // Perform the archive in your data layer.
+            return { ok: true, projectId }
+          },
+        })
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+        import type { auth } from '@clerk/nextjs/server'
+        import { tool } from 'ai'
+        import { z } from 'zod'
+
+        type Auth = Awaited<ReturnType<typeof auth>>
+
+        const archiveProject = tool({
+          description: 'Archive a project in the current workspace.',
+          inputSchema: z.object({ projectId: z.string() }),
+          contextSchema: z.custom<{ has: Auth['has'] }>(),
+          execute: async ({ projectId }, { context }) => {
+            if (!context.has({ permission: 'org:project:archive' })) {
+              return { error: 'Not authorized to archive projects.' }
+            }
+
+            // Perform the archive in your data layer.
+            return { ok: true, projectId }
+          },
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Tab>
+
+  <Tab>
+    <Tabs items={["AI SDK v6", "AI SDK v7"]}>
+      <Tab>
+        ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+        import type { auth } from '@clerk/nextjs/server'
+        import { tool } from 'ai'
+        import { z } from 'zod'
+
+        type Auth = Awaited<ReturnType<typeof auth>>
+
+        const generateReport = tool({
+          description: 'Generate a detailed report on a topic.',
+          inputSchema: z.object({ topic: z.string() }),
+          execute: async ({ topic }, { experimental_context }) => {
+            const { has } = experimental_context as Pick<Auth, 'has'>
+
+            if (!has({ plan: 'pro' })) {
+              return { error: 'This tool requires an active subscription to the Pro plan. Direct the user to upgrade on the billing page.' }
+            }
+
+            // Generate the report in your data layer.
+            return { ok: true, topic }
+          },
+        })
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+        import type { auth } from '@clerk/nextjs/server'
+        import { tool } from 'ai'
+        import { z } from 'zod'
+
+        type Auth = Awaited<ReturnType<typeof auth>>
+
+        const generateReport = tool({
+          description: 'Generate a detailed report on a topic.',
+          inputSchema: z.object({ topic: z.string() }),
+          contextSchema: z.custom<{ has: Auth['has'] }>(),
+          execute: async ({ topic }, { context }) => {
+            if (!context.has({ plan: 'pro' })) {
+              return { error: 'This tool requires an active subscription to the Pro plan. Direct the user to upgrade on the billing page.' }
+            }
+
+            // Generate the report in your data layer.
+            return { ok: true, topic }
+          },
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Tab>
+
+  <Tab>
+    <Tabs items={["AI SDK v6", "AI SDK v7"]}>
+      <Tab>
+        ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+        import type { auth } from '@clerk/nextjs/server'
+        import { tool } from 'ai'
+        import { z } from 'zod'
+
+        type Auth = Awaited<ReturnType<typeof auth>>
+
+        const generateReport = tool({
+          description: 'Generate a detailed report on a topic.',
+          inputSchema: z.object({ topic: z.string() }),
+          execute: async ({ topic }, { experimental_context }) => {
+            const { has } = experimental_context as Pick<Auth, 'has'>
+
+            if (!has({ feature: 'reports' })) {
+              return { error: "Inform the user that they don't have access to the reports feature but can opt in by emailing support@acme.com." }
+            }
+
+            // Generate the report in your data layer.
+            return { ok: true, topic }
+          },
+        })
+        ```
+      </Tab>
+
+      <Tab>
+        ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+        import type { auth } from '@clerk/nextjs/server'
+        import { tool } from 'ai'
+        import { z } from 'zod'
+
+        type Auth = Awaited<ReturnType<typeof auth>>
+
+        const generateReport = tool({
+          description: 'Generate a detailed report on a topic.',
+          inputSchema: z.object({ topic: z.string() }),
+          contextSchema: z.custom<{ has: Auth['has'] }>(),
+          execute: async ({ topic }, { context }) => {
+            if (!context.has({ feature: 'reports' })) {
+              return { error: "Inform the user that they don't have access to the reports feature but can opt in by emailing support@acme.com." }
+            }
+
+            // Generate the report in your data layer.
+            return { ok: true, topic }
+          },
+        })
+        ```
+      </Tab>
+    </Tabs>
+  </Tab>
+</Tabs>
+
+## Add the tools to your route handler
+
+First, check if the user is authenticated with [`auth()`](/docs/reference/nextjs/app-router/auth). 
+Then, pass `has` and `userId` to your tools through `experimental_context` or `toolsContext` (depending on the AI SDK version).
+
+<Tabs items={["AI SDK v6", "AI SDK v7"]}>
+  <Tab>
+    ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+    import { auth } from '@clerk/nextjs/server'
+    import {
+      convertToModelMessages,
+      stepCountIs,
+      streamText,
+      type UIMessage,
+    } from 'ai'
+    import { archiveProject, generateReport } from './tools'
+    import { NextResponse } from 'next/server'
+
+    export async function POST(req: Request) {
+
+      const { has, userId, isAuthenticated } = await auth()
+
+      if (!isAuthenticated) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      const result = streamText({
+        model: 'openai/gpt-5',
+        messages: await convertToModelMessages(messages),
+        tools: {
+          generateReport,
+          archiveProject,
+        },
+        experimental_context: { has, userId },
+        stopWhen: stepCountIs(3),
+      })
+
+      return result.toUIMessageStreamResponse()
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts {{ filename: 'app/api/chat/tools/route.ts' }}
+    import { auth } from '@clerk/nextjs/server'
+    import {
+      convertToModelMessages,
+      stepCountIs,
+      streamText,
+      type UIMessage,
+    } from 'ai'
+    import { archiveProject, generateReport } from './tools'
+    import { NextResponse } from 'next/server'
+
+    export async function POST(req: Request) {
+
+      const { has, userId, isAuthenticated } = await auth()
+
+      if (!isAuthenticated) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      const result = streamText({
+        model: 'openai/gpt-5',
+        messages: await convertToModelMessages(messages),
+        tools: {
+          generateReport,
+          archiveProject,
+        },
+        toolsContext: {
+          archiveProject: { has, userId },
+        },
+        stopWhen: stepCountIs(3),
+      })
+
+      return result.toUIMessageStreamResponse()
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Combining auth strategies
+
+Route guards and tool guards can be used together. Gating at the route level keeps unauthenticated callers from reaching the model and consuming tokens. Performing stricter checks inside tools keeps callers from triggering work they shouldn't run. See [Securing chat endpoints](/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints) for route-level options.
+
+## Tool approvals
+
+AI SDK v7 introduces `toolApproval`, a per-tool callback that decides whether each call gets approved, denied, or escalated to a human, based on the parsed tool input and runtime context. It runs before `execute`, so you can combine Clerk's `has()` with input thresholds without invoking the tool's side effect.
+
+```ts
+const transferFunds = tool({
+  description: 'Move funds between accounts.',
+  inputSchema: z.object({ amount: z.number(), recipient: z.string() }),
+  contextSchema: z.custom<{ has: Auth['has'] }>(),
+  execute: async ({ amount, recipient }) => {
+    // perform the transfer
+    return { ok: true, amount, recipient }
+  },
+  toolApproval: async ({ amount }, { runtimeContext }) => {
+    const { has } = runtimeContext as { has: Auth['has'] }
+    if (!has({ permission: 'finance:transfer' })) return 'denied'
+    if (amount > 10_000) return 'user-approval'
+    return 'approved'
+  },
+})
+```
+
+See the AI SDK [`toolApproval` reference](https://ai-sdk.dev/v7/docs/agents/tool-approvals#decide-based-on-tool-input) for the full approval flow.
+
+On AI SDK v6, you can approximate this by inspecting tool input inside `execute` and returning a structured error the model surfaces to the user. The key limitation: v6 can't pause the loop for human confirmation, so there's no equivalent of v7's `'user-approval'` return. For the v6 inline pattern, see the AI SDK [tools and tool-calling reference](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling).
+
+## Next steps
+
+- [Securing chat endpoints](/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints): role-based permissions, plan and feature gating.
+- [Agents](/docs/guides/ai/vercel-ai-sdk/agents): configure each agent machine's model, tools, and role through M2M token claims.
+- [Agent orchestration](/docs/guides/ai/vercel-ai-sdk/agent-orchestration): run long-lived agents in resumable workflows with a Clerk machine identity.
+- [Roles and permissions](/docs/guides/organizations/control-access/roles-and-permissions): full reference for Clerk's role and permission model.

--- a/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls.mdx
@@ -295,6 +295,6 @@ On AI SDK v6, you can approximate this by inspecting tool input inside `execute`
 ## Next steps
 
 - [Securing chat endpoints](/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints): role-based permissions, plan and feature gating.
-- [Agents](/docs/guides/ai/vercel-ai-sdk/agents): configure each agent machine's model, tools, and role through M2M token claims.
+- [Agent configuration](/docs/guides/ai/vercel-ai-sdk/agents): configure each agent machine's model, tools, and role through M2M token claims.
 - [Agent orchestration](/docs/guides/ai/vercel-ai-sdk/agent-orchestration): run long-lived agents in resumable workflows with a Clerk machine identity.
 - [Roles and permissions](/docs/guides/organizations/control-access/roles-and-permissions): full reference for Clerk's role and permission model.

--- a/docs/guides/ai/vercel-ai-sdk/enriching-prompts-and-runtime-context.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/enriching-prompts-and-runtime-context.mdx
@@ -153,4 +153,6 @@ Pass M2M tokens, API keys, permission helpers, or request IDs to your tools with
 
 ## Next steps
 
+- [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls): permission-gate individual tool calls with Clerk's `has()` helper.
+- [Agent orchestration](/docs/guides/ai/vercel-ai-sdk/agent-orchestration): pass M2M tokens through context across nested subagents.
 - [Runtime and tool context (Vercel AI SDK)](https://ai-sdk.dev/v7/docs/ai-sdk-core/runtime-and-tool-context): canonical reference for v7's context model.

--- a/docs/guides/ai/vercel-ai-sdk/getting-started.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/getting-started.mdx
@@ -107,5 +107,7 @@ This guide shows how to combine Clerk authentication with the [Vercel AI SDK](ht
 ## Next steps
 
 - [Securing chat endpoints](/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints): role-based permissions, plan and feature gating.
+- [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls): authorize each tool the model can invoke against the user's permissions.
 - [Enriching prompts and runtime context](/docs/guides/ai/vercel-ai-sdk/enriching-prompts-and-runtime-context): inject Clerk user, organization, and runtime data into prompts and tool context.
+- [Agent orchestration](/docs/guides/ai/vercel-ai-sdk/agent-orchestration): run long-lived agents in resumable workflows with a Clerk machine identity.
 - [Vercel AI SDK documentation](https://ai-sdk.dev/docs): full reference for streaming, tools, providers, and the `useChat` hook.

--- a/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints.mdx
+++ b/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints.mdx
@@ -153,6 +153,8 @@ To restrict endpoints to users with specific features or billing plans, create t
   </Tab>
 </Tabs>
 
+For finer-grained checks inside individual AI SDK tools, see [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls).
+
 ## Machine token authentication
 
 If your goal is to authenticate requests that don't come from human users (CLIs, agents, servers, etc.), set up your endpoint to support [machine tokens](/docs/guides/development/machine-auth/overview). Simply swap `auth.protect()` for `auth({ acceptsToken })` and specify which token type the route should accept.
@@ -254,6 +256,8 @@ if (!isAuthenticated) {
 }
 ```
 
+For an inter-agent M2M example, see [Agent orchestration](/docs/guides/ai/vercel-ai-sdk/agent-orchestration).
+
 ### Multi-token
 
 The same route can accept several token types at once. Branch on `tokenType` when the application logic differs by caller (for example, scope checks on an API key vs. permission checks on a session).
@@ -277,5 +281,6 @@ if (tokenType === 'api_key') {
 
 ## Next steps
 
+- [Authorizing tool calls](/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls): authorize each tool the model can invoke against the user's permissions.
 - [Roles and permissions](/docs/guides/organizations/control-access/roles-and-permissions): full reference for Clerk's role and permission model.
 - [Clerk Billing](/docs/guides/billing/overview): set up plans and features that the `has()` helper can check against.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1240,7 +1240,7 @@
                           "href": "/docs/guides/ai/vercel-ai-sdk/enriching-prompts-and-runtime-context"
                         },
                         {
-                          "title": "Agents",
+                          "title": "Agent configuration",
                           "href": "/docs/guides/ai/vercel-ai-sdk/agents"
                         },
                         {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1232,8 +1232,20 @@
                           "href": "/docs/guides/ai/vercel-ai-sdk/securing-chat-endpoints"
                         },
                         {
+                          "title": "Authorizing tool calls",
+                          "href": "/docs/guides/ai/vercel-ai-sdk/authorizing-tool-calls"
+                        },
+                        {
                           "title": "Enriching prompts and runtime context",
                           "href": "/docs/guides/ai/vercel-ai-sdk/enriching-prompts-and-runtime-context"
+                        },
+                        {
+                          "title": "Agents",
+                          "href": "/docs/guides/ai/vercel-ai-sdk/agents"
+                        },
+                        {
+                          "title": "Agent orchestration",
+                          "href": "/docs/guides/ai/vercel-ai-sdk/agent-orchestration"
                         }
                       ]
                     ]


### PR DESCRIPTION
## Summary

Companion PR to draft #3415 (Clerk x Vercel AI SDK patterns) 
Extends the foundational concepts with added patterns for advanced usage.

**Authorizing tool calls**: Covers gating individual tool invocations by Clerk permissions, plans, or features. It also introduces authorization patterns with the new tool-approval mechanism arriving in AI SDK v7.

**Agents**: Introduces a new conceptual framing: Clerk machines as agent identities. It opens the question of extending machine identity to carry first-class agent metadata of its own. For simplicity, the page shows agent configuration persisted on `organization_metadata` and projected onto each `M2M token` claims at mint time.

**Agent orchestration**: Using M2M auth to verify-and-delegate between a parent agent and a subagent inside a resumable workflow.

## Status

Draft. Same caveats as #3415, waiting for initial feedback before polishing or further testing.

### Preview

https://clerk.com/docs/pr/nicolas-guides-ai-vercel-ai-sdk-advanced/guides/ai/vercel-ai-sdk/getting-started

## Test plan

- [x] `pnpm run build:tsx` clean
- [ ] Snippet validation in local playground app
- [ ] Companion repo wired up
