### PR TITLE
PR#3414 (feat: add doc for seat-based billing plans) follow-up

### DIFF
--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -20,26 +20,25 @@ Seat limits and per-seat pricing can be used independently or together:
 - **Seat limits** determine the maximum number of seats an Organization may have.
 - **Per-seat pricing** determines how much an Organization is charged.
 
-## Creating a Plan with a seat limit
+## Create a Plan with a seat limit
 
 1. In the Clerk Dashboard, navigate to the [**New Organization Plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page.
-1. Toggle on the **Seat-based** section, then choose how many seats the Plan allows:
+1. Enable **Seat-based** and choose how many seats the Plan allows:
    - To cap the number of seats, select **Custom limit** and enter the desired value.
    - To allow an unlimited number of seats, select **Unlimited members**.
 
 > [!NOTE]
 > The [B2B Authentication add-on](/docs/guides/organizations/overview) is required to set a custom limit greater than 20 seats or to allow unlimited members.
 
-## Creating a Plan with per-seat pricing
+## Create a Plan with per-seat pricing
 
-1. Ensure the seat-based configuration described above is complete.
-1. Toggle on the **Per-seat fee** section, then:
-   - Enter the price per seat in the **Cost per member seat monthly** section.
-   - To bundle free seats into the Plan, enter the desired value in the **Included seats** section.
+1. After following the steps to [create a Plan with a seat limit](#create-a-plan-with-a-seat-limit), under **Seat-based**, enable **Per-seat fee** and configure the pricing:
+   - **Cost per member seat monthly**: Enter the price per seat.
+   - **Included seats**: Enter the number of seats that are included in the Plan for free.
 
 ## SDK version requirements
 
-To use seat-based billing, you need to be using one of the following Clerk SDK versions:
+To use seat-based Billing Plans, you need to use one of the following Clerk SDK versions:
 
 - `@clerk/react` v6.9.0 or higher
 - `@clerk/nextjs` v7.5.1 or higher
@@ -47,18 +46,18 @@ To use seat-based billing, you need to be using one of the following Clerk SDK v
 - `@clerk/react-router` v3.4.1 or higher
 - `@clerk/tanstack-react-start` v1.4.1 or higher
 
-Seat-based billing also requires `@clerk/clerk-js` v6.16.0 or higher and `@clerk/ui` v1.16.0 or higher. If you've pinned these dependencies, please update them before attempting to use seat-based Billing Plans.
+Seat-based Billing Plans also require `@clerk/clerk-js` v6.16.0 or higher and `@clerk/ui` v1.16.0 or higher. If you've [pinned](/docs/pinning) these dependencies, update them before attempting to use seat-based Billing Plans.
 
 ## How per-seat pricing works
 
-When an Organization subscribes to a Plan with per-seat pricing, each provisioned seat contributes to the Subscription cost according to the parameters configured on the Plan. Plans may also include a recurring base fee and free seat tiers in addition to seat-based charges. For example, a Plan may include the first five seats for $10 a month and charge $5 a month for any additional seats.
+When an Organization subscribes to a Plan with per-seat pricing, each provisioned seat contributes to the Subscription cost according to the parameters configured on the Plan. Plans may also include a recurring base fee and included seats in addition to seat-based charges. For example, a Plan may include the first five seats for $10 a month and charge $5 a month for any additional seats.
 
-### Purchasing seats
+### Seat purchases
 
 When an Organization subscribes to a per-seat Plan, it purchases an initial quantity of seats during checkout:
 
 - The number of purchased seats covers the current number of members in the Organization plus any pending invitations.
-- If an Organization has no unused seats left and a new member is added, the admin will be prompted to purchase an additional seat.
+- If an Organization has no unused seats left and a new member is added, the [admin](/docs/guides/organizations/control-access/roles-and-permissions) will be prompted to purchase an additional seat.
 - Additional seats are added to the existing Subscription and are prorated based on the amount of time that has passed in the current billing period.
 - If the Plan also has a seat limit configured, Organizations cannot purchase more seats than the Plan's maximum allowed seat count.
 
@@ -66,11 +65,11 @@ When an Organization subscribes to a Plan with a seat limit but no per-seat fee,
 
 ### Recurring billing
 
-At the beginning of each new billing period, the Subscription's seat quantity is automatically adjusted to match the number of members currently in the Organization before the renewal charge is calculated. This means that seats that were purchased but never occupied during the previous billing period will not automatically renew. Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
+At the beginning of each new billing period, the Subscription's seat quantity is automatically adjusted to match the number of members currently in the Organization (subject to any included-seat minimums) before the renewal charge is calculated. This means that seats that were purchased but never occupied during the previous billing period will not automatically renew. Organizations can continue purchasing additional seats throughout the billing period as their membership grows.
 
 This automatic seat adjustment will never reduce the Organization's seats below what it still needs. If the Plan has no per-seat fee, no seat adjustment is made. If the Plan includes free seats, the seat count will not be reduced below the number of included seats.
 
-## Managing seat limits
+## Seat limit management
 
 > [!IMPORTANT]
 >
@@ -86,7 +85,7 @@ Organizations can invite members up to their purchased seat count. Once all seat
 - Existing members are removed from the Organization
 - Pending invitations are revoked
 
-### Changing Plans
+### Plan changes
 
 If an Organization wants to switch to a Plan with a seat limit and has more members than allowed by the Plan, it must remove members from the Organization before switching Plans.
 
@@ -99,6 +98,6 @@ Per-seat pricing can be configured in a variety of ways depending on how you'd l
 | Pricing model | Plan configuration | Example |
 | - | - | - |
 | Base fee + per-seat | $20 base + $5 per member | 1 member → $20 + $5 = **$25**<br />3 members → $20 + $15 = **$35**<br />10 members → $20 + $50 = **$70** |
-| Included seats | $25 base, includes 1 seat, then $10 per additional seat | 1 member → **$25**<br />4 members → $25 + (3 × $10) = **$55** |
+| Included seats | $25 base, includes 1 seat, then $10 per additional seat | 1 member → **$25**<br />4 members → $25 + (3 x $10) = **$55** |
 | No base fee | $8 per member | 1 member → **$8**<br />10 members → 10 × $8 = **$80** |
 | Per-seat with seat limit | $5 per member, 10-seat limit | 10 members → 10 × $5 = **$50**<br />12 members → exceeds seat limit |

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -55,7 +55,7 @@ When an Organization subscribes to a per-seat Plan, it purchases an initial quan
 - Additional seats are added to the existing Subscription and are prorated based on the amount of time that has passed in the current billing period.
 - If the Plan also has a seat limit configured, Organizations cannot purchase more seats than the Plan's maximum allowed seat count.
 - Purchased seats cannot be reduced mid-period.
-- If a member is removed mid-billing period, the seat becomes available for reuse within the Organization.
+- If a member is removed mid-billing period, the seat becomes available for reuse within the Organization and persists on the Subscription until renewal.
 
 When an Organization subscribes to a Plan with a seat limit but no per-seat fee, its seat limit will be set to the Plan's seat limit.
 

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -51,7 +51,7 @@ When an Organization subscribes to a Plan with per-seat pricing, each provisione
 When an Organization subscribes to a per-seat Plan, it purchases an initial quantity of seats during checkout:
 
 - The number of purchased seats covers the current number of members in the Organization plus any pending [invitations](/docs/guides/organizations/add-members/invitations).
-- If an Organization has no unused seats left, when the user tries to add a new member, they will be prompted to purchase an additional seat.
+- If an Organization has no unused seats left, when the user tries to add a new member, they will be prompted to purchase an additional seat. This user will need the `org:sys_billing:read` and `org:sys_billing:manage` [System Permissions](/docs/guides/organizations/control-access/roles-and-permissions#system-permissions) to purchase additional seats; [admins](/docs/guides/organizations/control-access/roles-and-permissions#default-roles) have these permissions by default.
 - Additional seats are added to the existing Subscription and are prorated based on the amount of time that has passed in the current billing period.
 - If the Plan also has a seat limit configured, Organizations cannot purchase more seats than the Plan's maximum allowed seat count.
 - Purchased seats cannot be reduced mid-period.

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -13,26 +13,20 @@ Clerk Billing Plans can use seat-based configuration to:
 
 This makes it possible to tailor Plans to Organizations based on size, or to offer pricing that scales with growth.
 
-## How seat-based Plans work
-
-Seat limits and per-seat pricing can be used independently or together:
+## Create a seat-based Plan
 
 - **Seat limits** determine the maximum number of seats an Organization may have.
-- **Per-seat pricing** determines how much an Organization is charged.
+- **Per-seat pricing** determines how much an Organization is charged for each seat.
 
-## Create a Plan with a seat limit
+Seat limits can be configured on their own or alongside per-seat pricing. If you want to do per-seat pricing without a seat limit, you can set the seat limit to unlimited.
 
 1. In the Clerk Dashboard, navigate to the [**New Organization Plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page.
 1. Enable **Seat-based** and choose how many seats the Plan allows:
    - To cap the number of seats, select **Custom limit** and enter the desired value.
    - To allow an unlimited number of seats, select **Unlimited members**.
-
-> [!NOTE]
-> The [B2B Authentication add-on](/docs/guides/organizations/overview) is required to set a custom limit greater than 20 seats or to allow unlimited members.
-
-## Create a Plan with per-seat pricing
-
-1. After following the steps to [create a Plan with a seat limit](#create-a-plan-with-a-seat-limit), under **Seat-based**, enable **Per-seat fee** and configure the pricing:
+   > [!NOTE]
+   > The [B2B Authentication add-on](https://clerk.com/pricing){{ target: '_blank' }} is required to set a custom limit greater than 20 seats or to allow unlimited members.
+1. If you want to charge Organizations based on the number of purchased seats, enable **Per-seat fee** and configure the pricing:
    - **Cost per member seat monthly**: Enter the price per seat.
    - **Included seats**: Enter the number of seats that are included in the Plan for free.
 
@@ -56,10 +50,12 @@ When an Organization subscribes to a Plan with per-seat pricing, each provisione
 
 When an Organization subscribes to a per-seat Plan, it purchases an initial quantity of seats during checkout:
 
-- The number of purchased seats covers the current number of members in the Organization plus any pending invitations.
-- If an Organization has no unused seats left and a new member is added, the [admin](/docs/guides/organizations/control-access/roles-and-permissions) will be prompted to purchase an additional seat.
+- The number of purchased seats covers the current number of members in the Organization plus any pending [invitations](/docs/guides/organizations/add-members/invitations).
+- If an Organization has no unused seats left, when the user tries to add a new member, they will be prompted to purchase an additional seat.
 - Additional seats are added to the existing Subscription and are prorated based on the amount of time that has passed in the current billing period.
 - If the Plan also has a seat limit configured, Organizations cannot purchase more seats than the Plan's maximum allowed seat count.
+- Purchased seats cannot be reduced mid-period.
+- If a member is removed mid-billing period, the seat becomes available for reuse within the Organization.
 
 When an Organization subscribes to a Plan with a seat limit but no per-seat fee, its seat limit will be set to the Plan's seat limit.
 

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -98,6 +98,6 @@ Per-seat pricing can be configured in a variety of ways depending on how you'd l
 | Pricing model | Plan configuration | Example |
 | - | - | - |
 | Base fee + per-seat | $20 base + $5 per member | 1 member → $20 + $5 = **$25**<br />3 members → $20 + $15 = **$35**<br />10 members → $20 + $50 = **$70** |
-| Included seats | $25 base, includes 1 seat, then $10 per additional seat | 1 member → **$25**<br />4 members → $25 + (3 x $10) = **$55** |
+| Included seats | $25 base, includes 1 seat, then $10 per additional seat | 1 member → **$25**<br />4 members → $25 + (3 × $10) = **$55** |
 | No base fee | $8 per member | 1 member → **$8**<br />10 members → 10 × $8 = **$80** |
 | Per-seat with seat limit | $5 per member, 10-seat limit | 10 members → 10 × $5 = **$50**<br />12 members → exceeds seat limit |

--- a/docs/guides/billing/seat-based-plans.mdx
+++ b/docs/guides/billing/seat-based-plans.mdx
@@ -15,10 +15,12 @@ This makes it possible to tailor Plans to Organizations based on size, or to off
 
 ## Create a seat-based Plan
 
+A seat-based Plan consists of configuring seat limits and per-seat pricing:
+
 - **Seat limits** determine the maximum number of seats an Organization may have.
 - **Per-seat pricing** determines how much an Organization is charged for each seat.
 
-Seat limits can be configured on their own or alongside per-seat pricing. If you want to do per-seat pricing without a seat limit, you can set the seat limit to unlimited.
+Seat limits can be configured on their own or alongside per-seat pricing. If you want to do per-seat pricing without a seat limit, you can set the seat limit to **unlimited members**.
 
 1. In the Clerk Dashboard, navigate to the [**New Organization Plan**](https://dashboard.clerk.com/~/billing/plans/new/org) page.
 1. Enable **Seat-based** and choose how many seats the Plan allows:
@@ -28,7 +30,7 @@ Seat limits can be configured on their own or alongside per-seat pricing. If you
    > The [B2B Authentication add-on](https://clerk.com/pricing){{ target: '_blank' }} is required to set a custom limit greater than 20 seats or to allow unlimited members.
 1. If you want to charge Organizations based on the number of purchased seats, enable **Per-seat fee** and configure the pricing:
    - **Cost per member seat monthly**: Enter the price per seat.
-   - **Included seats**: Enter the number of seats that are included in the Plan for free.
+   - **Included seats**: Enter how many seats are included in the Plan before per-seat charges apply.
 
 ## SDK version requirements
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -562,20 +562,20 @@
                     "href": "/docs/guides/billing/for-b2b"
                   },
                   {
-                    "title": "Free trials",
-                    "href": "/docs/guides/billing/free-trials"
-                  },
-                  {
-                    "title": "Seat-based Plans",
-                    "href": "/docs/guides/billing/seat-based-plans"
-                  },
-                  {
                     "title": "Default Plans",
                     "href": "/docs/guides/billing/default-plans"
                   },
                   {
                     "title": "Custom Plans and prices",
                     "href": "/docs/guides/billing/custom-plans"
+                  },
+                  {
+                    "title": "Free trials",
+                    "href": "/docs/guides/billing/free-trials"
+                  },
+                  {
+                    "title": "Seat-based Plans",
+                    "href": "/docs/guides/billing/seat-based-plans"
                   }
                 ]
               ]


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/aa-3414-followup/guides/billing/seat-based-plans

### What does this solve? 

Follow-up to [#3414](https://github.com/clerk/clerk-docs/pull/3414) regarding `docs/guides/billing/seat-based-plans.mdx`.

- Headings switched from gerunds to noun/imperative forms (`Create…`, `Seat purchases`, `Seat limit management`, `Plan changes`) to align with the style guide.
- Tightened the recurring-billing description to acknowledge included-seat minimums.
- Renamed `free seat tiers` → `included seats` so the prose matches the dashboard label and the example table.
- Linked `admin` to roles-and-permissions.
- Linked the `pinned` mention in SDK requirements to `/docs/pinning`.
- Minor wording cleanup across SDK requirements, dashboard steps, and the per-seat creation flow.

Handles questions answered [from Slack discussion](https://clerkinc.slack.com/archives/C01QFRQNHSN/p1781133123169169):
- Clarifies how seat limits and per-seat pricing work together, or "independently"
- Clarifies the B2B Auth requirement; updates the link to point to the pricing page. 
- Clarifies the requirements for purchasing new seats when inviting a user to an Organization with no unused seats left. Adds links to the references regarding System Permissions and the **admin** role.
- Adds that a seat becomes available for reuse and persists on the Subscription until renewal, when a member is removed mid-period.
- Adds that purchased seats cannot be reduced mid-period.

### Deadline

No rush.

### Other resources

- [Original PR #3414](https://github.com/clerk/clerk-docs/pull/3414)
- [Slack conversation](https://clerkinc.slack.com/archives/C01QFRQNHSN/p1781133123169169)
- [Slack ask to update pricing page](https://clerkinc.slack.com/archives/C07R4NBU54H/p1781207056317429)
