### PR TITLE
Update Client Trust enable steps to Attack protection page

### DIFF
--- a/docs/guides/development/custom-flows/authentication/client-trust.mdx
+++ b/docs/guides/development/custom-flows/authentication/client-trust.mdx
@@ -18,7 +18,7 @@ description: Learn how to build a custom sign-in flow that requires Client Trust
   > If you're using an older version of one of these SDKs, or are using the legacy API, refer to the [legacy API documentation](/docs/guides/development/custom-flows/authentication/legacy/email-password-mfa).
 </If>
 
-If you have [Client Trust](/docs/guides/secure/client-trust) enabled for your application, when a user is signing in **with a password** on a new client (e.g. device), **the sign-in attempt will return a status of `needs_client_trust`**. Your custom sign-in flow needs to support handling either an email code or SMS code, depending on the settings you've enabled in the Clerk Dashboard.
+If you have [Client Trust](/docs/guides/secure/client-trust) enabled for your application, when a user is signing in **with a password** on a new client (e.g. device), **the sign-in attempt will return a status of `needs_client_trust`**. Your custom sign-in flow needs to support handling an email code, SMS code, or email link, depending on the settings you've enabled in the Clerk Dashboard. This guide demonstrates the email code and SMS code strategies.
 
 If Client Trust **and** MFA are enabled, MFA will take precedence and the sign-in attempt will return a status of `needs_second_factor`. See the [MFA custom flow guide](/docs/guides/development/custom-flows/authentication/multi-factor-authentication) for more information.
 
@@ -754,7 +754,7 @@ If Client Trust **and** MFA are enabled, MFA will take precedence and the sign-i
     1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
     1. Ensure all email options are disabled.
     1. Select the **Phone** tab. Ensure all the settings are enabled.
-    1. Select the **Password** tab and enable **Sign-up with password**. **Client Trust** is enabled by default.
+    1. Select the **Password** tab and enable **Sign-up with password**. **Client Trust** is enabled by default (applications created before November 14, 2025 will need to [enable Client Trust](/docs/guides/secure/client-trust#enable-client-trust)).
 
     ### Build the custom flow
 

--- a/docs/guides/secure/client-trust.mdx
+++ b/docs/guides/secure/client-trust.mdx
@@ -24,8 +24,11 @@ When these conditions are met, Clerk sends a [one-time verification code](!otp) 
 
 Client Trust is automatically enabled for Clerk applications created after November 14, 2025. For applications created before this date, you can enable Client Trust in the Clerk Dashboard:
 
-1. In the Clerk Dashboard, navigate to the [**Updates**](https://dashboard.clerk.com/~/updates) page.
-1. Enable the **Client Trust** update.
+1. In the Clerk Dashboard, navigate to the [**Attack protection**](https://dashboard.clerk.com/~/protect/attack-protection) page.
+1. Enable **Client Trust**.
+
+> [!NOTE]
+> Client Trust requires password-based sign-in to be enabled.
 
 ## How Client Trust differs from traditional MFA
 

--- a/docs/guides/secure/client-trust.mdx
+++ b/docs/guides/secure/client-trust.mdx
@@ -15,7 +15,7 @@ Client Trust automatically requires a [second factor](!second-factor) when **all
 1. The user **hasn't enabled [multi-factor authentication (MFA)](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication)**.
 1. The user is signing in from a **new device**.
 
-When these conditions are met, Clerk sends a [one-time verification code](!otp) to the user's email address or phone number. The user must enter this code to complete the sign-in process.
+When these conditions are met, Clerk uses an email code, SMS code, or email link based on your settings. The user must complete this verification to finish the sign-in process.
 
 > [!NOTE]
 > If the user has already enabled MFA (such as an authenticator app or SMS verification), Client Trust will not trigger - their existing MFA method will be used instead.
@@ -35,7 +35,7 @@ Client Trust is automatically enabled for Clerk applications created after Novem
 | Aspect | Client Trust | Traditional MFA |
 | - | - | - |
 | **Trigger** | Automatic on new devices | User must enable it |
-| **Verification method** | Email/phone code | TOTP, SMS code, backup codes |
+| **Verification method** | Email code, SMS code, or email link | TOTP, SMS code, backup codes |
 | **User setup required** | None | User must configure their preferred method |
 | **When it applies** | Only for password sign-ins | All sign-ins |
 
@@ -43,13 +43,15 @@ Client Trust is automatically enabled for Clerk applications created after Novem
 
 If you've built a [custom sign-in flow](!custom-flow) that allows password-based sign-ins using the Clerk API or SDKs, you'll need to handle the `needs_client_trust` status that Client Trust can trigger.
 
-When Client Trust requires verification, the sign-in attempt will return a status of `needs_client_trust` with `email_code` or `phone_code` in the `supportedSecondFactors` array. Your flow should:
+> [!NOTE]
+> If an older application has Client Trust enabled but your custom sign-in flow receives the legacy `needs_second_factor` status with `client_trust_state` instead of `needs_client_trust`, opt in to the **Client Trust Status** update on the [**Updates**](https://dashboard.clerk.com/~/updates) page. This update doesn't enable Client Trust. It only changes the custom-flow response from `needs_second_factor` to `needs_client_trust`.
+
+When Client Trust requires verification, the sign-in attempt will return a status of `needs_client_trust` with `email_code`, `phone_code`, or `email_link` in the `supportedSecondFactors` array. Your flow should:
 
 1. Check if the sign-in status is `needs_client_trust`.
-1. Check if `email_code` or `phone_code` is in the `supportedSecondFactors` array.
-1. Call `prepareSecondFactor()` to send the verification code to the user's email address or phone number.
-1. Collect the code from the user.
-1. Call `attemptSecondFactor()` to verify the code.
+1. Check if `email_code`, `phone_code`, or `email_link` is in the `supportedSecondFactors` array.
+1. Call `prepareSecondFactor()` for the selected strategy.
+1. Complete the selected strategy's verification.
 1. If successful, set the session as active.
 
 For a complete implementation example, see the [email/password custom flow guide](/docs/guides/development/custom-flows/authentication/email-password#sign-in-flow).
@@ -59,5 +61,5 @@ For a complete implementation example, see the [email/password custom flow guide
 
 ## Limitations
 
-- **Password-only**: Client Trust only applies to password-based sign-ins. Passwordless authentication methods (such as email links, [OTPs](!otp), passkeys, and OAuth) are not affected.
-- **Email/Phone number required**: Client Trust requires the user to have a verified email address or phone number to receive the verification code.
+- **Password-only**: Client Trust only applies to password-based sign-ins. Passwordless authentication methods (such as email link sign-ins, [OTPs](!otp), passkeys, and OAuth) are not affected.
+- **Email/Phone number required**: Client Trust requires the user to have a verified email address or phone number to receive the verification.

--- a/docs/guides/secure/client-trust.mdx
+++ b/docs/guides/secure/client-trust.mdx
@@ -44,7 +44,7 @@ Client Trust is automatically enabled for Clerk applications created after Novem
 If you've built a [custom sign-in flow](!custom-flow) that allows password-based sign-ins using the Clerk API or SDKs, you'll need to handle the `needs_client_trust` status that Client Trust can trigger.
 
 > [!NOTE]
-> If an older application has Client Trust enabled but your custom sign-in flow receives the legacy `needs_second_factor` status with `client_trust_state` instead of `needs_client_trust`, opt in to the **Client Trust Status** update on the [**Updates**](https://dashboard.clerk.com/~/updates) page. This update doesn't enable Client Trust. It only changes the custom-flow response from `needs_second_factor` to `needs_client_trust`.
+> If an older application has Client Trust enabled but your custom sign-in flow receives the legacy `needs_second_factor` status instead of `needs_client_trust`, opt in to the **Client Trust Status** update on the [**Updates**](https://dashboard.clerk.com/~/updates) page. This update doesn't enable Client Trust. It only changes the custom-flow response from `needs_second_factor` to `needs_client_trust`.
 
 When Client Trust requires verification, the sign-in attempt will return a status of `needs_client_trust` with `email_code`, `phone_code`, or `email_link` in the `supportedSecondFactors` array. Your flow should:
 

--- a/docs/guides/secure/client-trust.mdx
+++ b/docs/guides/secure/client-trust.mdx
@@ -28,7 +28,7 @@ Client Trust is automatically enabled for Clerk applications created after Novem
 1. Enable **Client Trust**.
 
 > [!NOTE]
-> Client Trust requires password-based sign-in to be enabled.
+> Client Trust requires [password-based sign-in](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#user-and-authentication) to be enabled.
 
 ## How Client Trust differs from traditional MFA
 


### PR DESCRIPTION
## Description

The Client Trust control is moving from the **Password** settings tab to the **Attack protection** page in the dashboard (clerk/dashboard#9387). This updates the "Enable Client Trust" steps in the Client Trust guide to point to **Attack protection**, matching the navigation convention already used by the bot-protection, user-lockout, and user-enumeration-protection guides.

This also clarifies two related Client Trust details:

- Client Trust requires password-based sign-in to be enabled.
- The **Client Trust Status** update on the **Updates** page does not enable Client Trust. It only changes older custom-flow responses from the legacy `needs_second_factor` + `client_trust_state` shape to the newer `needs_client_trust` status.

## Merge timing

Held behind the `do not merge` label until clerk/dashboard#9387 ships — merging earlier would document a control location that is not live yet.

## Testing

- `pnpm run build:tsx`
- `pnpm run lint`