### PR TITLE
[Draft] Restructure: seat-based plans doc

### DIFF
--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -11,6 +11,7 @@ For example, you might offer a Plan with a $20 monthly base fee and a $5 monthly
 ## Creating a Plan with per-seat pricing
 
 To create a Plan with per-seat pricing:
+
 1. Navigate to the [**New Organization plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page in the Clerk Dashboard.
 1. Toggle on the **Seat-based** section.
 1. If you'd like to set a limit, select **Custom limit** and enter the desired value. (You need the B2B Authentication add-on to set a limit greater than 20.)
@@ -22,6 +23,7 @@ To create a Plan with per-seat pricing:
 ## SDK version requirements
 
 To use seat-based, you need to be using the following Clerk SDK versions:
+
 - TODO
 
 ## How per-seat pricing works
@@ -40,6 +42,7 @@ Additional seats are added to the existing subscription and are prorated based o
 
 Organizations can invite members up to their purchased seat entitlement.
 Once all seats are occupied, additional invitations will be blocked until:
+
 - Additional seats are purchased
 - Existing members are removed from the organization
 - Pending invitations are revoked

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -17,8 +17,8 @@ To create a Plan with per-seat pricing:
 1. If you'd like to set a limit, select **Custom limit** and enter the desired value. (You need the B2B Authentication add-on to set a limit greater than 20.)
 1. If you'd like the Plan to allow an unlimited number of seats, select **Unlimited members**. (You need to have the B2B Authentication add-on to select this option.)
 1. Toggle on the **Per-seat fee** section.
-1. Enter the price per seat in the **Cost per member seat monthly** section. 
-1. If you'd like to include seats in the plan, enter the desired value in the **Included seats** section. 
+1. Enter the price per seat in the **Cost per member seat monthly** section.
+1. If you'd like to include seats in the plan, enter the desired value in the **Included seats** section.
 
 ## How per-seat pricing works
 

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -9,12 +9,14 @@ Per-seat pricing can be configured directly on Clerk Billing Plans, allowing org
 
 A Plan can combine a **base recurring fee** with a **per-seat fee**, and you can configure **included (free) seats** and **seat limits** to support more advanced pricing models.
 
-For example, a Plan with a **$20 monthly base fee** and a **$5 monthly charge per member** would bill as follows:
+For example:
 
-| Organization size | Base fee | Per-seat fee | Monthly total |
-| - | - | - | - |
-| 3 members | $20 | $15 (3 × $5) | **$35** |
-| 10 members | $20 | $50 (10 × $5) | **$70** |
+| Pricing concept | Plan configuration | Example (org size → monthly total) |
+| - | - | - |
+| Base fee + per-seat | $20 base + $5/member | 10 members → $20 + $50 = **$70** |
+| Included (free) seats | $25 base, includes 1 seat, then $10/additional seat | 4 members → $25 + (3 × $10) = **$55** |
+| No base fee | $8/member, no base fee | 10 members → **$80** |
+| Per-seat with a seat limit | $5/member, 10-seat limit | 10 members (at limit) → **$50** |
 
 ## Creating a Plan with per-seat pricing
 

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -21,7 +21,7 @@ To create a Plan with per-seat pricing:
 
 ## SDK version requirements
 
-To use seat limits, you need to be using the following Clerk SDK versions:
+To use seat-based, you need to be using the following Clerk SDK versions:
 - TODO
 
 ## How per-seat pricing works

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -29,11 +29,8 @@ Plans may also include free seat tiers. For example, a plan may include the firs
 ## Purchasing seats
 
 When an organization subscribes to a per-seat plan, they purchase an initial seat entitlement during checkout.
-
 The number of seats purchased must be greater than or equal to the number of members currently in the organization.
-
 Organizations can purchase additional seats at any time while their subscription is active.
-
 Additional seats are added to the existing subscription and are prorated based on the remaining time in the current billing period.
 
 ## Seat entitlement and organization membership
@@ -54,8 +51,7 @@ This means that seats that were purchased but never occupied during the previous
 
 ## Seat limits and per-seat pricing
 
-### Per-seat pricing and seat limits can be used independently or together.
-
+Per-seat pricing and seat limits can be used independently or together.
 Per-seat pricing determines how much an organization is charged.
 Seat limits determine the maximum number of seats an organization may purchase.
 

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -5,62 +5,84 @@ description: Configure Plans that bill organizations based on purchased seats.
 
 <Include src="_partials/billing/billing-experimental" />
 
-Per-seat pricing can now be configured directly on Clerk Billing Plans, allowing organizations to pay based on the number of members using your application. This makes it possible to offer pricing that scales with organization size.
-For example, you might offer a Plan with a $20 monthly base fee and a $5 monthly charge per member. An organization with three members would pay $35 per month, while an organization with ten members would pay $70 per month. You can also configure included seats and seat limits to support more advanced pricing models.
+Per-seat pricing can be configured directly on Clerk Billing Plans, allowing organizations to pay based on the number of members using your application. This makes it possible to offer pricing that scales with organization size.
+
+A Plan can combine a **base recurring fee** with a **per-seat fee**, and you can configure **included (free) seats** and **seat limits** to support more advanced pricing models.
+
+For example, a Plan with a **$20 monthly base fee** and a **$5 monthly charge per member** would bill as follows:
+
+| Organization size | Base fee | Per-seat fee | Monthly total |
+| - | - | - | - |
+| 3 members | $20 | $15 (3 × $5) | **$35** |
+| 10 members | $20 | $50 (10 × $5) | **$70** |
 
 ## Creating a Plan with per-seat pricing
 
-To create a Plan with per-seat pricing:
+<Steps>
+  ## Open the new Plan page
 
-1. Navigate to the [**New Organization plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page in the Clerk Dashboard.
-1. Toggle on the **Seat-based** section.
-1. If you'd like to set a limit, select **Custom limit** and enter the desired value. (You need the B2B Authentication add-on to set a limit greater than 20.)
-1. If you'd like the Plan to allow an unlimited number of seats, select **Unlimited members**. (You need to have the B2B Authentication add-on to select this option.)
-1. Toggle on the **Per-seat fee** section.
-1. Enter the price per seat in the **Cost per member seat monthly** section.
-1. If you'd like to include seats in the plan, enter the desired value in the **Included seats** section.
+  Navigate to the [**New Organization plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page in the Clerk Dashboard.
+
+  ## Configure seats
+
+  Toggle on the **Seat-based** section, then choose how many seats the Plan allows:
+
+  - To cap the number of seats, select **Custom limit** and enter the desired value.
+  - To allow an unlimited number of seats, select **Unlimited members**.
+
+  ## Configure the per-seat fee
+
+  Toggle on the **Per-seat fee** section, then:
+
+  - Enter the price per seat in the **Cost per member seat monthly** section.
+  - To bundle free seats into the Plan, enter the desired value in the **Included seats** section.
+</Steps>
+
+> [!NOTE]
+> The [B2B Authentication add-on](/docs/guides/organizations/overview) is required to set a custom limit greater than 20 seats or to allow unlimited members.
 
 ## SDK version requirements
 
-To use seat-based, you need to be using the following Clerk SDK versions:
+To use seat-based pricing, you need to be using the following Clerk SDK versions:
 
 - TODO
 
 ## How per-seat pricing works
 
-When an organization subscribes to a plan with per-seat pricing, each provisioned seat contributes to the subscription cost according to the pricing tiers configured on the plan. Plans may also include a base recurring fee in addition to seat-based charges.
-There's also an option to include free seat tiers. For example, a plan may include the first five seats at no cost and charge only for additional seats.
+When an organization subscribes to a Plan with per-seat pricing, each provisioned seat contributes to the subscription cost according to the pricing tiers configured on the Plan. In addition to seat-based charges, a Plan can include:
+
+- A **base recurring fee** that applies regardless of seat count.
+- **Free seat tiers** — for example, a Plan may include the first five seats at no cost and charge only for additional seats.
 
 ### Purchasing seats
 
-When an organization subscribes to a per-seat plan, they purchase an initial seat entitlement during checkout.
-The number of seats purchased must be greater than or equal to the number of members currently in the organization.
-Organizations can purchase additional seats at any time while their subscription is active.
-Additional seats are added to the existing subscription and are prorated based on the remaining time in the current billing period.
+When an organization subscribes to a per-seat Plan, they purchase an initial seat entitlement during checkout:
 
-### Seat entitlement and organization membership
+- The number of seats purchased must be greater than or equal to the number of members currently in the organization.
+- Organizations can purchase additional seats at any time while their subscription is active.
+- Additional seats are added to the existing subscription and are prorated based on the remaining time in the current billing period.
+- If the Plan also has a seat limit configured, organizations cannot purchase more seats than the Plan's maximum allowed seat count.
 
-Organizations can invite members up to their purchased seat entitlement.
-Once all seats are occupied, additional invitations will be blocked until:
+### Inviting members
 
-- Additional seats are purchased
-- Existing members are removed from the organization
-- Pending invitations are revoked
+Organizations can invite members up to their purchased seat entitlement. This applies to all invitation flows, including standard invitations and SSO-based invitations.
 
-If a plan also has a seat limit configured, organizations cannot purchase more seats than the plan's maximum allowed seat count.
+Once all seats are occupied, new invitations are blocked until one of the following happens:
+
+- Additional seats are purchased.
+- Existing members are removed from the organization.
+- Pending invitations are revoked.
 
 ### Recurring billing
 
-At the beginning of each new billing period, the subscription's seat quantity is automatically adjusted to match the number of members currently in the organization.
-This means that seats that were purchased but never occupied during the previous billing period will not automatically renew. Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
+At the beginning of each new billing period, the subscription's seat quantity is automatically adjusted to match the number of members currently in the organization:
 
-### Seat limits and per-seat pricing
+- Seats that were purchased but never occupied during the previous billing period will not automatically renew.
+- Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
 
-Per-seat pricing and seat limits can be used independently or together.
-Per-seat pricing determines how much an organization is charged, while seat limits determine the maximum number of seats an organization may purchase.
+### Using per-seat pricing with seat limits
 
-### Organization invitations
+Per-seat pricing and seat limits can be used independently or together:
 
-Organizations subscribed to a per-seat Plan can invite members as long as an unused seat is available.
-If all purchased seats are occupied, new invitations will be blocked until additional seats are purchased.
-This behavior applies to all invitation flows, including standard invitations and SSO-based invitations.
+- **Per-seat pricing** determines how much an organization is charged.
+- **Seat limits** determine the maximum number of seats an organization may purchase.

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -1,0 +1,52 @@
+---
+title: Seat-based plans
+description: Configure Plans that bill organizations based on purchased seats.
+---
+
+<Include src="_partials/billing/billing-experimental" />
+
+Per-seat pricing can now be configured directly on Clerk Billing Plans, allowing organizations to pay based on the number of members using your application. This makes it possible to offer pricing that scales with organization size.
+For example, you might offer a Plan with a $20 monthly base fee and a $5 monthly charge per member. An organization with three members would pay $35 per month, while an organization with ten members would pay $70 per month. You can also configure included seats and seat limits to support more advanced pricing models.
+
+## Creating a Plan with per-seat pricing
+
+### Configuring seat pricing
+- TODO
+
+## How per-seat pricing works
+When an organization subscribes to a plan with per-seat pricing, each provisioned seat contributes to the subscription cost according to the pricing tiers configured on the plan. Plans may also include a base recurring fee in addition to seat-based charges.
+
+Plans may also include free seat tiers. For example, a plan may include the first five seats at no cost and charge only for additional seats.
+
+## Purchasing seats
+When an organization subscribes to a per-seat plan, they purchase an initial seat entitlement during checkout.
+
+The number of seats purchased must be greater than or equal to the number of members currently in the organization.
+
+Organizations can purchase additional seats at any time while their subscription is active.
+
+Additional seats are added to the existing subscription and are prorated based on the remaining time in the current billing period.
+
+## Seat entitlement and organization membership
+Organizations can invite members up to their purchased seat entitlement.
+Once all seats are occupied, additional invitations will be blocked until:
+- Additional seats are purchased
+- Existing members are removed from the organization
+- Pending invitations are revoked
+
+If a plan also has a seat limit configured, organizations cannot purchase more seats than the plan's maximum allowed seat count.
+
+## Recurring billing 
+At the beginning of each new billing period, the subscription's seat quantity is automatically adjusted to match the number of members currently in the organization.
+This means that seats that were purchased but never occupied during the previous billing period will not automatically renew. Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
+
+## Seat limits and per-seat pricing
+
+### Per-seat pricing and seat limits can be used independently or together.
+Per-seat pricing determines how much an organization is charged.
+Seat limits determine the maximum number of seats an organization may purchase.
+
+## Organization invitations
+Organizations subscribed to a per-seat Plan can invite members as long as an unused seat is available.
+If all purchased seats are occupied, new invitations will be blocked until additional seats are purchased.
+This behavior applies to all invitation flows, including standard invitations and SSO-based invitations.

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -11,7 +11,6 @@ For example, you might offer a Plan with a $20 monthly base fee and a $5 monthly
 ## Creating a Plan with per-seat pricing
 
 To create a Plan with per-seat pricing:
-
 1. Navigate to the [**New Organization plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page in the Clerk Dashboard.
 1. Toggle on the **Seat-based** section.
 1. If you'd like to set a limit, select **Custom limit** and enter the desired value. (You need the B2B Authentication add-on to set a limit greater than 20.)
@@ -20,42 +19,44 @@ To create a Plan with per-seat pricing:
 1. Enter the price per seat in the **Cost per member seat monthly** section.
 1. If you'd like to include seats in the plan, enter the desired value in the **Included seats** section.
 
+## SDK version requirements
+
+To use seat limits, you need to be using the following Clerk SDK versions:
+- TODO
+
 ## How per-seat pricing works
 
 When an organization subscribes to a plan with per-seat pricing, each provisioned seat contributes to the subscription cost according to the pricing tiers configured on the plan. Plans may also include a base recurring fee in addition to seat-based charges.
+There's also an option to include free seat tiers. For example, a plan may include the first five seats at no cost and charge only for additional seats.
 
-Plans may also include free seat tiers. For example, a plan may include the first five seats at no cost and charge only for additional seats.
-
-## Purchasing seats
+### Purchasing seats
 
 When an organization subscribes to a per-seat plan, they purchase an initial seat entitlement during checkout.
 The number of seats purchased must be greater than or equal to the number of members currently in the organization.
 Organizations can purchase additional seats at any time while their subscription is active.
 Additional seats are added to the existing subscription and are prorated based on the remaining time in the current billing period.
 
-## Seat entitlement and organization membership
+### Seat entitlement and organization membership
 
 Organizations can invite members up to their purchased seat entitlement.
 Once all seats are occupied, additional invitations will be blocked until:
-
 - Additional seats are purchased
 - Existing members are removed from the organization
 - Pending invitations are revoked
 
 If a plan also has a seat limit configured, organizations cannot purchase more seats than the plan's maximum allowed seat count.
 
-## Recurring billing
+### Recurring billing
 
 At the beginning of each new billing period, the subscription's seat quantity is automatically adjusted to match the number of members currently in the organization.
 This means that seats that were purchased but never occupied during the previous billing period will not automatically renew. Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
 
-## Seat limits and per-seat pricing
+### Seat limits and per-seat pricing
 
 Per-seat pricing and seat limits can be used independently or together.
-Per-seat pricing determines how much an organization is charged.
-Seat limits determine the maximum number of seats an organization may purchase.
+Per-seat pricing determines how much an organization is charged, while seat limits determine the maximum number of seats an organization may purchase.
 
-## Organization invitations
+### Organization invitations
 
 Organizations subscribed to a per-seat Plan can invite members as long as an unused seat is available.
 If all purchased seats are occupied, new invitations will be blocked until additional seats are purchased.

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -10,9 +10,15 @@ For example, you might offer a Plan with a $20 monthly base fee and a $5 monthly
 
 ## Creating a Plan with per-seat pricing
 
-### Configuring seat pricing
+To create a Plan with per-seat pricing:
 
-- TODO
+1. Navigate to the [**New Organization plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page in the Clerk Dashboard.
+1. Toggle on the **Seat-based** section.
+1. If you'd like to set a limit, select **Custom limit** and enter the desired value. (You need the B2B Authentication add-on to set a limit greater than 20.)
+1. If you'd like the Plan to allow an unlimited number of seats, select **Unlimited members**. (You need to have the B2B Authentication add-on to select this option.)
+1. Toggle on the **Per-seat fee** section.
+1. Enter the price per seat in the **Cost per member seat monthly** section. 
+1. If you'd like to include seats in the plan, enter the desired value in the **Included seats** section. 
 
 ## How per-seat pricing works
 

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -11,14 +11,17 @@ For example, you might offer a Plan with a $20 monthly base fee and a $5 monthly
 ## Creating a Plan with per-seat pricing
 
 ### Configuring seat pricing
+
 - TODO
 
 ## How per-seat pricing works
+
 When an organization subscribes to a plan with per-seat pricing, each provisioned seat contributes to the subscription cost according to the pricing tiers configured on the plan. Plans may also include a base recurring fee in addition to seat-based charges.
 
 Plans may also include free seat tiers. For example, a plan may include the first five seats at no cost and charge only for additional seats.
 
 ## Purchasing seats
+
 When an organization subscribes to a per-seat plan, they purchase an initial seat entitlement during checkout.
 
 The number of seats purchased must be greater than or equal to the number of members currently in the organization.
@@ -28,25 +31,30 @@ Organizations can purchase additional seats at any time while their subscription
 Additional seats are added to the existing subscription and are prorated based on the remaining time in the current billing period.
 
 ## Seat entitlement and organization membership
+
 Organizations can invite members up to their purchased seat entitlement.
 Once all seats are occupied, additional invitations will be blocked until:
+
 - Additional seats are purchased
 - Existing members are removed from the organization
 - Pending invitations are revoked
 
 If a plan also has a seat limit configured, organizations cannot purchase more seats than the plan's maximum allowed seat count.
 
-## Recurring billing 
+## Recurring billing
+
 At the beginning of each new billing period, the subscription's seat quantity is automatically adjusted to match the number of members currently in the organization.
 This means that seats that were purchased but never occupied during the previous billing period will not automatically renew. Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
 
 ## Seat limits and per-seat pricing
 
 ### Per-seat pricing and seat limits can be used independently or together.
+
 Per-seat pricing determines how much an organization is charged.
 Seat limits determine the maximum number of seats an organization may purchase.
 
 ## Organization invitations
+
 Organizations subscribed to a per-seat Plan can invite members as long as an unused seat is available.
 If all purchased seats are occupied, new invitations will be blocked until additional seats are purchased.
 This behavior applies to all invitation flows, including standard invitations and SSO-based invitations.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -570,6 +570,10 @@
                     "href": "/docs/guides/billing/seat-limit-plans"
                   },
                   {
+                    "title": "Seat-based Plans",
+                    "href": "/docs/guides/billing/seat-based-plans"
+                  },
+                  {
                     "title": "Default Plans",
                     "href": "/docs/guides/billing/default-plans"
                   },


### PR DESCRIPTION
Draft / preview only — do not merge.

Structural restructure of the seat-based billing plans doc from #3414, to compare how the information renders. Same content, reorganized for scannability:

- Pricing example moved into a comparison table
- Creation flow uses `<Steps>` with grouped sub-bullets; B2B add-on caveats lifted into a note callout
- Dense paragraphs broken into bullet lists
- Two overlapping invitation sections consolidated into 'Inviting members'

Companion to #3414 (authored by @l-armstrong). This is for visual comparison of structure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)