### PR TITLE
docs(application-logs): add new event types to reference tables

### DIFF
--- a/docs/guides/dashboard/logs/application-logs.mdx
+++ b/docs/guides/dashboard/logs/application-logs.mdx
@@ -220,6 +220,12 @@ The following tables list all event types that can appear in Application Logs, o
 | `session.revoked` | Session was revoked |
 | `session.token.created` | Session token was created |
 
+### Device events
+
+| Event type | Description |
+| - | - |
+| `device.verified` | Device was verified |
+
 ### SCIM events
 
 | Event type | Description |
@@ -337,6 +343,7 @@ The following tables list all event types that can appear in Application Logs, o
 
 | Event type | Description |
 | - | - |
+| `oauth_application.created` | OAuth application was created |
 | `oauth_authorization.granted` | OAuth authorization was granted |
 | `oauth_authorization.failed` | OAuth authorization failed |
 | `oauth_consent.denied` | OAuth consent was denied by user |
@@ -364,6 +371,12 @@ The following tables list all event types that can appear in Application Logs, o
 | - | - |
 | `sign_in_token.created` | Sign-in token was created for user |
 | `sign_in_token.revoked` | Sign-in token was revoked |
+
+### JWT service token events
+
+| Event type | Description |
+| - | - |
+| `jwt_service_token.created` | JWT service token was created |
 
 ### Agent task events
 


### PR DESCRIPTION

### 🔎 Previews:

<img width="731" height="183" alt="image" src="https://github.com/user-attachments/assets/01109a75-faaa-4392-b6b2-5628167ab6f2" />
<img width="731" height="413" alt="image" src="https://github.com/user-attachments/assets/08e9f21d-1e83-453a-a2f6-50c797bcdd0e" />
<img width="731" height="199" alt="image" src="https://github.com/user-attachments/assets/0fc6d22f-f6d4-47e3-846e-5049ce8ebe94" />


### What does this solve? What changed?

Document three additional event types that can appear in Application Logs:

- `device.verified` under a new Device events table
- `oauth_application.created` under the OAuth events table
- `jwt_service_token.created` under a new JWT service token events table

-

### Deadline

By the end of the week.
