### PR TITLE
Cross-reference the Clerk CLI and Skills in AI docs

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -79,7 +79,7 @@ The CLI is designed to work seamlessly with AI coding agents:
 - **Automatic agent detection** — The CLI auto-detects agent vs. human mode. Non-TTY environments default to agent mode, or you can set it explicitly with `--mode agent`.
 - **Agent-friendly setup** — `clerk init --prompt` outputs framework-specific integration instructions for your AI agent and exits without modifying the project.
 - **Read-only production status** — `clerk deploy --mode agent` returns a JSON snapshot of your production instance's configuration state so your AI agent can inspect progress and recommend next steps.
-- **Clerk Skills** — Run `clerk skill install` or accept the prompt during `clerk init` to install [Clerk Skills](/docs/guides/ai/skills), giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
+- **Clerk Skills** — Accept the optional prompt during `clerk init` (which installs Clerk's agent skills, including `clerk-cli`), or run `npx skills add clerk/skills` anytime, to install [Clerk Skills](/docs/guides/ai/skills) — giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -77,7 +77,7 @@ Run `clerk --help` for a full list of commands.
 The CLI is designed to work seamlessly with AI coding agents:
 
 - **Automatic agent detection** — The CLI auto-detects agent vs. human mode. Non-TTY environments default to agent mode, or you can set it explicitly with `--mode agent`.
-- **Agent-friendly setup** — `clerk init --prompt` outputs framework-specific integration instructions for your AI agent and exits without modifying the project.
+- **Agent-friendly setup** — `clerk init -y` runs the full setup non-interactively, skipping all confirmation prompts, which is ideal for AI agents.
 - **Read-only production status** — `clerk deploy --mode agent` returns a JSON snapshot of your production instance's configuration state so your AI agent can inspect progress and recommend next steps.
 - **Clerk Skills** — Accept the optional prompt during `clerk init` (which installs Clerk's agent skills, including `clerk-cli`), or run `npx skills add clerk/skills` anytime, to install [Clerk Skills](/docs/guides/ai/skills) — giving your AI agent deeper knowledge about Clerk's SDKs and patterns.
 

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -31,7 +31,7 @@ sdk: expo
 There are three approaches for adding authentication to your Expo app.
 
 <If is="llm">
-  **For AI agents:** In an existing Expo app, run `npx clerk@latest init --framework expo` to install `@clerk/expo` and pull your keys into your project's env file (it won't scaffold screens or bootstrap a new app, so follow the steps below for the provider and UI). Install [Clerk's skills](/docs/guides/ai/skills) with `npx skills add clerk/skills` — includes `clerk-expo-patterns`.
+  **For AI agents:** In an existing Expo app, run `npx clerk@latest init --framework expo` to install `@clerk/expo` and pull your keys into your project's env file (it won't scaffold screens or bootstrap a new app, so follow the steps below for the provider and UI). Install [Clerk's skills](/docs/guides/ai/skills) with `npx skills add clerk/skills` — includes `clerk-expo` and `clerk-expo-patterns`.
 </If>
 
 | Approach | Auth UI | OAuth | Requires dev build | Best for |

--- a/docs/guides/ai/overview.mdx
+++ b/docs/guides/ai/overview.mdx
@@ -3,11 +3,11 @@ title: Using Clerk with AI
 description: Learn how to integrate Clerk authentication with AI-powered applications and development tools.
 ---
 
-Clerk provides support for building AI-powered applications with secure authentication. Whether you're using AI-powered development tools to build applications with Clerk, or building a [Model Context Protocol (MCP)](!model-context-protocol) server that allows AI agents to access user data, these guides cover everything you need to get started.
+Clerk helps you build AI-powered applications with secure authentication. Whether you're using AI coding tools to build with Clerk, or building a [Model Context Protocol (MCP)](!model-context-protocol) server that lets AI agents access user data, these guides cover everything you need to get started.
 
 ## Skills
 
-Clerk Skills are installable packages that give AI coding agents specialized knowledge about Clerk. Once installed, agents can help you add authentication, manage organizations, sync users, and more.
+Clerk Skills are installable packages that give AI coding agents specialized knowledge about Clerk. Once installed, agents can help you add authentication, manage Organizations, sync users, and more.
 
 ```bash
 npx skills add clerk/skills

--- a/docs/guides/ai/overview.mdx
+++ b/docs/guides/ai/overview.mdx
@@ -15,6 +15,16 @@ npx skills add clerk/skills
 
 Works with most agents including Claude Code, Cursor, Windsurf, GitHub Copilot, Codex, Gemini CLI, and more. See the [dedicated guide](/docs/guides/ai/skills) for available Skills and installation options.
 
+## CLI
+
+The Clerk CLI lets you and your AI agents set up and manage Clerk authentication directly from the terminal — installing the SDK, pulling environment variables, configuring your instance, and deploying to production. It auto-detects agent vs. human mode, and `clerk init` can install Clerk Skills for your agent.
+
+```bash
+npx clerk@latest init
+```
+
+See the [CLI guide](/docs/cli) for installation and all available commands.
+
 ## Use Clerk's MCP server
 
 Clerk provides its own MCP server that helps AI coding agents provide accurate SDK snippets and implementation patterns. This is useful when building authentication features with Clerk in AI tools. Learn how to [connect to Clerk's MCP server](/docs/guides/ai/mcp/clerk-mcp-server).

--- a/docs/guides/ai/prompts.mdx
+++ b/docs/guides/ai/prompts.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Prompts
+title: AI prompts
 description: Curated prompts for working with Clerk using AI-powered IDE tools like Cursor, GitHub Copilot, and Claude.
 sdk: nextjs, react, astro
 ---

--- a/docs/guides/ai/skills.mdx
+++ b/docs/guides/ai/skills.mdx
@@ -3,7 +3,7 @@ title: Clerk Skills
 description: Install Clerk Skills to enhance AI coding agents with authentication expertise.
 ---
 
-[Clerk Skills](https://github.com/clerk/skills) are installable packages that give AI coding agents specialized knowledge about Clerk. Once installed, your agent can help you add authentication, manage organizations, sync users, and more.
+[Clerk Skills](https://github.com/clerk/skills) are installable packages that give AI coding agents specialized knowledge about Clerk. Once installed, your agent can help you add authentication, manage Organizations, sync users, and more.
 
 ## Installation
 

--- a/docs/guides/ai/skills.mdx
+++ b/docs/guides/ai/skills.mdx
@@ -21,6 +21,9 @@ npx skills add clerk/skills --skill {skill-name}
 
 Works with Claude Code, Cursor, Windsurf, GitHub Copilot, Codex, Gemini CLI, and more. See [all supported agents](https://github.com/vercel-labs/skills?tab=readme-ov-file#supported-agents).
 
+> [!NOTE]
+> If you use the [Clerk CLI](/docs/cli), running `clerk init` also offers to install Clerk Skills (including `clerk-cli`) for your agent.
+
 ## Available skills
 
 The following table lists the available Skills. See the linked reference for more information about each Skill.
@@ -30,6 +33,7 @@ The following table lists the available Skills. See the linked reference for mor
 | Skill | Description | When to use |
 | - | - | - |
 | [/clerk](https://github.com/clerk/skills/blob/main/skills/core/clerk/SKILL.md) | Router - routes to the right skill | Always start here |
+| [/clerk-cli](https://github.com/clerk/skills/blob/main/skills/core/clerk-cli/SKILL.md) | Operate the [Clerk CLI](/docs/cli) (`clerk` binary) | Managing users, orgs, apps, env keys, and deploy checks from the terminal |
 | [/clerk-setup](https://github.com/clerk/skills/blob/main/skills/core/clerk-setup/SKILL.md) | Add Clerk to any framework | New projects, framework setup |
 | [/clerk-custom-ui](https://github.com/clerk/skills/blob/main/skills/core/clerk-custom-ui/SKILL.md) | Custom sign-in/up flows and appearance | Building custom forms, styling, branding |
 | [/clerk-backend-api](https://github.com/clerk/skills/blob/main/skills/core/clerk-backend-api/SKILL.md) | Backend REST API explorer | Browsing and executing Clerk Backend API endpoints |
@@ -39,6 +43,7 @@ The following table lists the available Skills. See the linked reference for mor
 | Skill | Description | When to use |
 | - | - | - |
 | [/clerk-orgs](https://github.com/clerk/skills/blob/main/skills/features/clerk-orgs/SKILL.md) | Multi-tenant business-to-business (B2B) organizations | Team workspaces, role-based access control (RBAC), verified domains, enterprise single sign-on (SSO) |
+| [/clerk-billing](https://github.com/clerk/skills/blob/main/skills/features/clerk-billing/SKILL.md) | Subscription billing and feature gating | Pricing tables, plans, per-seat billing, feature entitlements with `has()` |
 | [/clerk-testing](https://github.com/clerk/skills/blob/main/skills/features/clerk-testing/SKILL.md) | End-to-end (E2E) testing for auth flows | Writing Playwright/Cypress tests |
 | [/clerk-webhooks](https://github.com/clerk/skills/blob/main/skills/features/clerk-webhooks/SKILL.md) | Real-time events and data syncing | Database sync, notifications, integrations |
 
@@ -61,6 +66,7 @@ The following table lists the available Skills. See the linked reference for mor
 | Skill | Description | When to use |
 | - | - | - |
 | [/clerk-android](https://github.com/clerk/skills/blob/main/skills/mobile/clerk-android/SKILL.md) | Native Android/Kotlin authentication | Building native Android/Compose apps |
+| [/clerk-expo](https://github.com/clerk/skills/blob/main/skills/mobile/clerk-expo/SKILL.md) | Expo / React Native authentication with `@clerk/expo` | Adding Clerk to an Expo app — prebuilt AuthView/UserButton or custom hook-driven flows |
 | [/clerk-swift](https://github.com/clerk/skills/blob/main/skills/mobile/clerk-swift/SKILL.md) | Native iOS/SwiftUI authentication | Building native Swift/iOS apps |
 
 ## Example prompts
@@ -71,13 +77,16 @@ Once Skills are installed, you can ask your AI agent:
 | - | - |
 | "Add Clerk auth to my Next.js app" | `/clerk-setup` |
 | "Build custom sign-in form with styling" | `/clerk-custom-ui` |
+| "List my Clerk users from the terminal" | `/clerk-cli` |
 | "List all user endpoints in the Backend API" | `/clerk-backend-api` |
 | "Set up organizations for my B2B app" | `/clerk-orgs` |
+| "Add subscription billing with a pricing table" | `/clerk-billing` |
 | "Add Playwright tests for auth" | `/clerk-testing` |
 | "Sync users to Prisma via webhooks" | `/clerk-webhooks` |
 | "Use Server Actions with Clerk" | `/clerk-nextjs-patterns` |
 | "Add Clerk auth to my Vite React app" | `/clerk-react-patterns` |
-| "Add auth to my Expo / React Native app" | `/clerk-expo-patterns` |
+| "Add Clerk auth to my Expo / React Native app" | `/clerk-expo` |
+| "Use SecureStore and OAuth deep linking in Expo" | `/clerk-expo-patterns` |
 | "Add Clerk to my TanStack Start app" | `/clerk-tanstack-patterns` |
 | "Protect routes in my React Router v7 app" | `/clerk-react-router-patterns` |
 | "Set up Clerk in Astro with SSR" | `/clerk-astro-patterns` |


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/manovotny-confused-silence/guides/ai/skills
- https://clerk.com/docs/pr/manovotny-confused-silence/cli
- https://clerk.com/docs/pr/manovotny-confused-silence/guides/ai/overview
- https://clerk.com/docs/pr/manovotny-confused-silence/guides/ai/prompts

### What does this solve? What changed?

The [Skills page](https://clerk.com/docs/guides/ai/skills) is now a top-10 docs page and a primary AI/agent entrypoint, but the CLI ↔ Skills relationship in docs was one-directional and partly broken — Colin flagged that the Skills page never mentions the CLI, which may be suppressing CLI awareness. This tightens that cross-referencing and fixes stale commands.

**Cross-referencing + correctness (`68f4995`, `a203c57`):**

- **Skills page** — added a CLI back-link (a `[!NOTE]` callout plus the new `/clerk-cli` row linking to `/docs/cli`), so CLI ↔ Skills is now bidirectional.
- **Skills table sync** — added the three rows missing vs. the [`clerk/skills`](https://github.com/clerk/skills) repo: `clerk-cli`, `clerk-billing`, and `clerk-expo` (distinct from the existing `clerk-expo-patterns` — Expo *setup* vs. *patterns*), plus matching example prompts.
- **CLI page** — corrected two removed commands in the AI-agent section: replaced `clerk skill install` (removed in [clerk/cli#315](https://github.com/clerk/cli/pull/315)) with the current install paths (the optional `clerk init` prompt, or `npx skills add clerk/skills`), and replaced `clerk init --prompt` (removed in [clerk/cli#241](https://github.com/clerk/cli/pull/241)) with `clerk init -y` for non-interactive agent setup.
- **AI overview** — added a CLI section linking to `/docs/cli`.

**Copy/casing polish on the AI overview (`0135f0e`):**

- Tightened the overview intro.
- Capitalized the **Organizations** feature reference (proper noun, per the styleguide).
- Kept "AI prompts" lowercase (a descriptive label, not a product) and aligned the `prompts.mdx` page title to match.

Verified with `pnpm run build:tsx` and `pnpm run lint` (both clean), and peer-reviewed via `/co-fix`.

This also closes the loop on [#3418](https://github.com/clerk/clerk-docs/pull/3418), which added agent nudges pointing to the Skills page "for correct CLI usage" — the destination page now actually surfaces the CLI.

### Deadline

- No rush.

### Other resources

- [DOCS-11816](https://linear.app/clerk/issue/DOCS-11816) — this ticket
- [DOCS-11814](https://linear.app/clerk/issue/DOCS-11814) / [#3418](https://github.com/clerk/clerk-docs/pull/3418) — the `<If is="llm">` CLI nudges this closes the loop on
- [GROW-1145](https://linear.app/clerk/issue/GROW-1145) — follow-up A/B test (copy-prompt experiment, Growth-owned)
- [clerk/cli#315](https://github.com/clerk/cli/pull/315) — removed the `clerk skill install` command
- [clerk/cli#241](https://github.com/clerk/cli/pull/241) — removed `clerk init --prompt`
- Slack: [Colin's thread](https://clerkinc.slack.com/archives/C02SCBZ08GN/p1779997226117819) · [docs metrics update](https://clerkinc.slack.com/archives/C01QFRQNHSN/p1780001599012929)
