### PR TITLE
Update Android native view dismiss prop docs

### DIFF
--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -53,6 +53,8 @@ export default function SignInScreen() {
 
 ### Dismissible auth view
 
+The following example enables the native dismiss button with the `isDismissable` prop.
+
 ```tsx
 <AuthView isDismissable />
 ```

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -51,6 +51,12 @@ export default function SignInScreen() {
 <AuthView mode="signUp" />
 ```
 
+### Dismissible auth view
+
+```tsx
+<AuthView isDismissable />
+```
+
 ## Properties
 
 <Properties>

--- a/docs/reference/views/authentication/auth-view.mdx
+++ b/docs/reference/views/authentication/auth-view.mdx
@@ -45,7 +45,7 @@ By default, the `AuthView` will automatically determine whether to sign users in
     - `modifier`
     - `Modifier`
 
-    A modifier that gets applied to the `AuthView` composable. This is by default applied to the top level `NavDisplay` and shouldn't be used to change the appearance of the `AuthView` itself.
+    A modifier that gets applied to the top-level container of the `AuthView`. It shouldn't be used to change the appearance of the `AuthView` itself.
 
     ---
 
@@ -206,6 +206,8 @@ By default, the `AuthView` will automatically determine whether to sign users in
   ```
 
   ### Custom dismiss handling
+
+  Provide an `onDismiss` callback to handle dismissal yourself, such as to navigate away from the auth screen.
 
   ```kotlin
   import com.clerk.ui.auth.AuthView

--- a/docs/reference/views/authentication/auth-view.mdx
+++ b/docs/reference/views/authentication/auth-view.mdx
@@ -43,10 +43,72 @@ By default, the `AuthView` will automatically determine whether to sign users in
 <If sdk="android">
   <Properties>
     - `modifier`
-
     - `Modifier`
 
     A modifier that gets applied to the `AuthView` composable. This is by default applied to the top level `NavDisplay` and shouldn't be used to change the appearance of the `AuthView` itself.
+
+    ---
+
+    - `clerkTheme`
+    - `ClerkTheme?`
+
+    The theme to apply to the `AuthView`.
+
+    ---
+
+    - `initialIdentifier`
+    - `String?`
+
+    The initial value for the identifier field. Phone-like values are routed to the phone number field automatically.
+
+    ---
+
+    - `persistIdentifiers`
+    - `Boolean`
+
+    Whether stored auth-start identifiers should persist between auth attempts. Defaults to `true`.
+
+    ---
+
+    - `preferGoogleOneTap`
+    - `Boolean`
+
+    Whether Google social authentication uses native Google One Tap when it's configured. When `false`, Google social authentication always uses browser OAuth. Defaults to `true`.
+
+    ---
+
+    - `startSocialOAuthAsSignUp`
+    - `Boolean`
+
+    Whether browser OAuth social authentication starts from a sign-up attempt and transfers back to sign-in if the selected account already exists. Defaults to `false`.
+
+    ---
+
+    - `unsafeMetadata`
+    - `Map<String, Any>?`
+
+    Custom metadata to attach to users created by the prebuilt sign-up flow. This metadata isn't validated by Clerk and shouldn't contain sensitive information.
+
+    ---
+
+    - `isDismissible`
+    - `Boolean`
+
+    Whether the auth start screen shows a dismiss affordance. When `true`, the user can dismiss the view from the auth start screen. Defaults to `true`.
+
+    ---
+
+    - `onDismiss`
+    - `(() -> Unit)?`
+
+    Called when the user presses the dismiss affordance. When omitted, dismissal falls back to the system back dispatcher.
+
+    ---
+
+    - `onAuthComplete`
+    - `() -> Unit`
+
+    Called when authentication completes.
   </Properties>
 </If>
 
@@ -131,6 +193,29 @@ By default, the `AuthView` will automatically determine whether to sign users in
           }
       }
   }
+  ```
+
+  ### Non-dismissible auth
+
+  Use `isDismissible = false` when the auth flow is the required fullscreen experience for the current route.
+
+  ```kotlin
+  import com.clerk.ui.auth.AuthView
+
+  AuthView(isDismissible = false)
+  ```
+
+  ### Custom dismiss handling
+
+  ```kotlin
+  import com.clerk.ui.auth.AuthView
+
+  AuthView(
+      isDismissible = true,
+      onDismiss = {
+          // Navigate away from the auth screen.
+      },
+  )
   ```
 </If>
 

--- a/docs/reference/views/user/user-profile-view.mdx
+++ b/docs/reference/views/user/user-profile-view.mdx
@@ -31,16 +31,44 @@ The `UserProfileView` renders a comprehensive user profile interface that displa
 <If sdk="android">
   <Properties>
     - `clerkTheme`
-    - `ClerkTheme`
+    - `ClerkTheme?`
 
     The theme to apply to the `UserProfileView`. This will override any theme applied to the `UserProfileView`'s parent view, or configured in the `Clerk` global object.
 
     ---
 
-    - `onDismiss`
-    - `() -> Unit`
+    - `customRows`
+    - `List<UserProfileCustomRow>`
 
-    A callback function that is called when the user dismisses the view, such as when they tap a back button or close button. Use this callback to handle navigation or perform cleanup when the user closes the profile view, for example, navigating back to the previous screen or updating your app's state.
+    Custom rows to display on the profile account screen.
+
+    ---
+
+    - `customDestination`
+    - `(@Composable (String) -> Unit)?`
+
+    Destination builder for custom rows. The destination receives the tapped row's `routeKey`. Custom rows are ignored when this is `null`.
+
+    ---
+
+    - `onAddAccount`
+    - `(() -> Unit)?`
+
+    Called when the user selects the add account action. Use this to host the add account auth flow outside the profile view.
+
+    ---
+
+    - `onDismiss`
+    - `(() -> Unit)?`
+
+    Called when the user profile view is dismissed. When omitted, dismissal falls back to the system back dispatcher.
+
+    ---
+
+    - `isDismissible`
+    - `Boolean`
+
+    Whether the view shows a top-right close affordance that dismisses the profile. Defaults to `true`.
   </Properties>
 </If>
 
@@ -119,6 +147,14 @@ The `UserProfileView` renders a comprehensive user profile interface that displa
       UserProfileView()
     }
   }
+  ```
+
+  ### Non-dismissible profile view
+
+  ```kotlin
+  import com.clerk.ui.userprofile.UserProfileView
+
+  UserProfileView(isDismissible = false)
   ```
 </If>
 

--- a/docs/reference/views/user/user-profile-view.mdx
+++ b/docs/reference/views/user/user-profile-view.mdx
@@ -151,6 +151,8 @@ The `UserProfileView` renders a comprehensive user profile interface that displa
 
   ### Non-dismissible profile view
 
+  Use `isDismissible = false` when the profile view is the required fullscreen experience for the current route.
+
   ```kotlin
   import com.clerk.ui.userprofile.UserProfileView
 


### PR DESCRIPTION
## What changed

- Updates Android `AuthView` docs to include the current dismiss-related Kotlin parameters from `clerk/clerk-android#710`, including `isDismissible` and `onDismiss`.
- Updates Android `UserProfileView` docs for optional `onDismiss` and `isDismissible` behavior.
- Adds an Expo native `<AuthView />` usage example for `isDismissable`, alongside the existing `mode` examples.

## Notes

Current `main` no longer contains the standalone Organization view reference pages, so this clean branch does not reintroduce those deleted pages.

## Validation

- `pnpm run build:tsx`
- `pnpm run lint`
- `git diff --check origin/main...HEAD`