### PR TITLE
Fix link to Clerk Dashboard on email deliverability guide 

### DIFF
--- a/docs/guides/development/troubleshooting/email-deliverability.mdx
+++ b/docs/guides/development/troubleshooting/email-deliverability.mdx
@@ -83,8 +83,7 @@ Another thing you can do is sign up for [Sender Support](https://sendersupport.o
 
 If you would like to handle the delivery of these messages yourself, you can opt out of Clerk's email and SMS delivery on a **per-template basis**. To do this:
 
-1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com).
-1. In the navigation sidenav, select **Customization** and then select which option you would like to manage: **Emails** or **SMS**.
+1. In the Clerk Dashboard, navigate to the [**Emails**](https://dashboard.clerk.com/~/customization/email) or [**SMS**](https://dashboard.clerk.com/~/customization/sms) page, depending on which you would like to manage.
 1. Select the template you would like to manage.
 1. Disable **Delivered by Clerk**.
 

--- a/docs/guides/development/troubleshooting/email-deliverability.mdx
+++ b/docs/guides/development/troubleshooting/email-deliverability.mdx
@@ -83,7 +83,7 @@ Another thing you can do is sign up for [Sender Support](https://sendersupport.o
 
 If you would like to handle the delivery of these messages yourself, you can opt out of Clerk's email and SMS delivery on a **per-template basis**. To do this:
 
-1. Navigate to the [Clerk Dashboard]().
+1. Navigate to the [Clerk Dashboard](https://dashboard.clerk.com).
 1. In the navigation sidenav, select **Customization** and then select which option you would like to manage: **Emails** or **SMS**.
 1. Select the template you would like to manage.
 1. Disable **Delivered by Clerk**.


### PR DESCRIPTION
While reviewing this [PR](https://github.com/clerk/clerk-docs/pull/3425), I noticed one of the links was broken. This PR fixes it.  