### PR TITLE
Update Expo native component docs

### DIFF
--- a/docs/_partials/expo/auth-view-modal-lifecycle-callout.mdx
+++ b/docs/_partials/expo/auth-view-modal-lifecycle-callout.mdx
@@ -1,2 +1,2 @@
 > [!IMPORTANT]
-> Keep the React Native `<Modal>` that contains `<AuthView />` mounted at the same level as your signed-in and signed-out content. Don't render the modal only inside signed-out content, because auth state can change before required session tasks are finished and unmount the modal too early.
+> Keep the React Native `<Modal>` that contains `<AuthView />` mounted at the same level as your signed-in and signed-out content. Don't render the modal only inside signed-out content, because auth state can change before required [session tasks](!session-tasks) are finished and unmount the modal too early.

--- a/docs/_partials/expo/auth-view-modal-lifecycle-callout.mdx
+++ b/docs/_partials/expo/auth-view-modal-lifecycle-callout.mdx
@@ -1,0 +1,2 @@
+> [!IMPORTANT]
+> Keep the React Native `<Modal>` that contains `<AuthView />` mounted at the same level as your signed-in and signed-out content. Don't render the modal only inside signed-out content, because auth state can change before required session tasks are finished and unmount the modal too early.

--- a/docs/_partials/expo/email-pass-sign-in.mdx
+++ b/docs/_partials/expo/email-pass-sign-in.mdx
@@ -1,6 +1,6 @@
 In the `(auth)` group, create a `sign-in.tsx` file with the following code. The [`useSignIn()`](/docs/reference/hooks/use-sign-in) hook is used to create a sign-in flow. The user can sign in using email address and password, or navigate to the sign-up page.
 
-```tsx {{ filename: 'app/(auth)/sign-in.tsx', collapsible: true }}
+```tsx {{ filename: 'src/app/(auth)/sign-in.tsx', collapsible: true }}
 import { ThemedText } from '@/components/themed-text'
 import { ThemedView } from '@/components/themed-view'
 import { useSignIn } from '@clerk/expo'

--- a/docs/_partials/expo/email-pass-sign-up.mdx
+++ b/docs/_partials/expo/email-pass-sign-up.mdx
@@ -1,6 +1,6 @@
 In the `(auth)` group, create a `sign-up.tsx` file with the following code. The [`useSignUp()`](/docs/reference/hooks/use-sign-up) hook is used to create a sign-up flow. The user can sign up using their email and password and will receive an email verification code to confirm their email.
 
-```tsx {{ filename: 'app/(auth)/sign-up.tsx', collapsible: true }}
+```tsx {{ filename: 'src/app/(auth)/sign-up.tsx', collapsible: true }}
 import { ThemedText } from '@/components/themed-text'
 import { ThemedView } from '@/components/themed-view'
 import { useAuth, useSignUp } from '@clerk/expo'

--- a/docs/_partials/expo/next-steps-web-support.mdx
+++ b/docs/_partials/expo/next-steps-web-support.mdx
@@ -1,4 +1,4 @@
-Learn more about Clerk components, how to build custom flows for your native apps, and how to use Clerk's client-side helpers using the following guides.
+Learn more about Clerk components, how to build custom flows, and how to use Clerk's client-side helpers using the following guides.
 
 <Cards>
   - [Create a custom sign-up page](/docs/guides/development/web-support/custom-sign-up-page)
@@ -17,7 +17,7 @@ Learn more about Clerk components, how to build custom flows for your native app
   ---
 
   - [Custom flows](/docs/guides/development/custom-flows/overview)
-  - Expo native apps require custom flows in place of prebuilt components.
+  - Build custom authentication flows with Clerk's API when prebuilt components don't fit your product.
 
   ---
 

--- a/docs/_partials/expo/quickstart/clerk-provider.mdx
+++ b/docs/_partials/expo/quickstart/clerk-provider.mdx
@@ -2,7 +2,7 @@
 
 Add the component to your root layout and pass your [Publishable Key](!publishable-key) and `tokenCache` from `@clerk/expo/token-cache` as props, as shown in the following example:
 
-```tsx {{ filename: 'app/_layout.tsx' }}
+```tsx {{ filename: 'src/app/_layout.tsx' }}
 import { ClerkProvider } from '@clerk/expo'
 import { tokenCache } from '@clerk/expo/token-cache'
 import { Slot } from 'expo-router'

--- a/docs/_partials/expo/quickstart/create-first-user-step.mdx
+++ b/docs/_partials/expo/quickstart/create-first-user-step.mdx
@@ -1,5 +1,5 @@
 Once the app opens on your device or simulator:
 
-- Navigate to the Sign up screen.
+- Open the sign-up flow.
 - Enter your details and complete the authentication flow.
 - After signing up, your first user will be created and you'll be signed in.

--- a/docs/_partials/expo/quickstart/remove-default-template-files.mdx
+++ b/docs/_partials/expo/quickstart/remove-default-template-files.mdx
@@ -1,20 +1,10 @@
-The default Expo template includes files that will conflict with the routes you'll create in this guide. Remove the conflicting files:
+The default Expo template includes starter routes that aren't used in this guide. Remove them:
 
 ```bash
-rm -rf "app/(tabs)" app/modal.tsx app/+not-found.tsx
+rm -f src/app/index.tsx src/app/explore.tsx
 ```
 
-The default template also includes `react-native-reanimated`, which can cause [known Android build issues](https://docs.expo.dev/versions/latest/sdk/reanimated/#known-issues). Since it's not needed for this guide, remove it to avoid build errors:
+This guide replaces the starter `src/app/_layout.tsx` file and creates the app routes in later steps.
 
-```bash
-npm uninstall react-native-reanimated react-native-worklets --legacy-peer-deps
-```
-
-Then, remove the reanimated import from `app/_layout.tsx`:
-
-```diff {{ filename: 'app/_layout.tsx' }}
-- import 'react-native-reanimated';
-```
-
-> [!IMPORTANT]
-> You can skip this step if you used `npx create-expo-app@latest --template blank` to create your app. However, the blank template doesn't include [Expo Router](https://docs.expo.dev/router/introduction/) or pre-styled UI components. You'll need to install `expo-router` and its dependencies to follow along with this guide.
+> [!NOTE]
+> If your Expo app uses a root `app` folder instead of `src/app`, use the same file paths without `src/`.

--- a/docs/_partials/expo/session-sync-callout.mdx
+++ b/docs/_partials/expo/session-sync-callout.mdx
@@ -1,2 +1,2 @@
 > [!IMPORTANT]
-> When using native components, pass `{ treatPendingAsSignedOut: false }` to `useAuth()` so pending [session tasks](!session-tasks) are not treated as signed out.
+> When using native components, pass `{ treatPendingAsSignedOut: false }` to [`useAuth()`](/docs/reference/hooks/use-auth) so pending [session tasks](!session-tasks) are not treated as signed out.

--- a/docs/_partials/expo/session-sync-callout.mdx
+++ b/docs/_partials/expo/session-sync-callout.mdx
@@ -1,2 +1,2 @@
 > [!IMPORTANT]
-> When using native components, pass `{ treatPendingAsSignedOut: false }` to `useAuth()` to keep auth state in sync with the native SDK and avoid issues with pending [session tasks](!session-tasks).
+> When using native components, pass `{ treatPendingAsSignedOut: false }` to `useAuth()` so pending [session tasks](!session-tasks) are not treated as signed out.

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -117,6 +117,7 @@ Use the following tabs to choose your preferred approach:
 
       export default function MainScreen() {
         const { isSignedIn, isLoaded } = useAuth({ treatPendingAsSignedOut: false })
+        const [isAuthOpen, setIsAuthOpen] = useState(false)
 
         if (!isLoaded) {
           return (
@@ -126,15 +127,9 @@ Use the following tabs to choose your preferred approach:
           )
         }
 
-        return <View style={styles.container}>{isSignedIn ? <UserButton /> : <SignedOutButton />}</View>
-      }
-
-      function SignedOutButton() {
-        const [isAuthOpen, setIsAuthOpen] = useState(false)
-
         return (
-          <>
-            <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
+          <View style={styles.container}>
+            {isSignedIn ? <UserButton /> : <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />}
             <Modal
               animationType="slide"
               visible={isAuthOpen}
@@ -143,7 +138,7 @@ Use the following tabs to choose your preferred approach:
             >
               <AuthView onDismiss={() => setIsAuthOpen(false)} />
             </Modal>
-          </>
+          </View>
         )
       }
 

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -112,18 +112,11 @@ Use the following tabs to choose your preferred approach:
       ```tsx {{ filename: 'app/index.tsx', collapsible: true }}
       import { useAuth } from '@clerk/expo'
       import { AuthView, UserButton } from '@clerk/expo/native'
-      import { useEffect, useState } from 'react'
+      import { useState } from 'react'
       import { View, StyleSheet, ActivityIndicator, Button, Modal } from 'react-native'
 
       export default function MainScreen() {
-        const [isAuthOpen, setIsAuthOpen] = useState(false)
         const { isSignedIn, isLoaded } = useAuth({ treatPendingAsSignedOut: false })
-
-        useEffect(() => {
-          if (isSignedIn) {
-            setIsAuthOpen(false)
-          }
-        }, [isSignedIn])
 
         if (!isLoaded) {
           return (
@@ -133,9 +126,15 @@ Use the following tabs to choose your preferred approach:
           )
         }
 
+        return <View style={styles.container}>{isSignedIn ? <UserButton /> : <SignedOutButton />}</View>
+      }
+
+      function SignedOutButton() {
+        const [isAuthOpen, setIsAuthOpen] = useState(false)
+
         return (
-          <View style={styles.container}>
-            {isSignedIn ? <UserButton /> : <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />}
+          <>
+            <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
             <Modal
               animationType="slide"
               visible={isAuthOpen}
@@ -144,7 +143,7 @@ Use the following tabs to choose your preferred approach:
             >
               <AuthView onDismiss={() => setIsAuthOpen(false)} />
             </Modal>
-          </View>
+          </>
         )
       }
 

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -69,12 +69,10 @@ Use the following tabs to choose your preferred approach:
 
       - The [Clerk Expo SDK](/docs/reference/expo/overview) gives you access to prebuilt components, hooks, and helpers to make user authentication easier.
       - Clerk stores the active user's session token in memory by default. In Expo apps, the recommended way to store sensitive data, such as tokens, is by using `expo-secure-store` which encrypts the data before storing it.
-      - `expo-auth-session` handles authentication redirects and OAuth flows in Expo apps.
-      - `expo-web-browser` opens the system browser during authentication and returns the user to the app once the flow is complete.
       - `expo-dev-client` allows you to build and run your app in development mode.
 
       ```bash
-      npx expo install @clerk/expo expo-secure-store expo-auth-session expo-web-browser expo-dev-client
+      npx expo install @clerk/expo expo-secure-store expo-dev-client
       ```
 
       ## Set your Clerk API keys

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -109,6 +109,8 @@ Use the following tabs to choose your preferred approach:
 
       <Include src="_partials/expo/session-sync-callout" />
 
+      <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
+
       ```tsx {{ filename: 'app/index.tsx', collapsible: true }}
       import { useAuth } from '@clerk/expo'
       import { AuthView, UserButton } from '@clerk/expo/native'

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -392,7 +392,7 @@ See the [`expo-updates`](https://docs.expo.dev/versions/latest/sdk/updates) libr
 
 ## Next steps
 
-Learn more about Clerk prebuilt components, custom flows for your native apps, and how to deploy an Expo app to production using the following guides.
+Learn more about Clerk prebuilt components, custom flows, and how to deploy an Expo app to production using the following guides.
 
 <Cards>
   - [Prebuilt native components (beta)](/docs/reference/expo/native-components/overview)
@@ -401,7 +401,7 @@ Learn more about Clerk prebuilt components, custom flows for your native apps, a
   ---
 
   - [Custom flows](/docs/guides/development/custom-flows/overview)
-  - Use custom flows in place of prebuilt components.
+  - Build custom authentication flows with Clerk's API when prebuilt components don't fit your product.
 
   ---
 

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -137,6 +137,7 @@ Use the following tabs to choose your preferred approach:
           <View style={styles.container}>
             {isSignedIn ? <UserButton /> : <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />}
             <Modal
+              animationType="slide"
               visible={isAuthOpen}
               presentationStyle="pageSheet"
               onRequestClose={() => setIsAuthOpen(false)}

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -59,7 +59,7 @@ Use the following tabs to choose your preferred approach:
 
       <Include src="_partials/expo/quickstart/create-new-expo-app" />
 
-      ## Remove default template files
+      ## Remove the starter routes
 
       <Include src="_partials/expo/quickstart/remove-default-template-files" />
 
@@ -103,13 +103,13 @@ Use the following tabs to choose your preferred approach:
 
       With [native components](/docs/reference/expo/native-components/overview), you can build a complete app in a single file. The [`<AuthView />`](/docs/reference/expo/native-components/auth-view) component handles all sign-in and sign-up flows, and [`<UserButton />`](/docs/reference/expo/native-components/user-button) provides a profile avatar that opens the native user profile.
 
-      Create an `index.tsx` file in your `app` folder with the following code. If the user is signed in, it displays the `<UserButton />`. If they're not signed in, it displays a **Sign in** button that opens the `<AuthView />`.
+      Create a `src/app/index.tsx` file with the following code. If the user is signed in, it displays the `<UserButton />`. If they're not signed in, it displays a **Sign in** button that opens the `<AuthView />`.
 
       <Include src="_partials/expo/session-sync-callout" />
 
       <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
 
-      ```tsx {{ filename: 'app/index.tsx', collapsible: true }}
+      ```tsx {{ filename: 'src/app/index.tsx', collapsible: true }}
       import { useAuth } from '@clerk/expo'
       import { AuthView, UserButton } from '@clerk/expo/native'
       import { useState } from 'react'
@@ -200,7 +200,7 @@ Use the following tabs to choose your preferred approach:
 
       <Include src="_partials/expo/quickstart/create-new-expo-app" />
 
-      ## Remove default template files
+      ## Remove the starter routes
 
       <Include src="_partials/expo/quickstart/remove-default-template-files" />
 
@@ -238,7 +238,7 @@ Use the following tabs to choose your preferred approach:
       1. Create an `(auth)` [route group](https://docs.expo.dev/router/advanced/shared-routes/). This will group your sign-up and sign-in pages.
       1. In the `(auth)` group, create a `_layout.tsx` file with the following code. The [`useAuth()`](/docs/reference/hooks/use-auth) hook is used to access the user's authentication state. If the user is already signed in, they will be redirected to the home page.
 
-      ```tsx {{ filename: 'app/(auth)/_layout.tsx' }}
+      ```tsx {{ filename: 'src/app/(auth)/_layout.tsx' }}
       import { useAuth } from '@clerk/expo'
       import { Redirect, Stack } from 'expo-router'
 
@@ -277,7 +277,7 @@ Use the following tabs to choose your preferred approach:
       1. Create a `(home)` route group.
       1. In the `(home)` group, create a `_layout.tsx` file with the following code.
 
-      ```tsx {{ filename: 'app/(home)/_layout.tsx' }}
+      ```tsx {{ filename: 'src/app/(home)/_layout.tsx' }}
       import { useAuth } from '@clerk/expo'
       import { Redirect, Stack } from 'expo-router'
 
@@ -298,7 +298,7 @@ Use the following tabs to choose your preferred approach:
 
       Then, in the same folder, create an `index.tsx` file. If the user is signed in, it displays their email and a sign-out button. If they're not signed in, it displays sign-in and sign-up links.
 
-      ```tsx {{ filename: 'app/(home)/index.tsx', collapsible: true }}
+      ```tsx {{ filename: 'src/app/(home)/index.tsx', collapsible: true }}
       import { Show, useUser } from '@clerk/expo'
       import { useClerk } from '@clerk/expo'
       import { Link } from 'expo-router'

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -103,22 +103,27 @@ Use the following tabs to choose your preferred approach:
 
       ## Add authentication and home screen
 
-      With [native components](/docs/reference/expo/native-components/overview), you can build a complete app in a single file. The [`<AuthView />`](/docs/reference/expo/native-components/auth-view) component handles all sign-in and sign-up flows, [`<UserButton />`](/docs/reference/expo/native-components/user-button) provides a profile avatar that opens the native profile modal, and the [`useUserProfileModal()`](/docs/reference/expo/native-components/user-profile-view) hook lets you open the profile modal from any button.
+      With [native components](/docs/reference/expo/native-components/overview), you can build a complete app in a single file. The [`<AuthView />`](/docs/reference/expo/native-components/auth-view) component handles all sign-in and sign-up flows, and [`<UserButton />`](/docs/reference/expo/native-components/user-button) provides a profile avatar that opens the native user profile.
 
-      Create an `index.tsx` file in your `app` folder with the following code. If the user is signed in, it displays their email, a profile button, and a sign-out button. If they're not signed in, it displays the `<AuthView />` component which handles both sign-in and sign-up.
+      Create an `index.tsx` file in your `app` folder with the following code. If the user is signed in, it displays the `<UserButton />`. If they're not signed in, it displays a **Sign in** button that opens the `<AuthView />`.
 
       <Include src="_partials/expo/session-sync-callout" />
 
       ```tsx {{ filename: 'app/index.tsx', collapsible: true }}
-      import { useAuth, useUser, useClerk, useUserProfileModal } from '@clerk/expo'
+      import { useAuth } from '@clerk/expo'
       import { AuthView, UserButton } from '@clerk/expo/native'
-      import { Text, View, StyleSheet, Image, TouchableOpacity, ActivityIndicator } from 'react-native'
+      import { useEffect, useState } from 'react'
+      import { View, StyleSheet, ActivityIndicator, Button, Modal } from 'react-native'
 
       export default function MainScreen() {
+        const [isAuthOpen, setIsAuthOpen] = useState(false)
         const { isSignedIn, isLoaded } = useAuth({ treatPendingAsSignedOut: false })
-        const { user } = useUser()
-        const { signOut } = useClerk()
-        const { presentUserProfile } = useUserProfileModal()
+
+        useEffect(() => {
+          if (isSignedIn) {
+            setIsAuthOpen(false)
+          }
+        }, [isSignedIn])
 
         if (!isLoaded) {
           return (
@@ -128,33 +133,16 @@ Use the following tabs to choose your preferred approach:
           )
         }
 
-        if (!isSignedIn) {
-          return <AuthView mode="signInOrUp" />
-        }
-
         return (
           <View style={styles.container}>
-            <View style={styles.header}>
-              <Text style={styles.title}>Welcome</Text>
-              <View style={{ width: 44, height: 44, borderRadius: 22, overflow: 'hidden' }}>
-                <UserButton />
-              </View>
-            </View>
-            <View style={styles.profileCard}>
-              {user?.imageUrl && <Image source={{ uri: user.imageUrl }} style={styles.avatar} />}
-              <View>
-                <Text>Hello {user?.id}</Text>
-              </View>
-            </View>
-            <TouchableOpacity style={styles.linkButton} onPress={presentUserProfile}>
-              <Text style={styles.linkButtonText}>Manage Profile</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[styles.linkButton, { backgroundColor: '#666' }]}
-              onPress={() => signOut()}
+            {isSignedIn ? <UserButton /> : <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />}
+            <Modal
+              visible={isAuthOpen}
+              presentationStyle="pageSheet"
+              onRequestClose={() => setIsAuthOpen(false)}
             >
-              <Text style={styles.linkButtonText}>Sign Out</Text>
-            </TouchableOpacity>
+              <AuthView onDismiss={() => setIsAuthOpen(false)} />
+            </Modal>
           </View>
         )
       }
@@ -169,51 +157,10 @@ Use the following tabs to choose your preferred approach:
         },
         container: {
           flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
           backgroundColor: '#fff',
           padding: 20,
-          paddingTop: 60,
-          gap: 16,
-        },
-        header: {
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        },
-        title: {
-          fontSize: 28,
-          fontWeight: 'bold',
-        },
-        profileCard: {
-          flexDirection: 'row',
-          alignItems: 'center',
-          padding: 16,
-          backgroundColor: '#f5f5f5',
-          borderRadius: 12,
-          gap: 12,
-        },
-        avatar: {
-          width: 48,
-          height: 48,
-          borderRadius: 24,
-        },
-        name: {
-          fontSize: 18,
-          fontWeight: '600',
-        },
-        email: {
-          fontSize: 14,
-          color: '#666',
-        },
-        linkButton: {
-          backgroundColor: '#007AFF',
-          padding: 16,
-          borderRadius: 12,
-          alignItems: 'center',
-        },
-        linkButtonText: {
-          color: '#fff',
-          fontSize: 16,
-          fontWeight: '600',
         },
       })
       ```
@@ -291,7 +238,7 @@ Use the following tabs to choose your preferred approach:
 
       ## Add sign-up and sign-in pages
 
-      Clerk currently only supports [control components](/docs/reference/components/overview#control-components) for Expo native. [UI components](/docs/reference/components/overview) are only available for Expo web. Instead, you must build [custom flows](!custom-flow) using Clerk's API. The following sections demonstrate how to build [custom email/password sign-up and sign-in flows](/docs/guides/development/custom-flows/authentication/email-password). If you want to use different authentication methods, such as passwordless or OAuth, see the dedicated custom flow guides.
+      For JavaScript-only Expo native apps that run in Expo Go, use Clerk's [control components](/docs/reference/components/overview#control-components) and build [custom flows](!custom-flow) with Clerk's API. [UI components](/docs/reference/components/overview) are available for Expo web, and [native components](/docs/reference/expo/native-components/overview) are available for iOS and Android apps that use a development build. The following sections demonstrate how to build [custom email/password sign-up and sign-in flows](/docs/guides/development/custom-flows/authentication/email-password). If you want to use different authentication methods, such as passwordless or OAuth, see the dedicated custom flow guides.
 
       ### Layout page
 

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -147,15 +147,11 @@ Use the following tabs to choose your preferred approach:
           flex: 1,
           justifyContent: 'center',
           alignItems: 'center',
-          backgroundColor: '#fff',
-          padding: 40,
         },
         container: {
           flex: 1,
           justifyContent: 'center',
           alignItems: 'center',
-          backgroundColor: '#fff',
-          padding: 20,
         },
       })
       ```

--- a/docs/guides/development/web-support/overview.mdx
+++ b/docs/guides/development/web-support/overview.mdx
@@ -4,7 +4,7 @@ description: Add web support to your Expo project with Clerk.
 sdk: expo
 ---
 
-Expo provides a way to [develop web applications](https://docs.expo.dev/workflow/web/) using the same codebase as your iOS and Android apps. Though Clerk prebuilt components cannot be used in native apps, they can be used in web applications built with Expo.
+Expo provides a way to [develop web applications](https://docs.expo.dev/workflow/web/) using the same codebase as your iOS and Android apps. Clerk provides prebuilt components for Expo web projects through `@clerk/expo/web` and prebuilt native components for iOS and Android through `@clerk/expo/native`.
 
 ## Create a new project with web support
 
@@ -15,7 +15,7 @@ If you're starting from scratch, you can follow the [Expo quickstart](/docs/expo
 If you already have an Expo project and want to add web support, you must first ensure that your existing Clerk [custom flows](/docs/guides/development/custom-flows/overview) do not have any native-specific code. If you have any native-specific code you will have to either adjust your custom flows to also work on web by leveraging [platform-specific code](https://reactnative.dev/docs/platform-specific-code#platform-specific-extensions), if you are using Expo Router you can also take a look at the [platform-specific modules](https://docs.expo.dev/router/advanced/platform-specific-modules/) guide.
 
 > [!WARNING]
-> Clerk prebuilt components are only available on the web platform. If you're using Expo for iOS or Android, you'll need to build components using [custom flows](/docs/guides/development/custom-flows/overview).
+> Use the components that match the platform. Use web components from `@clerk/expo/web` for Expo web projects, and use [native components](/docs/reference/expo/native-components/overview) from `@clerk/expo/native` for iOS and Android.
 
 ## Next steps
 

--- a/docs/guides/development/web-support/overview.mdx
+++ b/docs/guides/development/web-support/overview.mdx
@@ -15,7 +15,7 @@ If you're starting from scratch, follow the [Expo quickstart](/docs/expo/getting
 If you already have an Expo project and want to add web support, you must first ensure that your existing Clerk [custom flows](/docs/guides/development/custom-flows/overview) do not have any native-specific code. If you have any native-specific code you will have to either adjust your custom flows to also work on web by leveraging [platform-specific code](https://reactnative.dev/docs/platform-specific-code#platform-specific-extensions), if you are using Expo Router you can also take a look at the [platform-specific modules](https://docs.expo.dev/router/advanced/platform-specific-modules/) guide.
 
 > [!WARNING]
-> Use the components that match the platform. Use web components from `@clerk/expo/web` for Expo web projects, and use [native components](/docs/reference/expo/native-components/overview) from `@clerk/expo/native` for iOS and Android.
+> Use the components that match the platform. Use [web components](/docs/reference/components/overview) from `@clerk/expo/web` for Expo web projects, and use [native components](/docs/reference/expo/native-components/overview) from `@clerk/expo/native` for iOS and Android.
 
 ## Next steps
 

--- a/docs/guides/development/web-support/overview.mdx
+++ b/docs/guides/development/web-support/overview.mdx
@@ -8,7 +8,7 @@ Expo provides a way to [develop web applications](https://docs.expo.dev/workflow
 
 ## Create a new project with web support
 
-If you're starting from scratch, you can follow the [Expo quickstart](/docs/expo/getting-started/quickstart), which showcases how to create a sign-in and sign-up page with the same code for all platforms Expo supports.
+If you're starting from scratch, follow the [Expo quickstart](/docs/expo/getting-started/quickstart), which shows the available Expo authentication approaches and how to choose the components that match each platform.
 
 ## Add web support to an existing project
 

--- a/docs/reference/components/clerk-provider.mdx
+++ b/docs/reference/components/clerk-provider.mdx
@@ -69,7 +69,7 @@ The recommended approach is to wrap your entire app with `<ClerkProvider>` at th
 </If>
 
 <If sdk="expo">
-  ```tsx {{ filename: 'app/_layout.tsx' }}
+  ```tsx {{ filename: 'src/app/_layout.tsx' }}
   import { ClerkProvider } from '@clerk/expo'
   import { Slot } from 'expo-router'
 

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -38,22 +38,22 @@ import { Button, Modal, Text, View } from 'react-native'
 export default function AuthButton() {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
   const { user } = useUser()
-  const [isPresented, setIsPresented] = useState(false)
+  const [isAuthOpen, setIsAuthOpen] = useState(false)
 
   return (
     <View>
       {isSignedIn ? (
         <Text>Welcome, {user?.firstName}</Text>
       ) : (
-        <Button title="Sign in" onPress={() => setIsPresented(true)} />
+        <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
       )}
       <Modal
         animationType="slide"
-        visible={isPresented}
+        visible={isAuthOpen}
         presentationStyle="pageSheet"
-        onRequestClose={() => setIsPresented(false)}
+        onRequestClose={() => setIsAuthOpen(false)}
       >
-        <AuthView onDismiss={() => setIsPresented(false)} />
+        <AuthView onDismiss={() => setIsAuthOpen(false)} />
       </Modal>
     </View>
   )

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -9,6 +9,8 @@ sdk: expo
 
 The `<AuthView />` component renders a complete native authentication interface using SwiftUI on iOS and Jetpack Compose on Android. It handles all authentication flows including email, phone, OAuth, passkeys, and multi-factor authentication. All methods enabled in your [Clerk Dashboard](https://dashboard.clerk.com) are automatically supported.
 
+The `<AuthView />` renders inline in your React Native view hierarchy. Your app owns the presentation surface, so you can render it in a route, a full-screen screen, a React Native `<Modal>`, or any other layout.
+
 <Include src="_partials/expo/expo-requirements-callout" />
 
 ## Usage
@@ -35,20 +37,47 @@ export default function SignInScreen() {
     }
   }, [isSignedIn])
 
-  return <AuthView mode="signInOrUp" />
+  return <AuthView isDismissible={false} />
 }
 ```
 
 ### Sign-in only
 
 ```tsx
-<AuthView mode="signIn" />
+<AuthView mode="signIn" isDismissible={false} />
 ```
 
 ### Sign-up only
 
 ```tsx
-<AuthView mode="signUp" />
+<AuthView mode="signUp" isDismissible={false} />
+```
+
+### Present in a React Native Modal
+
+The following example demonstrates how to render `<AuthView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
+
+```tsx {{ filename: 'app/(auth)/sign-in.tsx' }}
+import { AuthView } from '@clerk/expo/native'
+import { useState } from 'react'
+import { Button, Modal, View } from 'react-native'
+
+export default function SignedOut() {
+  const [isPresented, setIsPresented] = useState(false)
+
+  return (
+    <View>
+      <Button title="Sign in" onPress={() => setIsPresented(true)} />
+      <Modal
+        visible={isPresented}
+        presentationStyle="pageSheet"
+        onRequestClose={() => setIsPresented(false)}
+      >
+        <AuthView onDismiss={() => setIsPresented(false)} />
+      </Modal>
+    </View>
+  )
+}
 ```
 
 ### Dismissible auth view
@@ -73,13 +102,17 @@ The following example enables the native dismiss button with the `isDismissable`
 
   ---
 
-  - `isDismissable`
+  - `isDismissible`
   - `boolean`
 
-  Whether the authentication view can be dismissed by the user. When `true`, a dismiss button appears. When `false`, no dismiss button is shown. Defaults to `false`.
+  Whether the authentication view can be dismissed by the user. When `true`, a dismiss button appears in the native navigation bar. When `false`, no dismiss button is shown. Defaults to `true`.
 
-  > [!IMPORTANT]
-  > Do not set `isDismissable={true}` when rendering inside a React Native `<Modal>`. The native dismiss button relies on SwiftUI (iOS) or Jetpack Compose (Android) to close the view, which cannot dismiss a React Native `<Modal>`. Tapping the native dismiss button will not close the modal and may leave the screen unresponsive.
+  ---
+
+  - `onDismiss`
+  - `() => void`
+
+  A callback that runs when the user dismisses the native authentication view. Use this to update your app's presentation state, such as closing a React Native `<Modal>`.
 </Properties>
 
 ## Social connection (OAuth) configuration

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -33,7 +33,7 @@ The following example demonstrates one way to render `<AuthView />` inside a Rea
 import { AuthView } from '@clerk/expo/native'
 import { useAuth, useUser } from '@clerk/expo'
 import { useState } from 'react'
-import { Button, Modal, Text, View } from 'react-native'
+import { Button, Modal, StyleSheet, Text, View } from 'react-native'
 
 export default function AuthButton() {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
@@ -41,9 +41,9 @@ export default function AuthButton() {
   const [isAuthOpen, setIsAuthOpen] = useState(false)
 
   return (
-    <View>
+    <View style={styles.container}>
       {isSignedIn ? (
-        <Text>Welcome, {user?.firstName}</Text>
+        <Text>User ID: {user?.id}</Text>
       ) : (
         <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
       )}
@@ -58,6 +58,14 @@ export default function AuthButton() {
     </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+})
 ```
 
 ### Sign-in only

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -29,7 +29,7 @@ The following example demonstrates one way to render `<AuthView />` inside a Rea
 
 <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
 
-```tsx {{ filename: 'app/index.tsx' }}
+```tsx {{ filename: 'src/app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useAuth, useUser } from '@clerk/expo'
 import { useState } from 'react'
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 
 You can render `<AuthView />` directly in a full-screen view when users must authenticate before continuing. In this case, pass `isDismissible={false}` so the native dismiss button isn't shown.
 
-```tsx {{ filename: 'app/(auth)/sign-in.tsx' }}
+```tsx {{ filename: 'src/app/(auth)/sign-in.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useSession } from '@clerk/expo'
 import { useRouter } from 'expo-router'

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -7,6 +7,10 @@ sdk: expo
 > [!NOTE]
 > This documents the native `<AuthView />` from `@clerk/expo/native`. For web projects, use the [web `<SignIn />`](/docs/reference/components/authentication/sign-in) or [`<SignUp />`](/docs/reference/components/authentication/sign-up) components from `@clerk/expo/web`.
 
+| iOS | Android |
+| - | - |
+| ![The AuthView renders a comprehensive authentication interface that handles both user sign-in and sign-up flows on iOS.](/docs/images/ui-components/ios-auth-view.png){{ width: 303, height: 590, style: { objectFit: 'contain' } }} | ![The AuthView renders a comprehensive authentication interface that handles both user sign-in and sign-up flows on Android.](/docs/images/ui-components/android-auth-view.png){{ width: 303, height: 590, style: { objectFit: 'contain' } }} |
+
 The `<AuthView />` component renders a complete native authentication interface using SwiftUI on iOS and Jetpack Compose on Android. It handles all authentication flows including email, phone, OAuth, passkeys, and multi-factor authentication. All methods enabled in your [Clerk Dashboard](https://dashboard.clerk.com) are automatically supported.
 
 The `<AuthView />` renders inline in your React Native view hierarchy, so you can place it in a modal, route, full-screen view, or any other layout that fits your app.

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -78,19 +78,19 @@ You can render `<AuthView />` directly in a full-screen view when users must aut
 
 ```tsx {{ filename: 'app/(auth)/sign-in.tsx' }}
 import { AuthView } from '@clerk/expo/native'
-import { useAuth } from '@clerk/expo'
+import { useSession } from '@clerk/expo'
 import { useRouter } from 'expo-router'
 import { useEffect } from 'react'
 
 export default function SignInScreen() {
-  const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
+  const { session } = useSession()
   const router = useRouter()
 
   useEffect(() => {
-    if (isSignedIn) {
+    if (session?.status === 'active') {
       router.replace('/(home)')
     }
-  }, [isSignedIn])
+  }, [session?.status, router])
 
   return <AuthView isDismissible={false} />
 }

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -19,7 +19,7 @@ The following examples show how to use the `<AuthView />` in your Expo app. You 
 
 ### Render in a modal
 
-The following example demonstrates how to render `<AuthView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
+The following example demonstrates one way to render `<AuthView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
 
 <Include src="_partials/expo/session-sync-callout" />
 

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -36,20 +36,15 @@ import { Button, Modal, Text, View } from 'react-native'
 export default function AuthButton() {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
   const { user } = useUser()
-
-  if (isSignedIn) {
-    return <Text>Welcome, {user?.firstName}</Text>
-  }
-
-  return <SignedOutButton />
-}
-
-function SignedOutButton() {
   const [isPresented, setIsPresented] = useState(false)
 
   return (
     <View>
-      <Button title="Sign in" onPress={() => setIsPresented(true)} />
+      {isSignedIn ? (
+        <Text>Welcome, {user?.firstName}</Text>
+      ) : (
+        <Button title="Sign in" onPress={() => setIsPresented(true)} />
+      )}
       <Modal
         animationType="slide"
         visible={isPresented}

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -9,17 +9,70 @@ sdk: expo
 
 The `<AuthView />` component renders a complete native authentication interface using SwiftUI on iOS and Jetpack Compose on Android. It handles all authentication flows including email, phone, OAuth, passkeys, and multi-factor authentication. All methods enabled in your [Clerk Dashboard](https://dashboard.clerk.com) are automatically supported.
 
-The `<AuthView />` renders inline in your React Native view hierarchy. Your app owns the presentation surface, so you can render it in a route, a full-screen screen, a React Native `<Modal>`, or any other layout.
+The `<AuthView />` renders inline in your React Native view hierarchy, so you can place it in a modal, route, full-screen view, or any other layout that fits your app.
 
 <Include src="_partials/expo/expo-requirements-callout" />
 
 ## Usage
 
-The following examples show how to use the `<AuthView />` in your Expo app. Use [`useAuth()`](/docs/reference/hooks/use-auth) or [`useUser()`](/docs/reference/hooks/use-user) in a `useEffect` to react to authentication state changes.
+The following examples show how to use the `<AuthView />` in your Expo app. You can use [`useAuth()`](/docs/reference/hooks/use-auth) or [`useUser()`](/docs/reference/hooks/use-user) to read authentication state and update your UI after auth changes.
 
-### Basic usage
+### Render in a modal
+
+The following example demonstrates how to render `<AuthView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
 
 <Include src="_partials/expo/session-sync-callout" />
+
+```tsx {{ filename: 'app/index.tsx' }}
+import { AuthView } from '@clerk/expo/native'
+import { useAuth } from '@clerk/expo'
+import { useState } from 'react'
+import { Button, Modal, View } from 'react-native'
+
+export default function AuthButton() {
+  const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
+
+  if (isSignedIn) {
+    return null
+  }
+
+  return <SignedOutButton />
+}
+
+function SignedOutButton() {
+  const [isPresented, setIsPresented] = useState(false)
+
+  return (
+    <View>
+      <Button title="Sign in" onPress={() => setIsPresented(true)} />
+      <Modal
+        animationType="slide"
+        visible={isPresented}
+        presentationStyle="pageSheet"
+        onRequestClose={() => setIsPresented(false)}
+      >
+        <AuthView onDismiss={() => setIsPresented(false)} />
+      </Modal>
+    </View>
+  )
+}
+```
+
+### Sign-in only
+
+```tsx
+<AuthView mode="signIn" />
+```
+
+### Sign-up only
+
+```tsx
+<AuthView mode="signUp" />
+```
+
+### Render as a required full-screen view
+
+You can render `<AuthView />` directly in a full-screen view when users must authenticate before continuing. In this case, pass `isDismissible={false}` so the native dismiss button isn't shown.
 
 ```tsx {{ filename: 'app/(auth)/sign-in.tsx' }}
 import { AuthView } from '@clerk/expo/native'
@@ -39,53 +92,6 @@ export default function SignInScreen() {
 
   return <AuthView isDismissible={false} />
 }
-```
-
-### Sign-in only
-
-```tsx
-<AuthView mode="signIn" isDismissible={false} />
-```
-
-### Sign-up only
-
-```tsx
-<AuthView mode="signUp" isDismissible={false} />
-```
-
-### Present in a React Native Modal
-
-The following example demonstrates how to render `<AuthView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
-
-```tsx {{ filename: 'app/(auth)/sign-in.tsx' }}
-import { AuthView } from '@clerk/expo/native'
-import { useState } from 'react'
-import { Button, Modal, View } from 'react-native'
-
-export default function SignedOut() {
-  const [isPresented, setIsPresented] = useState(false)
-
-  return (
-    <View>
-      <Button title="Sign in" onPress={() => setIsPresented(true)} />
-      <Modal
-        visible={isPresented}
-        presentationStyle="pageSheet"
-        onRequestClose={() => setIsPresented(false)}
-      >
-        <AuthView onDismiss={() => setIsPresented(false)} />
-      </Modal>
-    </View>
-  )
-}
-```
-
-### Dismissible auth view
-
-The following example enables the native dismiss button with the `isDismissable` prop.
-
-```tsx
-<AuthView isDismissable />
 ```
 
 ## Properties
@@ -112,7 +118,7 @@ The following example enables the native dismiss button with the `isDismissable`
   - `onDismiss`
   - `() => void`
 
-  A callback that runs when the user dismisses the native authentication view. Use this to update your app's presentation state, such as closing a React Native `<Modal>`.
+  A callback that runs when the native authentication view requests dismissal. Use this to update your app's presentation state, such as closing a React Native `<Modal>`. Use `useAuth()`, `useUser()`, or `useSession()` to read auth state after authentication changes.
 </Properties>
 
 ## Social connection (OAuth) configuration

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -25,15 +25,16 @@ The following example demonstrates one way to render `<AuthView />` inside a Rea
 
 ```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
-import { useAuth } from '@clerk/expo'
+import { useAuth, useUser } from '@clerk/expo'
 import { useState } from 'react'
-import { Button, Modal, View } from 'react-native'
+import { Button, Modal, Text, View } from 'react-native'
 
 export default function AuthButton() {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
+  const { user } = useUser()
 
   if (isSignedIn) {
-    return null
+    return <Text>Welcome, {user?.firstName}</Text>
   }
 
   return <SignedOutButton />

--- a/docs/reference/expo/native-components/auth-view.mdx
+++ b/docs/reference/expo/native-components/auth-view.mdx
@@ -27,6 +27,8 @@ The following example demonstrates one way to render `<AuthView />` inside a Rea
 
 <Include src="_partials/expo/session-sync-callout" />
 
+<Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
+
 ```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useAuth, useUser } from '@clerk/expo'

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -92,7 +92,7 @@ The native components handle authentication through the native Clerk SDKs ([cler
 
 ## Session synchronization
 
-Native components do not use component-specific auth-completion callbacks. Instead, use hooks like `useAuth()`, `useUser()`, or `useSession()` in a `useEffect` to react to authentication state changes.
+Native components do not use component-specific auth-completion callbacks. Instead, you can use hooks like `useAuth()`, `useUser()`, or `useSession()` to read authentication state and update your UI after auth changes.
 
 <Include src="_partials/expo/session-sync-callout" />
 

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -8,6 +8,8 @@ sdk: expo
 
 The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components provide a fully native authentication experience while automatically synchronizing with the JavaScript SDK.
 
+`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy. Your app owns the presentation surface, so you can place them in a route, a React Native `<Modal>`, a full-screen screen, or any other layout. `<UserButton />` renders the platform-native Clerk button and opens the native user profile surface when tapped.
+
 ## Available components
 
 | Component | Description |
@@ -90,7 +92,7 @@ The native components handle authentication through the native Clerk SDKs ([cler
 
 ## Session synchronization
 
-Native components do not use imperative callbacks. Instead, use hooks like `useAuth()`, `useUser()`, or `useSession()` in a `useEffect` to react to authentication state changes.
+Native components do not use component-specific auth-completion callbacks. Instead, use hooks like `useAuth()`, `useUser()`, or `useSession()` in a `useEffect` to react to authentication state changes.
 
 <Include src="_partials/expo/session-sync-callout" />
 
@@ -110,7 +112,7 @@ export default function SignInScreen() {
     }
   }, [isSignedIn])
 
-  return <AuthView mode="signInOrUp" />
+  return <AuthView isDismissible={false} />
 }
 ```
 
@@ -132,7 +134,7 @@ export default function ProfileScreen() {
     }
   }, [isSignedIn])
 
-  return <UserProfileView style={{ flex: 1 }} />
+  return <UserProfileView isDismissible={false} style={{ flex: 1 }} />
 }
 ```
 

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -91,7 +91,7 @@ The following example demonstrates one way to open [`<AuthView />`](/docs/refere
 
 <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
 
-```tsx {{ filename: 'app/index.tsx' }}
+```tsx {{ filename: 'src/app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useAuth, useUser } from '@clerk/expo'
 import { useState } from 'react'
@@ -136,7 +136,7 @@ When rendering [`<AuthView />`](/docs/reference/expo/native-components/auth-view
 
 For Expo web projects, use the web-specific components from `@clerk/expo/web`:
 
-```tsx {{ filename: 'app/sign-in.web.tsx' }}
+```tsx {{ filename: 'src/app/sign-in.web.tsx' }}
 import { SignIn } from '@clerk/expo/web'
 
 export default function SignInScreen() {

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -105,7 +105,7 @@ export default function HomeScreen() {
   return (
     <View>
       {isSignedIn ? (
-        <Text>Welcome, {user?.firstName}</Text>
+        <Text>User ID: {user?.id}</Text>
       ) : (
         <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
       )}

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -118,6 +118,7 @@ export default function HomeScreen() {
     <View>
       <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
       <Modal
+        animationType="slide"
         visible={isAuthOpen}
         presentationStyle="pageSheet"
         onRequestClose={() => setIsAuthOpen(false)}

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -87,7 +87,7 @@ Use hooks like `useAuth()`, `useUser()`, or `useSession()` to read authenticatio
 
 <Include src="_partials/expo/session-sync-callout" />
 
-The following example demonstrates one way to present `<AuthView />` from a signed-out view.
+The following example demonstrates one way to open `<AuthView />` from a sign-in button.
 
 <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
 

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -96,23 +96,26 @@ Native components do not use component-specific auth-completion callbacks. Inste
 
 <Include src="_partials/expo/session-sync-callout" />
 
-The following example demonstrates one way to present `<AuthView />` and close it when the user signs in.
+The following example demonstrates one way to present `<AuthView />` from a signed-out view.
 
 ```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useAuth } from '@clerk/expo'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Button, Modal, View } from 'react-native'
 
 export default function HomeScreen() {
-  const [isAuthOpen, setIsAuthOpen] = useState(false)
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
 
-  useEffect(() => {
-    if (isSignedIn) {
-      setIsAuthOpen(false)
-    }
-  }, [isSignedIn])
+  if (isSignedIn) {
+    return null
+  }
+
+  return <SignedOutButton />
+}
+
+function SignedOutButton() {
+  const [isAuthOpen, setIsAuthOpen] = useState(false)
 
   return (
     <View>

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -8,7 +8,7 @@ sdk: expo
 
 The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components provide a fully native authentication experience while automatically synchronizing with the JavaScript SDK.
 
-`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy. Your app owns the presentation surface, so the common pattern is to place them in a React Native `<Modal>`. You can also render them in a route, full-screen view, or any other layout. `<UserButton />` renders the platform-native Clerk button and opens the native user profile surface when tapped.
+`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy, so you can place them in a modal, route, full-screen view, or any other layout that fits your app. `<UserButton />` renders the platform-native Clerk button and opens the native user profile surface when tapped.
 
 ## Available components
 
@@ -96,7 +96,7 @@ Native components do not use component-specific auth-completion callbacks. Inste
 
 <Include src="_partials/expo/session-sync-callout" />
 
-The following example demonstrates how to present `<AuthView />` in a React Native `<Modal>` and close it when the user signs in.
+The following example demonstrates one way to present `<AuthView />` and close it when the user signs in.
 
 ```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
@@ -129,7 +129,7 @@ export default function HomeScreen() {
 }
 ```
 
-You can also render `<AuthView />` or `<UserProfileView />` directly in a route or full-screen view. In those cases, pass `isDismissible={false}` when the user must complete the flow to continue.
+When rendering `<AuthView />` or `<UserProfileView />` directly in a route or full-screen view, pass `isDismissible={false}` if users must complete the flow to continue.
 
 ```tsx
 <AuthView isDismissible={false} />

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -6,9 +6,9 @@ sdk: expo
 
 <Include src="_partials/expo/beta-callout" />
 
-The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components provide a fully native authentication experience while automatically synchronizing with the JavaScript SDK.
+The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components provide a fully native authentication experience for Expo apps.
 
-`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy, so you can place them in a modal, route, full-screen view, or any other layout that fits your app. `<UserButton />` renders the platform-native Clerk button and opens the native user profile surface when tapped.
+`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy, so you can place them in a modal, route, full-screen view, or any other layout that fits your app. `<UserButton />` renders the platform-native Clerk button and opens `<UserProfileView />` when tapped.
 
 ## Available components
 
@@ -81,18 +81,9 @@ The plugin accepts the following options:
 }
 ```
 
-## How it works
+## Respond to auth changes
 
-The native components handle authentication through the native Clerk SDKs ([clerk-ios](https://github.com/clerk/clerk-ios) and [clerk-android](https://github.com/clerk/clerk-android)). When authentication completes, the session is automatically synchronized to the JavaScript SDK:
-
-1. **Native Authentication** - User authenticates through the native UI
-1. **Session Created** - Native SDK creates and manages the session
-1. **Session Sync** - `@clerk/expo` syncs the native session to the JS SDK
-1. **JS SDK Ready** - All hooks (`useUser`, `useAuth`, `useSession`, etc.) reflect the authenticated state
-
-## Session synchronization
-
-Native components do not use component-specific auth-completion callbacks. Instead, you can use hooks like `useAuth()`, `useUser()`, or `useSession()` to read authentication state and update your UI after auth changes.
+Use hooks like `useAuth()`, `useUser()`, or `useSession()` to read authentication state and update your UI after auth changes.
 
 <Include src="_partials/expo/session-sync-callout" />
 
@@ -100,15 +91,16 @@ The following example demonstrates one way to present `<AuthView />` from a sign
 
 ```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
-import { useAuth } from '@clerk/expo'
+import { useAuth, useUser } from '@clerk/expo'
 import { useState } from 'react'
-import { Button, Modal, View } from 'react-native'
+import { Button, Modal, Text, View } from 'react-native'
 
 export default function HomeScreen() {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
+  const { user } = useUser()
 
   if (isSignedIn) {
-    return null
+    return <Text>Welcome, {user?.firstName}</Text>
   }
 
   return <SignedOutButton />

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -89,6 +89,8 @@ Use hooks like `useAuth()`, `useUser()`, or `useSession()` to read authenticatio
 
 The following example demonstrates one way to present `<AuthView />` from a signed-out view.
 
+<Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
+
 ```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useAuth, useUser } from '@clerk/expo'

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -83,11 +83,11 @@ The plugin accepts the following options:
 
 ## Respond to auth changes
 
-Use hooks like `useAuth()`, `useUser()`, or `useSession()` to read authentication state and update your UI after auth changes.
+Use hooks like [`useAuth()`](/docs/reference/hooks/use-auth), [`useUser()`](/docs/reference/hooks/use-user), or [`useSession()`](/docs/reference/hooks/use-session) to read authentication state and update your UI after auth changes.
 
 <Include src="_partials/expo/session-sync-callout" />
 
-The following example demonstrates one way to open `<AuthView />` from a sign-in button.
+The following example demonstrates one way to open [`<AuthView />`](/docs/reference/expo/native-components/auth-view) from a sign-in button.
 
 <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
 
@@ -122,7 +122,7 @@ export default function HomeScreen() {
 }
 ```
 
-When rendering `<AuthView />` or `<UserProfileView />` directly in a route or full-screen view, pass `isDismissible={false}` if users must complete the flow to continue.
+When rendering [`<AuthView />`](/docs/reference/expo/native-components/auth-view) or [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view) directly in a route or full-screen view, pass `isDismissible={false}` if users must complete the flow to continue.
 
 ```tsx
 <AuthView isDismissible={false} />

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -98,20 +98,15 @@ import { Button, Modal, Text, View } from 'react-native'
 export default function HomeScreen() {
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
   const { user } = useUser()
-
-  if (isSignedIn) {
-    return <Text>Welcome, {user?.firstName}</Text>
-  }
-
-  return <SignedOutButton />
-}
-
-function SignedOutButton() {
   const [isAuthOpen, setIsAuthOpen] = useState(false)
 
   return (
     <View>
-      <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
+      {isSignedIn ? (
+        <Text>Welcome, {user?.firstName}</Text>
+      ) : (
+        <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
+      )}
       <Modal
         animationType="slide"
         visible={isAuthOpen}

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -8,7 +8,7 @@ sdk: expo
 
 The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components provide a fully native authentication experience while automatically synchronizing with the JavaScript SDK.
 
-`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy. Your app owns the presentation surface, so you can place them in a route, a React Native `<Modal>`, a full-screen screen, or any other layout. `<UserButton />` renders the platform-native Clerk button and opens the native user profile surface when tapped.
+`<AuthView />` and `<UserProfileView />` render inline in your React Native view hierarchy. Your app owns the presentation surface, so the common pattern is to place them in a React Native `<Modal>`. You can also render them in a route, full-screen view, or any other layout. `<UserButton />` renders the platform-native Clerk button and opens the native user profile surface when tapped.
 
 ## Available components
 
@@ -96,46 +96,47 @@ Native components do not use component-specific auth-completion callbacks. Inste
 
 <Include src="_partials/expo/session-sync-callout" />
 
-```tsx {{ filename: 'app/(auth)/sign-in.tsx' }}
+The following example demonstrates how to present `<AuthView />` in a React Native `<Modal>` and close it when the user signs in.
+
+```tsx {{ filename: 'app/index.tsx' }}
 import { AuthView } from '@clerk/expo/native'
 import { useAuth } from '@clerk/expo'
-import { useRouter } from 'expo-router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { Button, Modal, View } from 'react-native'
 
-export default function SignInScreen() {
+export default function HomeScreen() {
+  const [isAuthOpen, setIsAuthOpen] = useState(false)
   const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
-  const router = useRouter()
 
   useEffect(() => {
     if (isSignedIn) {
-      router.replace('/(home)')
+      setIsAuthOpen(false)
     }
   }, [isSignedIn])
 
-  return <AuthView isDismissible={false} />
+  return (
+    <View>
+      <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
+      <Modal
+        visible={isAuthOpen}
+        presentationStyle="pageSheet"
+        onRequestClose={() => setIsAuthOpen(false)}
+      >
+        <AuthView onDismiss={() => setIsAuthOpen(false)} />
+      </Modal>
+    </View>
+  )
 }
 ```
 
-The same pattern applies to sign-out detection:
+You can also render `<AuthView />` or `<UserProfileView />` directly in a route or full-screen view. In those cases, pass `isDismissible={false}` when the user must complete the flow to continue.
 
-```tsx {{ filename: 'app/(home)/profile.tsx' }}
-import { UserProfileView } from '@clerk/expo/native'
-import { useAuth } from '@clerk/expo'
-import { useRouter } from 'expo-router'
-import { useEffect } from 'react'
+```tsx
+<AuthView isDismissible={false} />
+```
 
-export default function ProfileScreen() {
-  const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
-  const router = useRouter()
-
-  useEffect(() => {
-    if (!isSignedIn) {
-      router.replace('/(auth)/sign-in')
-    }
-  }, [isSignedIn])
-
-  return <UserProfileView isDismissible={false} style={{ flex: 1 }} />
-}
+```tsx
+<UserProfileView isDismissible={false} style={{ flex: 1 }} />
 ```
 
 ## Web compatibility

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -8,9 +8,6 @@ sdk: expo
 
 You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
 
-> [!NOTE]
-> The `<UserButton />` doesn't accept style or appearance props. It renders through the native SDK and uses the theme configured by the `@clerk/expo` plugin.
-
 ## Configure the plugin
 
 Create a `clerk-theme.json` file in your project and reference it from the plugin in your `app.json`:

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -27,6 +27,8 @@ Create a `clerk-theme.json` file in your project and reference it from the plugi
 }
 ```
 
+## Apply the theme
+
 Run `npx expo prebuild --clean` (or rerun `npx expo run:ios` / `npx expo run:android`) so the plugin picks up the theme. The JSON is validated during prebuild — invalid hex colors or value types will fail the build with a descriptive error.
 
 ## Theme schema
@@ -103,16 +105,9 @@ When `darkColors` is provided, native components automatically use the dark pale
 > [!NOTE]
 > Custom font families are currently iOS-only. Android uses the system font.
 
-## How it works
-
-The plugin runs during `expo prebuild`:
-
-- **iOS:** the parsed theme is embedded in `Info.plist` under the `ClerkTheme` key. At runtime, the iOS components read it and apply the light or dark palette based on the current system appearance via SwiftUI's environment.
-- **Android:** the JSON is copied to `android/app/src/main/assets/clerk_theme.json`. At runtime the Android module parses it and assigns it to `Clerk.customTheme`.
-
 The plugin does not modify your app's `userInterfaceStyle` setting. To control whether your app follows the system appearance or is pinned to light/dark mode, set `"userInterfaceStyle"` in your `app.json`.
 
-Because the theme is applied at the native layer, it only affects the native views (`<AuthView />`, `<UserProfileView />`, and `<UserButton />`). It does not affect web components or other React Native UI elements in your app.
+Theme changes only affect the native views (`<AuthView />`, `<UserProfileView />`, and `<UserButton />`). They do not affect web components or other React Native UI elements in your app.
 
 ## Troubleshooting
 
@@ -134,4 +129,4 @@ Make sure you're providing `darkColors` and that `"userInterfaceStyle"` is set t
 
 ### I removed the `theme` prop but the old theme is still applied
 
-Run `npx expo prebuild --clean` after removing the `theme` option. Incremental prebuilds don't clean up previously embedded theme data from `Info.plist` or `android/app/src/main/assets/clerk_theme.json`.
+Run `npx expo prebuild --clean` after removing the `theme` option. Incremental prebuilds can keep previously generated native files.

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -6,7 +6,7 @@ sdk: expo
 
 <Include src="_partials/expo/beta-callout" />
 
-You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
+You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
 
 ## Configure the plugin
 

--- a/docs/reference/expo/native-components/theming.mdx
+++ b/docs/reference/expo/native-components/theming.mdx
@@ -6,10 +6,10 @@ sdk: expo
 
 <Include src="_partials/expo/beta-callout" />
 
-You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and the profile modal opened by `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
+You can customize the appearance of Clerk's [Expo native components](/docs/reference/expo/native-components/overview) (`<AuthView />`, `<UserProfileView />`, and `<UserButton />`) by passing a `theme` option to the `@clerk/expo` config plugin. The plugin reads a JSON file at prebuild time and applies it to both iOS and Android.
 
 > [!NOTE]
-> The `<UserButton />` avatar itself is a React Native component and is not affected by the theme.
+> The `<UserButton />` doesn't accept style or appearance props. It renders through the native SDK and uses the theme configured by the `@clerk/expo` plugin.
 
 ## Configure the plugin
 
@@ -115,7 +115,7 @@ The plugin runs during `expo prebuild`:
 
 The plugin does not modify your app's `userInterfaceStyle` setting. To control whether your app follows the system appearance or is pinned to light/dark mode, set `"userInterfaceStyle"` in your `app.json`.
 
-Because the theme is applied at the native layer, it only affects the native views (`<AuthView />`, `<UserProfileView />`, and the profile modal opened by `<UserButton />`). It does not affect web components or React Native UI elements like the `<UserButton />` avatar itself.
+Because the theme is applied at the native layer, it only affects the native views (`<AuthView />`, `<UserProfileView />`, and `<UserButton />`). It does not affect web components or other React Native UI elements in your app.
 
 ## Troubleshooting
 

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -36,6 +36,7 @@ export default function Screen() {
       <Show when="signed-out">
         <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
         <Modal
+          animationType="slide"
           visible={isAuthOpen}
           presentationStyle="pageSheet"
           onRequestClose={() => setIsAuthOpen(false)}

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -25,13 +25,13 @@ In addition to these requirements, this component requires the user to be signed
 import { Show } from '@clerk/expo'
 import { AuthView, UserButton } from '@clerk/expo/native'
 import { useState } from 'react'
-import { Button, Modal } from 'react-native'
+import { Button, Modal, StyleSheet, View } from 'react-native'
 
 export default function Screen() {
   const [isAuthOpen, setIsAuthOpen] = useState(false)
 
   return (
-    <>
+    <View style={styles.container}>
       <Show when="signed-in">
         <UserButton />
       </Show>
@@ -46,9 +46,17 @@ export default function Screen() {
       >
         <AuthView onDismiss={() => setIsAuthOpen(false)} />
       </Modal>
-    </>
+    </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+})
 ```
 
 ## Usage
@@ -68,7 +76,7 @@ export default function HomeScreen() {
   return (
     <View style={{ flex: 1, padding: 20 }}>
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Text style={{ fontSize: 24 }}>Welcome, {user?.fullName}</Text>
+        <Text style={{ fontSize: 24 }}>User ID: {user?.id}</Text>
         <UserButton />
       </View>
     </View>

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -86,7 +86,7 @@ export default function HomeScreen() {
 
 ### In a header
 
-The following example configures the header for the `app/(home)/index.tsx` route. Make sure that route exists in the same route group.
+The following example configures the header for screens in the `(home)` route group. Make sure the route group contains an `index.tsx` route.
 
 ```tsx {{ filename: 'src/app/(home)/_layout.tsx' }}
 import { View } from 'react-native'

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -7,11 +7,7 @@ sdk: expo
 > [!NOTE]
 > This documents the native `<UserButton />` from `@clerk/expo/native`. For web projects, use the [web `<UserButton />` component](/docs/reference/components/user/user-button).
 
-The `<UserButton />` component renders the platform-native Clerk user button. It displays the user's profile image or initials, and when tapped, it opens the native profile management surface powered by [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
-
-Sign-out is handled automatically and synced with the JavaScript SDK. You can use `useAuth()` to read the user's updated auth state after sign-out.
-
-Use a parent `<View>` for surrounding layout, such as margin or alignment.
+The `<UserButton />` component renders the platform-native Clerk user button. It displays the user's profile image or initials, and when tapped, it opens [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
 
 ## Requirements
 
@@ -108,7 +104,7 @@ export default function HomeLayout() {
 
 ## Properties
 
-The `<UserButton />` component does not accept any props. It uses the native SDK to render the avatar and present the profile surface.
+The `<UserButton />` component does not accept any props. It renders the avatar and opens [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
 
 ## Platform support
 

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -7,6 +7,10 @@ sdk: expo
 > [!NOTE]
 > This documents the native `<UserButton />` from `@clerk/expo/native`. For web projects, use the [web `<UserButton />` component](/docs/reference/components/user/user-button).
 
+| iOS | Android |
+| - | - |
+| ![The UserButton is a circular button that displays the signed-in user's profile image on iOS.](/docs/images/ui-components/ios-user-button.png){{ width: 320, height: 98, style: { objectFit: 'contain' } }} | ![The UserButton is a circular button that displays the signed-in user's profile image on Android.](/docs/images/ui-components/android-user-button.png){{ width: 320, height: 98, style: { objectFit: 'contain' } }} |
+
 The `<UserButton />` component renders the platform-native Clerk user button. It displays the user's profile image or initials, and when tapped, it opens [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
 
 ## Requirements

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -9,7 +9,7 @@ sdk: expo
 
 The `<UserButton />` component renders the platform-native Clerk user button. It displays the user's profile image or initials, and when tapped, it opens the native profile management surface powered by [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
 
-Sign-out is handled automatically and synced with the JavaScript SDK. If you need to react to sign-out, use `useAuth()` inside a `useEffect`.
+Sign-out is handled automatically and synced with the JavaScript SDK. You can use `useAuth()` to read the user's updated auth state after sign-out.
 
 Use a parent `<View>` for surrounding layout, such as margin or alignment.
 

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -19,6 +19,8 @@ The `<UserButton />` component renders the platform-native Clerk user button. It
 
 In addition to these requirements, this component requires the user to be signed in. The following example demonstrates how to use the [`<Show>`](/docs/reference/components/control/show) component to check if the user is signed in and render the `<UserButton />` or a **Sign in** button accordingly.
 
+<Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
+
 ```tsx {{ filename: 'app/(home)/index.tsx' }}
 import { Show } from '@clerk/expo'
 import { AuthView, UserButton } from '@clerk/expo/native'

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -17,20 +17,31 @@ Use a parent `<View>` for surrounding layout, such as margin or alignment.
 
 <Include src="_partials/expo/expo-requirements-callout" />
 
-In addition to these requirements, this component requires the user to be signed in. The following example demonstrates how to use the [`<Show>`](/docs/reference/components/control/show) component to check if the user is signed in and render the `<UserButton />` or `<AuthView />` accordingly.
+In addition to these requirements, this component requires the user to be signed in. The following example demonstrates how to use the [`<Show>`](/docs/reference/components/control/show) component to check if the user is signed in and render the `<UserButton />` or a **Sign in** button accordingly.
 
 ```tsx {{ filename: 'app/(home)/index.tsx' }}
 import { Show } from '@clerk/expo'
 import { AuthView, UserButton } from '@clerk/expo/native'
+import { useState } from 'react'
+import { Button, Modal } from 'react-native'
 
 export default function Screen() {
+  const [isAuthOpen, setIsAuthOpen] = useState(false)
+
   return (
     <>
       <Show when="signed-in">
         <UserButton />
       </Show>
       <Show when="signed-out">
-        <AuthView isDismissible={false} />
+        <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
+        <Modal
+          visible={isAuthOpen}
+          presentationStyle="pageSheet"
+          onRequestClose={() => setIsAuthOpen(false)}
+        >
+          <AuthView onDismiss={() => setIsAuthOpen(false)} />
+        </Modal>
       </Show>
     </>
   )

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -26,24 +26,16 @@ import { useState } from 'react'
 import { Button, Modal } from 'react-native'
 
 export default function Screen() {
+  const [isAuthOpen, setIsAuthOpen] = useState(false)
+
   return (
     <>
       <Show when="signed-in">
         <UserButton />
       </Show>
       <Show when="signed-out">
-        <SignedOutButton />
+        <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
       </Show>
-    </>
-  )
-}
-
-function SignedOutButton() {
-  const [isAuthOpen, setIsAuthOpen] = useState(false)
-
-  return (
-    <>
-      <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
       <Modal
         animationType="slide"
         visible={isAuthOpen}

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -7,11 +7,11 @@ sdk: expo
 > [!NOTE]
 > This documents the native `<UserButton />` from `@clerk/expo/native`. For web projects, use the [web `<UserButton />` component](/docs/reference/components/user/user-button).
 
-The `<UserButton />` component renders an avatar that displays the user's profile image or initials. When tapped, it opens a native profile management modal powered by [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
+The `<UserButton />` component renders the platform-native Clerk user button. It displays the user's profile image or initials, and when tapped, it opens the native profile management surface powered by [`<UserProfileView />`](/docs/reference/expo/native-components/user-profile-view).
 
 Sign-out is handled automatically and synced with the JavaScript SDK. If you need to react to sign-out, use `useAuth()` inside a `useEffect`.
 
-The component fills its parent container - use the parent's styles to control size, shape, border radius, and clipping.
+Use a parent `<View>` for surrounding layout, such as margin or alignment.
 
 ## Requirements
 
@@ -22,18 +22,15 @@ In addition to these requirements, this component requires the user to be signed
 ```tsx {{ filename: 'app/(home)/index.tsx' }}
 import { Show } from '@clerk/expo'
 import { AuthView, UserButton } from '@clerk/expo/native'
-import { View } from 'react-native'
 
 export default function Screen() {
   return (
     <>
       <Show when="signed-in">
-        <View style={{ width: 36, height: 36, borderRadius: 18, overflow: 'hidden' }}>
-          <UserButton />
-        </View>
+        <UserButton />
       </Show>
       <Show when="signed-out">
-        <AuthView />
+        <AuthView isDismissible={false} />
       </Show>
     </>
   )
@@ -58,9 +55,7 @@ export default function HomeScreen() {
     <View style={{ flex: 1, padding: 20 }}>
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
         <Text style={{ fontSize: 24 }}>Welcome, {user?.fullName}</Text>
-        <View style={{ width: 36, height: 36, borderRadius: 18, overflow: 'hidden' }}>
-          <UserButton />
-        </View>
+        <UserButton />
       </View>
     </View>
   )
@@ -79,9 +74,7 @@ export default function HomeLayout() {
     <Stack
       screenOptions={{
         headerRight: () => (
-          <View
-            style={{ width: 36, height: 36, borderRadius: 18, overflow: 'hidden', marginRight: 16 }}
-          >
+          <View style={{ marginRight: 16 }}>
             <UserButton />
           </View>
         ),
@@ -95,7 +88,7 @@ export default function HomeLayout() {
 
 ## Properties
 
-The `<UserButton />` component does not accept any props. It fills its parent container — use the parent's style to control size, shape, border radius, and clipping.
+The `<UserButton />` component does not accept any props. It uses the native SDK to render the avatar and present the profile surface.
 
 ## Platform support
 

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -21,7 +21,7 @@ In addition to these requirements, this component requires the user to be signed
 
 <Include src="_partials/expo/auth-view-modal-lifecycle-callout" />
 
-```tsx {{ filename: 'app/(home)/index.tsx' }}
+```tsx {{ filename: 'src/app/(home)/index.tsx' }}
 import { Show } from '@clerk/expo'
 import { AuthView, UserButton } from '@clerk/expo/native'
 import { useState } from 'react'
@@ -65,7 +65,7 @@ The following examples show how to use the `<UserButton />` in your Expo app.
 
 ### Basic usage
 
-```tsx {{ filename: 'app/(home)/index.tsx' }}
+```tsx {{ filename: 'src/app/(home)/index.tsx' }}
 import { View, Text } from 'react-native'
 import { UserButton } from '@clerk/expo/native'
 import { useUser } from '@clerk/expo'
@@ -88,7 +88,7 @@ export default function HomeScreen() {
 
 The following example configures the header for the `app/(home)/index.tsx` route. Make sure that route exists in the same route group.
 
-```tsx {{ filename: 'app/(home)/_layout.tsx' }}
+```tsx {{ filename: 'src/app/(home)/_layout.tsx' }}
 import { View } from 'react-native'
 import { Stack } from 'expo-router'
 import { UserButton } from '@clerk/expo/native'

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -86,6 +86,8 @@ export default function HomeScreen() {
 
 ### In a header
 
+The following example configures the header for the `app/(home)/index.tsx` route. Make sure that route exists in the same route group.
+
 ```tsx {{ filename: 'app/(home)/_layout.tsx' }}
 import { View } from 'react-native'
 import { Stack } from 'expo-router'

--- a/docs/reference/expo/native-components/user-button.mdx
+++ b/docs/reference/expo/native-components/user-button.mdx
@@ -26,24 +26,32 @@ import { useState } from 'react'
 import { Button, Modal } from 'react-native'
 
 export default function Screen() {
-  const [isAuthOpen, setIsAuthOpen] = useState(false)
-
   return (
     <>
       <Show when="signed-in">
         <UserButton />
       </Show>
       <Show when="signed-out">
-        <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
-        <Modal
-          animationType="slide"
-          visible={isAuthOpen}
-          presentationStyle="pageSheet"
-          onRequestClose={() => setIsAuthOpen(false)}
-        >
-          <AuthView onDismiss={() => setIsAuthOpen(false)} />
-        </Modal>
+        <SignedOutButton />
       </Show>
+    </>
+  )
+}
+
+function SignedOutButton() {
+  const [isAuthOpen, setIsAuthOpen] = useState(false)
+
+  return (
+    <>
+      <Button title="Sign in" onPress={() => setIsAuthOpen(true)} />
+      <Modal
+        animationType="slide"
+        visible={isAuthOpen}
+        presentationStyle="pageSheet"
+        onRequestClose={() => setIsAuthOpen(false)}
+      >
+        <AuthView onDismiss={() => setIsAuthOpen(false)} />
+      </Modal>
     </>
   )
 }

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -43,6 +43,7 @@ Use the following tabs to select an example.
         <View>
           <Button title="Account" onPress={() => setIsPresented(true)} />
           <Modal
+            animationType="slide"
             visible={isPresented}
             presentationStyle="pageSheet"
             onRequestClose={() => setIsPresented(false)}

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -34,13 +34,13 @@ The `<UserProfileView />` renders inline in your React Native view hierarchy, so
     ```tsx {{ filename: 'app/(home)/index.tsx' }}
     import { UserProfileView } from '@clerk/expo/native'
     import { useState } from 'react'
-    import { Button, Modal, View } from 'react-native'
+    import { Button, Modal, StyleSheet, View } from 'react-native'
 
     export default function HomeScreen() {
       const [isAuthOpen, setIsAuthOpen] = useState(false)
 
       return (
-        <View>
+        <View style={styles.container}>
           <Button title="Account" onPress={() => setIsAuthOpen(true)} />
           <Modal
             animationType="slide"
@@ -53,6 +53,14 @@ The `<UserProfileView />` renders inline in your React Native view hierarchy, so
         </View>
       )
     }
+
+    const styles = StyleSheet.create({
+      container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+      },
+    })
     ```
   </Tab>
 

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -68,14 +68,14 @@ The `<UserProfileView />` renders inline in your React Native view hierarchy, so
     import { useEffect } from 'react'
 
     export default function ProfileScreen() {
-      const { isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
+      const { isLoaded, isSignedIn } = useAuth({ treatPendingAsSignedOut: false })
       const router = useRouter()
 
       useEffect(() => {
-        if (!isSignedIn) {
+        if (isLoaded && !isSignedIn) {
           router.replace('/(auth)/sign-in')
         }
-      }, [isSignedIn])
+      }, [isLoaded, isSignedIn, router])
 
       return <UserProfileView isDismissible={false} style={{ flex: 1 }} />
     }

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -21,107 +21,37 @@ The `<UserProfileView />` component renders a fully native profile management in
 
 ## Usage
 
-There are **three ways** to render the profile view in an Expo app:
+The `<UserProfileView />` renders inline in your React Native view hierarchy. Your app owns the presentation surface, so you can render it in a React Native `<Modal>`, sheet, route, or directly in your layout.
 
-1. **Native modal (recommended):** Use the `useUserProfileModal()` hook to present the profile view as a native modal (SwiftUI/Jetpack Compose). This uses a native `X` button for dismissal.
-1. **React Native Modal:** Wrap the inline `<UserProfileView />` in a React Native `<Modal>` component. You must provide your own close button to dismiss the modal.
-1. **Inline:** Render `<UserProfileView />` directly in your layout without a modal.
-
-If you need to react to sign-out, use `useAuth()` inside a `useEffect`.
+If you need to react to sign-out, use `useAuth()` inside a `useEffect`. Sign-out from the native profile view is automatically synced with the JavaScript SDK.
 
 Use the following tabs to select your preferred approach.
 
-<Tabs items={["Using Native modal (recommended)", "Using a React Native Modal", "Inline"]}>
+<Tabs items={["Using a React Native Modal", "Inline"]}>
   <Tab>
-    The `useUserProfileModal()` hook provides an imperative `presentUserProfile()` function that opens the native profile modal directly from a button press. No component is needed.
+    The following example demonstrates how to render `<UserProfileView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
 
     ```tsx {{ filename: 'app/(home)/index.tsx' }}
-    import { useUserProfileModal } from '@clerk/expo'
-    import { Text, TouchableOpacity, View } from 'react-native'
-
-    export default function HomeScreen() {
-      const { presentUserProfile } = useUserProfileModal()
-
-      return (
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <TouchableOpacity onPress={presentUserProfile}>
-            <Text>Manage Profile</Text>
-          </TouchableOpacity>
-        </View>
-      )
-    }
-    ```
-
-    #### `useUserProfileModal()` return values
-
-    <Properties>
-      - `presentUserProfile`
-      - `() => Promise<void>`
-
-      Opens the native profile modal. The promise resolves when the modal is dismissed. If the user signs out from within the modal, the JS SDK session is automatically cleared.
-
-      ---
-
-      - `isAvailable`
-      - `boolean`
-
-      Whether the native module supports presenting the profile modal. Returns `false` on web or when the `@clerk/expo` plugin is not installed.
-
-      ---
-
-      - `sessions`
-      - <code>Ref\<[Session](/docs/reference/objects/session)></code>
-
-      A list of sessions that have been registered on the client device.
-    </Properties>
-  </Tab>
-
-  <Tab>
-    When rendering inside a React Native `<Modal>`, ensure `isDismissable` is set to `false` (the default) and provide your own close button to dismiss the modal.
-
-    > [!IMPORTANT]
-    > Do not use `useUserProfileModal()` when rendering inside a React Native `<Modal>`. The native modal system and React Native Modal are separate presentation layers and cannot coordinate dismissal. Use one approach or the other, not both.
-
-    ```tsx {{ filename: 'app/(home)/index.tsx' }}
-    import { useState } from 'react'
-    import { View, Text, TouchableOpacity, Modal, StyleSheet } from 'react-native'
     import { UserProfileView } from '@clerk/expo/native'
+    import { useState } from 'react'
+    import { Button, Modal, View } from 'react-native'
 
     export default function HomeScreen() {
-      const [showProfile, setShowProfile] = useState(false)
+      const [isPresented, setIsPresented] = useState(false)
 
       return (
-        <View style={{ flex: 1 }}>
-          <TouchableOpacity onPress={() => setShowProfile(true)}>
-            <Text>Open Profile</Text>
-          </TouchableOpacity>
-
-          <Modal visible={showProfile} animationType="slide">
-            <View style={styles.modalHeader}>
-              <TouchableOpacity onPress={() => setShowProfile(false)}>
-                <Text style={styles.closeButton}>Close</Text>
-              </TouchableOpacity>
-            </View>
-            <UserProfileView />
+        <View>
+          <Button title="Account" onPress={() => setIsPresented(true)} />
+          <Modal
+            visible={isPresented}
+            presentationStyle="pageSheet"
+            onRequestClose={() => setIsPresented(false)}
+          >
+            <UserProfileView onDismiss={() => setIsPresented(false)} />
           </Modal>
         </View>
       )
     }
-
-    const styles = StyleSheet.create({
-      modalHeader: {
-        paddingTop: 60,
-        paddingHorizontal: 20,
-        paddingBottom: 8,
-        alignItems: 'flex-end',
-        backgroundColor: '#fff',
-      },
-      closeButton: {
-        color: '#007AFF',
-        fontSize: 17,
-        fontWeight: '600',
-      },
-    })
     ```
   </Tab>
 
@@ -146,30 +76,34 @@ Use the following tabs to select your preferred approach.
         }
       }, [isSignedIn])
 
-      return <UserProfileView style={{ flex: 1 }} />
+      return <UserProfileView isDismissible={false} style={{ flex: 1 }} />
     }
     ```
-
-    ## Properties
-
-    <Properties>
-      - `isDismissable`
-      - `boolean`
-
-      Whether the inline profile view can be dismissed by the user. When `true`, a dismiss button appears. This does not present a modal — to present a native modal, use the `useUserProfileModal()` hook instead. Defaults to `false`.
-
-      > [!IMPORTANT]
-      > Do not set `isDismissable={true}` when rendering inside a React Native `<Modal>`. The native dismiss button relies on SwiftUI (iOS) or Jetpack Compose (Android) to close the view, which cannot dismiss a React Native `<Modal>`. Tapping the native dismiss button will not close the modal and may leave the screen unresponsive.
-
-      ---
-
-      - `style`
-      - `StyleProp<ViewStyle>`
-
-      Style applied to the container view.
-    </Properties>
   </Tab>
 </Tabs>
+
+## Properties
+
+<Properties>
+  - `isDismissible`
+  - `boolean`
+
+  Whether the profile view can be dismissed by the user. When `true`, a dismiss button appears in the native navigation bar. When `false`, no dismiss button is shown. Defaults to `true`.
+
+  ---
+
+  - `onDismiss`
+  - `() => void`
+
+  A callback that runs when the user dismisses the native profile view. Use this to update your app's presentation state, such as closing a React Native `<Modal>`.
+
+  ---
+
+  - `style`
+  - `StyleProp<ViewStyle>`
+
+  Style applied to the container view.
+</Properties>
 
 ## Platform support
 

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -37,18 +37,18 @@ The `<UserProfileView />` renders inline in your React Native view hierarchy, so
     import { Button, Modal, View } from 'react-native'
 
     export default function HomeScreen() {
-      const [isPresented, setIsPresented] = useState(false)
+      const [isAuthOpen, setIsAuthOpen] = useState(false)
 
       return (
         <View>
-          <Button title="Account" onPress={() => setIsPresented(true)} />
+          <Button title="Account" onPress={() => setIsAuthOpen(true)} />
           <Modal
             animationType="slide"
-            visible={isPresented}
+            visible={isAuthOpen}
             presentationStyle="pageSheet"
-            onRequestClose={() => setIsPresented(false)}
+            onRequestClose={() => setIsAuthOpen(false)}
           >
-            <UserProfileView onDismiss={() => setIsPresented(false)} />
+            <UserProfileView onDismiss={() => setIsAuthOpen(false)} />
           </Modal>
         </View>
       )

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -21,15 +21,15 @@ The `<UserProfileView />` component renders a fully native profile management in
 
 ## Usage
 
-The `<UserProfileView />` renders inline in your React Native view hierarchy. Your app owns the presentation surface, so the common pattern is to render it in a React Native `<Modal>`. You can also render it in a sheet, route, or directly in your layout.
+The `<UserProfileView />` renders inline in your React Native view hierarchy, so you can place it in a modal, sheet, route, full-screen view, or any other layout that fits your app.
 
 If you need to react to sign-out, use `useAuth()` inside a `useEffect`. Sign-out from the native profile view is automatically synced with the JavaScript SDK.
 
-Use the following tabs to select your preferred approach.
+Use the following tabs to select an example.
 
-<Tabs items={["Using a React Native Modal", "Full-screen view"]}>
+<Tabs items={["Modal", "Full-screen view"]}>
   <Tab>
-    The following example demonstrates how to render `<UserProfileView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
+    The following example demonstrates one way to render `<UserProfileView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
 
     ```tsx {{ filename: 'app/(home)/index.tsx' }}
     import { UserProfileView } from '@clerk/expo/native'
@@ -56,7 +56,7 @@ Use the following tabs to select your preferred approach.
   </Tab>
 
   <Tab>
-    You can render `<UserProfileView />` directly in a full-screen view when users should manage their profile without a modal. In this case, pass `isDismissible={false}` so the native dismiss button isn't shown.
+    When rendering `<UserProfileView />` directly in a full-screen view, pass `isDismissible={false}` if users shouldn't be able to dismiss the view.
 
     <Include src="_partials/expo/session-sync-callout" />
 

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -31,7 +31,7 @@ The `<UserProfileView />` renders inline in your React Native view hierarchy, so
   <Tab>
     The following example demonstrates one way to render `<UserProfileView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
 
-    ```tsx {{ filename: 'app/(home)/index.tsx' }}
+    ```tsx {{ filename: 'src/app/(home)/index.tsx' }}
     import { UserProfileView } from '@clerk/expo/native'
     import { useState } from 'react'
     import { Button, Modal, StyleSheet, View } from 'react-native'
@@ -69,7 +69,7 @@ The `<UserProfileView />` renders inline in your React Native view hierarchy, so
 
     <Include src="_partials/expo/session-sync-callout" />
 
-    ```tsx {{ filename: 'app/(home)/profile.tsx' }}
+    ```tsx {{ filename: 'src/app/(home)/profile.tsx' }}
     import { UserProfileView } from '@clerk/expo/native'
     import { useAuth } from '@clerk/expo'
     import { useRouter } from 'expo-router'

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -21,13 +21,13 @@ The `<UserProfileView />` component renders a fully native profile management in
 
 ## Usage
 
-The `<UserProfileView />` renders inline in your React Native view hierarchy. Your app owns the presentation surface, so you can render it in a React Native `<Modal>`, sheet, route, or directly in your layout.
+The `<UserProfileView />` renders inline in your React Native view hierarchy. Your app owns the presentation surface, so the common pattern is to render it in a React Native `<Modal>`. You can also render it in a sheet, route, or directly in your layout.
 
 If you need to react to sign-out, use `useAuth()` inside a `useEffect`. Sign-out from the native profile view is automatically synced with the JavaScript SDK.
 
 Use the following tabs to select your preferred approach.
 
-<Tabs items={["Using a React Native Modal", "Inline"]}>
+<Tabs items={["Using a React Native Modal", "Full-screen view"]}>
   <Tab>
     The following example demonstrates how to render `<UserProfileView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.
 
@@ -56,7 +56,7 @@ Use the following tabs to select your preferred approach.
   </Tab>
 
   <Tab>
-    You can render `<UserProfileView />` directly in your layout without a modal. This is useful for dedicated profile screens.
+    You can render `<UserProfileView />` directly in a full-screen view when users should manage their profile without a modal. In this case, pass `isDismissible={false}` so the native dismiss button isn't shown.
 
     <Include src="_partials/expo/session-sync-callout" />
 

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -23,10 +23,6 @@ The `<UserProfileView />` component renders a fully native profile management in
 
 The `<UserProfileView />` renders inline in your React Native view hierarchy, so you can place it in a modal, sheet, route, full-screen view, or any other layout that fits your app.
 
-Sign-out from the native profile view is automatically synced with the JavaScript SDK. You can use `useAuth()` to read the user's updated auth state after sign-out.
-
-Use the following tabs to select an example.
-
 <Tabs items={["Modal", "Full-screen view"]}>
   <Tab>
     The following example demonstrates one way to render `<UserProfileView />` inside a React Native `<Modal>`. The native dismiss button is shown by default. Use `onDismiss` to close the modal in React Native state.

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -23,7 +23,7 @@ The `<UserProfileView />` component renders a fully native profile management in
 
 The `<UserProfileView />` renders inline in your React Native view hierarchy, so you can place it in a modal, sheet, route, full-screen view, or any other layout that fits your app.
 
-If you need to react to sign-out, use `useAuth()` inside a `useEffect`. Sign-out from the native profile view is automatically synced with the JavaScript SDK.
+Sign-out from the native profile view is automatically synced with the JavaScript SDK. You can use `useAuth()` to read the user's updated auth state after sign-out.
 
 Use the following tabs to select an example.
 

--- a/docs/reference/expo/native-components/user-profile-view.mdx
+++ b/docs/reference/expo/native-components/user-profile-view.mdx
@@ -7,6 +7,10 @@ sdk: expo
 > [!NOTE]
 > This documents the native `<UserProfileView />` from `@clerk/expo/native`. For web projects, use the [web `<UserProfile />` component](/docs/reference/components/user/user-profile).
 
+| iOS | Android |
+| - | - |
+| ![The UserProfileView renders a comprehensive user profile interface that displays user information and provides account management options on iOS.](/docs/images/ui-components/ios-user-profile-view.png){{ width: 303, height: 590, style: { objectFit: 'contain' } }} | ![The UserProfileView renders a comprehensive user profile interface that displays user information and provides account management options on Android.](/docs/images/ui-components/android-user-profile-view.png){{ width: 303, height: 590, style: { objectFit: 'contain' } }} |
+
 The `<UserProfileView />` component renders a fully native profile management interface using SwiftUI on iOS and Jetpack Compose on Android. It allows users to manage:
 
 - Profile details


### PR DESCRIPTION
Supports https://github.com/clerk/javascript/pull/8699

## Summary

This updates the Expo docs for the native prebuilt component changes in `@clerk/expo`.

- Reworks the Expo quickstart so the native-components path matches the intended app shape: show a **Sign in** button while signed out, present `<AuthView />` from app-owned state, and show `<UserButton />` once signed in.
- Updates the native component reference pages to describe `<AuthView />` and `<UserProfileView />` as inline React Native views that can be placed in a modal, route, full-screen view, or any layout the app owns.
- Uses `onDismiss` in modal examples so the native dismiss control updates React Native modal state.
- Prefers auth-state-driven rendering in modal examples instead of using `useEffect` just to close a modal after sign-in. `useEffect` remains where the example is doing a real side effect, like route navigation.
- Tightens related Expo copy around web support, first-user creation, theming, and user profile/user button examples.

## Why

The Expo native prebuilt components now behave more like native SDK views: the components render inline, while the app owns how they are presented. The docs should model that mental model clearly without pushing a single presentation style.
