### PR TITLE
Update waitlist documentation

### DIFF
--- a/docs/guides/secure/restricting-access.mdx
+++ b/docs/guides/secure/restricting-access.mdx
@@ -49,6 +49,12 @@ Additional features available in **Restricted** mode:
 
 <Include src="_partials/waitlist/waitlist-explanation" />
 
+When a user joins the waitlist, they receive the **Waitlist confirmation** email acknowledging their request.
+
+Once [approved](#manage-users-on-your-waitlist), they receive the **Waitlist invitation** email with instructions on how to join your app. By default, this email includes an **Accept invitation** button that redirects them to your app's [Account Portal sign-up page](/docs/guides/account-portal/overview#sign-up), which hosts Clerk's `<SignUp />` component. What happens next depends on the settings configured in the Clerk Dashboard. If your app only requires an email address, the Account Portal creates the user's account and signs them in. If your app requires more information, the `<SignUp />` component collects that additional information before creating the account and signing the user in.
+
+You can [customize both waitlist emails](#customize-waitlist-emails) to match your brand.
+
 <Include src="_partials/waitlist/enable-waitlist-mode" />
 
 Additional features available in **Waitlist** mode:
@@ -57,19 +63,13 @@ Additional features available in **Waitlist** mode:
 
 - The [`<SignUp />`](/docs/reference/components/authentication/sign-up) is accessible only to users who have been invited and have a valid invitation link. Users who don't have access will see a message indicating that they need to join the waitlist to access your app.
 
-- The [`<Waitlist />`](/docs/reference/components/authentication/waitlist) component provides a form where users can submit their details to join the waitlist. Once [approved](#manage-users-on-your-waitlist), users will receive an email with instructions on how to join your app.
-
-- If you're using the `<Waitlist />` component, you must provide the `waitlistUrl` prop either in the [`<ClerkProvider>`](/docs/reference/components/clerk-provider#properties) or [`<SignIn />`](/docs/reference/components/authentication/sign-in#properties) component to ensure proper functionality.
+- The `<SignIn />` and `<SignUp />` components handle the waitlist flow for you. If you'd like to build a custom waitlist page, you can use the [`<Waitlist />`](/docs/reference/components/authentication/waitlist) component. See the [guide on building a custom waitlist page](/docs/guides/secure/waitlist) for more information.
 
 #### Manage users on your waitlist
 
 <Include src="_partials/waitlist/manage-users-on-your-waitlist" />
 
 #### Customize waitlist emails
-
-Users receive an email confirming their request to join the waitlist (the **Waitlist confirmation** email). Once approved, they receive an email with instructions on how to join your app (the **Waitlist invitation** email).
-
-You can disable the **Waitlist confirmation** email, but you can't disable the **Waitlist invitation** email. By default, both emails are enabled. You can also customize the emails to better match your brand.
 
 To configure the waitlist emails:
 

--- a/docs/reference/components/authentication/waitlist.mdx
+++ b/docs/reference/components/authentication/waitlist.mdx
@@ -27,7 +27,7 @@ Before using the `<Waitlist />` component, you must enable **Waitlist** mode in 
   ## Example
 
   > [!WARNING]
-  > Before using the `<Waitlist />` component, you must provide the `waitlistUrl` prop either in the [`<ClerkProvider>`](/docs/reference/components/clerk-provider#properties) or [`<SignIn />`](/docs/reference/components/authentication/sign-in#properties) component to ensure proper functionality.
+  > Hosting the `<Waitlist />` component on a custom route requires additional setup. See the [guide on building a custom waitlist page](/docs/guides/secure/waitlist) for instructions.
 
   The following example includes a basic implementation of the `<Waitlist />` component. You can use this as a starting point for your own implementation.
 


### PR DESCRIPTION
### 🔎 Previews:

-

### What does this solve? What changed?

Refreshes the waitlist documentation to better describe the post-approval flow and clarify when the `<Waitlist />` component is needed.

- In `docs/guides/secure/restricting-access.mdx`:
  - Expanded the **Waitlist** section to describe what happens after a user is approved: the **Waitlist invitation** email, the **Accept invitation** button, the redirect to the Account Portal sign-up page, and how the `<SignUp />` component handles apps that require more than an email.
  - Reframed the `<Waitlist />` bullet to note that `<SignIn />` and `<SignUp />` handle the waitlist flow by default, and pointed readers to the custom waitlist page guide for the self-hosted case.
  - Removed the now-redundant "Customize waitlist emails" intro paragraphs, since the email behavior is covered earlier in the section.
- In `docs/reference/components/authentication/waitlist.mdx`:
  - Replaced the `waitlistUrl` prop warning with a pointer to the custom waitlist page guide for the custom-route case.

### Deadline

- No rush.

### Other resources

Follow up to [linear ticket](https://linear.app/clerk/issue/DOCS-11688/feedback-for-docsnextjsguidessecurewaitlist)
