### PR TITLE
Codify lowercase "membership" and fix Application Logs capitalization drift

### DIFF
--- a/docs/guides/dashboard/logs/application-logs.mdx
+++ b/docs/guides/dashboard/logs/application-logs.mdx
@@ -266,7 +266,7 @@ The following tables list all event types that can appear in Application Logs, o
 | `organization_invitation.accepted` | User accepted invitation to join an Organization |
 | `organization_invitation.revoked` | Organization invitation was revoked |
 
-#### Membership request events
+#### Membership Request events
 
 | Event type | Description |
 | - | - |
@@ -283,35 +283,35 @@ The following tables list all event types that can appear in Application Logs, o
 
 | Event type | Description |
 | - | - |
-| `organization_domain.created` | Domain was added to organization |
-| `organization_domain.deleted` | Domain was removed from organization |
+| `organization_domain.created` | Domain was added to an Organization |
+| `organization_domain.deleted` | Domain was removed from an Organization |
 | `organization_domain.updated` | Organization domain was updated |
-| `organization_domain.enrollment_mode.updated` | Enrollment mode was updated for organization domain |
-| `organization_domain.affiliation_verification.prepared` | Affiliation verification was prepared for organization domain |
+| `organization_domain.enrollment_mode.updated` | Enrollment mode was updated for an Organization domain |
+| `organization_domain.affiliation_verification.prepared` | Affiliation verification was prepared for an Organization domain |
 | `organization_domain.affiliation.verified` | Organization domain affiliation was verified |
 
 ### Billing events
 
 | Event type | Description |
 | - | - |
-| `user.subscription_item.canceled` | User canceled subscription |
-| `user.subscription_item.free_trial.extended` | Free trial was extended for user subscription |
-| `user.subscription_item.price_transition.created` | Price transition was created for user subscription |
+| `user.subscription_item.canceled` | User canceled their Subscription |
+| `user.subscription_item.free_trial.extended` | Free trial was extended for a user's Subscription |
+| `user.subscription_item.price_transition.created` | Price transition was created for a user's Subscription |
 | `user.checkout.created` | User created checkout |
 | `user.checkout.confirmed` | User confirmed checkout |
 | `user.payment_method.created` | User created payment method |
 | `user.payment_method.initialized` | User initialized payment method setup |
 | `user.payment_method.deleted` | User deleted payment method |
 | `user.default_payment_method.set` | User set default payment method |
-| `organization.subscription_item.canceled` | Organization subscription was canceled |
-| `organization.subscription_item.free_trial.extended` | Free trial was extended for organization subscription |
-| `organization.subscription_item.price_transition.created` | Price transition was created for organization subscription |
+| `organization.subscription_item.canceled` | Organization Subscription was canceled |
+| `organization.subscription_item.free_trial.extended` | Free trial was extended for an Organization Subscription |
+| `organization.subscription_item.price_transition.created` | Price transition was created for an Organization Subscription |
 | `organization.checkout.created` | Organization checkout was created |
 | `organization.checkout.confirmed` | Organization checkout was confirmed |
-| `organization.payment_method.created` | Payment method created for organization |
-| `organization.payment_method.initialized` | Payment method setup initialized for organization |
-| `organization.payment_method.deleted` | Payment method deleted for organization |
-| `organization.default_payment_method.set` | Default payment method set for organization |
+| `organization.payment_method.created` | Payment method created for an Organization |
+| `organization.payment_method.initialized` | Payment method setup initialized for an Organization |
+| `organization.payment_method.deleted` | Payment method deleted for an Organization |
+| `organization.default_payment_method.set` | Default payment method set for an Organization |
 
 ### Email address events
 
@@ -378,12 +378,12 @@ The following tables list all event types that can appear in Application Logs, o
 | - | - |
 | `jwt_service_token.created` | JWT service token was created |
 
-### Agent task events
+### Agent Task events
 
 | Event type | Description |
 | - | - |
-| `agent_task.created` | Agent task was created |
-| `agent_task.revoked` | Agent task was revoked |
+| `agent_task.created` | Agent Task was created |
+| `agent_task.revoked` | Agent Task was revoked |
 
 ### Waitlist events
 
@@ -391,4 +391,4 @@ The following tables list all event types that can appear in Application Logs, o
 | - | - |
 | `waitlist_entry.created` | Waitlist entry was created |
 | `waitlist_entry.deleted` | Waitlist entry was deleted |
-| `waitlist_entry.invited` | An invitation was sent to the waitlist entry |
+| `waitlist_entry.invited` | An invitation was sent to the Waitlist entry |

--- a/docs/guides/dashboard/logs/application-logs.mdx
+++ b/docs/guides/dashboard/logs/application-logs.mdx
@@ -391,4 +391,4 @@ The following tables list all event types that can appear in Application Logs, o
 | - | - |
 | `waitlist_entry.created` | Waitlist entry was created |
 | `waitlist_entry.deleted` | Waitlist entry was deleted |
-| `waitlist_entry.invited` | An invitation was sent to the Waitlist entry |
+| `waitlist_entry.invited` | An invitation was sent to the waitlist entry |

--- a/styleguides/STYLEGUIDE.md
+++ b/styleguides/STYLEGUIDE.md
@@ -67,7 +67,7 @@ Keep lowercase:
 - **Bold UI labels** that mirror Clerk Dashboard text exactly, even when the Dashboard uses lowercase. For example, **Create first organization automatically**.
 - **Component-rendered text**, such as button labels and default values. For example, the `<OrganizationSwitcher />` component's "Create an organization" button and the "My organization" fallback name.
 - **Code**, including inline code, code blocks, prop values, string literals, URL paths, and API field or parameter names.
-- **`invitation(s)` and `webhook(s)`**, which aren't treated as feature proper nouns, even in phrases like "Organization invitation" and "webhook event".
+- **`invitation(s)`, `membership(s)`, and `webhook(s)`**, which aren't treated as feature proper nouns, even in phrases like "Organization invitation", "Organization membership", and "webhook event". Note that "Membership Request" _is_ a proper noun, per the list above.
 - **Compound adjectives** built on industry terms, like "role-based access control".
 
 ### Use "sign in" instead of "log in"


### PR DESCRIPTION
### 🔎 Previews:

- [Application Logs](https://clerk.com/docs/pr/manovotny-styleguide-membership-lowercase/guides/dashboard/logs/application-logs#membership-request-events)

### What does this solve? What changed?

Follow-up to @alexisintech's #3437 (`chore: standardize Clerk feature noun capitalization`).

**1. Codifies the "membership" decision in the styleguide.** During review of #3437, [it was decided](https://github.com/clerk/clerk-docs/pull/3437#discussion_r3393124069) that "membership" stays lowercase ("Organization membership") while "Membership Request" remains a proper noun. The content was fixed before merge, but the rule itself only lived in the comment thread — this adds `membership(s)` to the deliberate-lowercase list in `STYLEGUIDE.md` so the decision survives for future contributors (and AI tools doing sweeps).

**2. Fixes capitalization drift in Application Logs.** #3441 merged right after the sweep and its new event tables use lowercase feature nouns next to the freshly capitalized ones — e.g. "Domain was added to organization", "User canceled subscription", "Agent task was created". Fixed those rows to match the convention (`Organization`, `Subscription`, `Agent Task`, plus missing articles), along with one leftover in the same file: the "Membership Request events" heading. ("waitlist entry" stays lowercase — Waitlist isn't on the styleguide's proper-noun list, and mid-sentence reference-doc usage is lowercase.)

**Validation:** `pnpm run build:tsx` and `pnpm run lint` both pass clean.

### Deadline

No rush

### Other resources

- https://github.com/clerk/clerk-docs/pull/3437#discussion_r3393124069
