### PR TITLE
Fix dismissible prop names in view docs

### DIFF
--- a/docs/reference/views/authentication/auth-view.mdx
+++ b/docs/reference/views/authentication/auth-view.mdx
@@ -33,7 +33,7 @@ By default, the `AuthView` will automatically determine whether to sign users in
 
     ---
 
-    - `isDismissable`
+    - `isDismissible`
     - `Bool`
 
     Whether the view can be dismissed by the user. When `true`, a dismiss button appears and the view closes automatically after successful authentication. When `false`, no dismiss button is shown. Defaults to `true`.
@@ -117,7 +117,7 @@ By default, the `AuthView` will automatically determine whether to sign users in
 <If sdk="ios">
   The following examples show how to use the `AuthView` in your iOS app.
 
-  ### Basic usage as a dismissable sheet
+  ### Basic usage as a dismissible sheet
 
   ```swift
   import SwiftUI
@@ -144,7 +144,7 @@ By default, the `AuthView` will automatically determine whether to sign users in
   }
   ```
 
-  ### Fullscreen authentication (non-dismissable)
+  ### Fullscreen authentication (non-dismissible)
 
   ```swift
   import SwiftUI
@@ -156,9 +156,9 @@ By default, the `AuthView` will automatically determine whether to sign users in
 
     var body: some View {
       if clerk.user != nil {
-        UserProfileView(isDismissable: false)
+        UserProfileView(isDismissible: false)
       } else {
-        AuthView(isDismissable: false)
+        AuthView(isDismissible: false)
       }
     }
   }

--- a/docs/reference/views/organization/organization-list-view.mdx
+++ b/docs/reference/views/organization/organization-list-view.mdx
@@ -27,7 +27,7 @@ Personal Account selection clears the [Active Organization](!active-organization
 
     ---
 
-    - `isDismissable`
+    - `isDismissible`
     - `Bool`
 
     Whether the view can be dismissed by the user. When `true`, a dismiss button appears and the view closes automatically after account selection. When `false`, no dismiss button is shown. Defaults to `true`.
@@ -71,7 +71,7 @@ Personal Account selection clears the [Active Organization](!active-organization
 
     ---
 
-    - `isDismissable`
+    - `isDismissible`
     - `Boolean`
 
     Whether the view can be dismissed by the user. When `true`, a dismiss button appears and the view closes automatically after account selection. When `false`, no dismiss button is shown. Defaults to `true`.
@@ -88,7 +88,7 @@ Personal Account selection clears the [Active Organization](!active-organization
     - `onDismissRequest`
     - `(() -> Unit)?`
 
-    Called when the dismiss affordance is pressed or when a dismissable selection completes.
+    Called when the dismiss affordance is pressed or when a dismissible selection completes.
 
     ---
 
@@ -119,7 +119,7 @@ The following examples show how to use the `OrganizationListView` in your app.
 
   struct AccountPickerView: View {
     var body: some View {
-      OrganizationListView(isDismissable: false)
+      OrganizationListView(isDismissible: false)
     }
   }
   ```
@@ -156,7 +156,7 @@ The following examples show how to use the `OrganizationListView` in your app.
     var body: some View {
       NavigationStack(path: $path) {
         OrganizationListView(
-          isDismissable: false,
+          isDismissible: false,
           navigationPath: $path
         )
       }
@@ -203,7 +203,7 @@ The following examples show how to use the `OrganizationListView` in your app.
 
 <If sdk="ios">
   > [!NOTE]
-  > When using both `hidePersonal` and `isDismissable`, place `hidePersonal` before `isDismissable` in the `OrganizationListView` initializer. Otherwise, Swift will raise an argument-order error.
+  > When using both `hidePersonal` and `isDismissible`, place `hidePersonal` before `isDismissible` in the `OrganizationListView` initializer. Otherwise, Swift will raise an argument-order error.
 
   ```swift
   OrganizationListView(hidePersonal: true)

--- a/docs/reference/views/organization/organization-profile-view.mdx
+++ b/docs/reference/views/organization/organization-profile-view.mdx
@@ -20,7 +20,7 @@ The `OrganizationProfileView` renders the [Active Organization's](!active-organi
 
 <If sdk="ios">
   <Properties>
-    - `isDismissable`
+    - `isDismissible`
     - `Bool`
 
     Whether the view can be dismissed by the user. When `true`, a dismiss button appears in the navigation bar. When `false`, no dismiss button is shown. Defaults to `true`.
@@ -50,7 +50,7 @@ The `OrganizationProfileView` renders the [Active Organization's](!active-organi
 
     ---
 
-    - `isDismissable`
+    - `isDismissible`
     - `Boolean`
 
     Whether the view can be dismissed by the user. When `true`, a dismiss button appears in the navigation bar. When `false`, no dismiss button is shown. Defaults to `true`.
@@ -129,7 +129,7 @@ The following examples show how to use the `OrganizationProfileView` in your app
 
   struct OrganizationSettingsScreen: View {
     var body: some View {
-      OrganizationProfileView(isDismissable: false)
+      OrganizationProfileView(isDismissible: false)
     }
   }
   ```
@@ -166,7 +166,7 @@ The following examples show how to use the `OrganizationProfileView` in your app
     var body: some View {
       NavigationStack(path: $path) {
         OrganizationProfileView(
-          isDismissable: false,
+          isDismissible: false,
           navigationPath: $path
         )
       }
@@ -186,7 +186,7 @@ The following examples show how to use the `OrganizationProfileView` in your app
   fun OrganizationSettingsScreen(onDone: () -> Unit) {
       OrganizationProfileView(
           modifier = Modifier.fillMaxSize(),
-          isDismissable = true,
+          isDismissible = true,
           onDismiss = onDone,
       )
   }

--- a/docs/reference/views/user/user-profile-view.mdx
+++ b/docs/reference/views/user/user-profile-view.mdx
@@ -21,10 +21,10 @@ The `UserProfileView` renders a comprehensive user profile interface that displa
 
 <If sdk="ios">
   <Properties>
-    - `isDismissable`
+    - `isDismissible`
     - `Bool`
 
-    Whether the view can be dismissed by the user. When `true`, a dismiss button appears in the navigation bar and the view can be used in sheets or other dismissable contexts. When `false`, no dismiss button is shown, making it suitable for fullscreen usage. Defaults to `true`.
+    Whether the view can be dismissed by the user. When `true`, a dismiss button appears in the navigation bar and the view can be used in sheets or other dismissible contexts. When `false`, no dismiss button is shown, making it suitable for fullscreen usage. Defaults to `true`.
   </Properties>
 </If>
 
@@ -119,7 +119,7 @@ The `UserProfileView` renders a comprehensive user profile interface that displa
 
     var body: some View {
       if clerk.user != nil {
-        UserProfileView(isDismissable: false)
+        UserProfileView(isDismissible: false)
       }
     }
   }


### PR DESCRIPTION
### 🔎 Previews:

- AuthView
- UserProfileView
- OrganizationListView
- OrganizationProfileView

### What does this solve? What changed?

- Updates the native iOS and Android docs to use `isDismissible` instead of `isDismissable`.
- Updated parameter tables, code examples, and related copy.
- Left Expo docs unchanged since that work is covered separately.