### PR TITLE
createRouteMatcher migration guide + eslint-plugin docs

### DIFF
--- a/docs/_partials/nextjs/bulk-fixer-cli.mdx
+++ b/docs/_partials/nextjs/bulk-fixer-cli.mdx
@@ -59,7 +59,7 @@ The Bulk Fixer CLI will warn about resources that require manual attention, such
 
 If the resource is already protected by a wrapper or by code in another file, the rule can't currently verify that protection. In that case, add an ESLint disable comment with a reason:
 
-```tsx
+```ts
 // eslint-disable-next-line @clerk/next/require-auth-protection -- Protected by withAuth().
 export const POST = withAuth(handler)
 ```

--- a/docs/_partials/nextjs/bulk-fixer-cli.mdx
+++ b/docs/_partials/nextjs/bulk-fixer-cli.mdx
@@ -19,7 +19,7 @@ The command exits with a non-zero status when:
 - `--dry-run` reports changes that would be made.
 - Some resources need manual attention.
 
-The following examples demonstrate the resource-based checks that the Bulk Fixer CLI inserts. [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) redirects unauthenticated users to the sign-in page. If you want [more control over the response](/docs/guides/secure/protect-content#server-side), or if you want to perform [authorization checks](!authorization-check) instead, adjust resources manually.
+The following examples demonstrate the resource-based checks that the Bulk Fixer CLI inserts. When a user isn't authenticated, [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) redirects them to the sign-in page for document requests (such as pages), returns a `401` for Server Actions, and returns a `404` for other non-document requests (such as Route Handlers). If you want [more control over the response](/docs/guides/secure/protect-content#server-side), or if you want to perform [authorization checks](!authorization-check) instead, adjust resources manually.
 
 <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function"]}>
   ```tsx {{ filename: 'app/dashboard/page.tsx' }}
@@ -36,9 +36,9 @@ The following examples demonstrate the resource-based checks that the Bulk Fixer
   + import { auth } from '@clerk/nextjs/server'
 
     export async function GET() {
-  +   const { userId } = await auth.protect()
+  +   await auth.protect()
 
-      return Response.json({ userId })
+      return Response.json({ ok: true })
     }
   ```
 
@@ -48,9 +48,9 @@ The following examples demonstrate the resource-based checks that the Bulk Fixer
   + import { auth } from '@clerk/nextjs/server'
 
     export async function updateDashboard() {
-  +   const { userId } = await auth.protect()
+  +   await auth.protect()
 
-      // Add your Server Function logic using the `userId`
+      // Add your Server Function logic
     }
   ```
 </CodeBlockTabs>

--- a/docs/_partials/nextjs/bulk-fixer-cli.mdx
+++ b/docs/_partials/nextjs/bulk-fixer-cli.mdx
@@ -1,0 +1,65 @@
+> [!WARNING]
+> Applying these fixes changes your application's runtime behavior. It enforces authentication where there potentially was none, and it might override custom authentication checks that were already in place. Review the changes and test your application after running the Bulk Fixer CLI.
+
+Run the fixer with `npx`:
+
+```npm
+# Fix everything under the current directory.
+npx clerk-next-fix-auth-protection
+
+# Preview without writing files.
+npx clerk-next-fix-auth-protection --dry-run
+
+# Scope fixes to a specific path or glob.
+npx clerk-next-fix-auth-protection "src/**"
+```
+
+The command exits with a non-zero status when:
+
+- `--dry-run` reports changes that would be made.
+- Some resources need manual attention.
+
+The following examples demonstrate the resource-based checks that the Bulk Fixer CLI inserts. [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) redirects unauthenticated users to the sign-in page. If you want [more control over the response](/docs/guides/secure/protect-content#server-side), or if you want to perform [authorization checks](!authorization-check) instead, adjust resources manually.
+
+<CodeBlockTabs options={["Server Component", "Route Handler", "Server Function"]}>
+  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+  + import { auth } from '@clerk/nextjs/server'
+
+    export default async function Page() {
+  +   await auth.protect()
+
+      return <h1>Dashboard</h1>
+    }
+  ```
+
+  ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+  + import { auth } from '@clerk/nextjs/server'
+
+    export async function GET() {
+  +   const { userId } = await auth.protect()
+
+      return Response.json({ userId })
+    }
+  ```
+
+  ```tsx {{ filename: 'app/dashboard/actions.ts' }}
+    'use server'
+
+  + import { auth } from '@clerk/nextjs/server'
+
+    export async function updateDashboard() {
+  +   const { userId } = await auth.protect()
+
+      // Add your Server Function logic using the `userId`
+    }
+  ```
+</CodeBlockTabs>
+
+The Bulk Fixer CLI will warn about resources that require manual attention, such as imported or wrapped exports, or mixed-scope layouts that require explicit acknowledgement. Add protection manually to those resources when they still need it.
+
+If the resource is already protected by a wrapper or by code in another file, the rule can't currently verify that protection. In that case, add an ESLint disable comment with a reason:
+
+```tsx
+// eslint-disable-next-line @clerk/next/require-auth-protection -- Protected by withAuth().
+export const POST = withAuth(handler)
+```

--- a/docs/guides/development/custom-sign-in-or-up-page.mdx
+++ b/docs/guides/development/custom-sign-in-or-up-page.mdx
@@ -27,7 +27,7 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
 
   Ensure the `/sign-in` route is accessible to all users, including unauthenticated users.
 
-  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating from middleware-based auth checks](/docs/reference/nextjs/clerk-middleware#migrating-from-middleware-based-auth-checks).
+  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating away from middleware-based auth checks](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher).
 
   ## Update your environment variables
 

--- a/docs/guides/development/custom-sign-in-or-up-page.mdx
+++ b/docs/guides/development/custom-sign-in-or-up-page.mdx
@@ -27,7 +27,7 @@ To set up separate sign-in and sign-up pages, follow this guide, and then follow
 
   Ensure the `/sign-in` route is accessible to all users, including unauthenticated users.
 
-  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating away from middleware-based auth checks](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher).
+  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating away from Middleware-based auth checks](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher).
 
   ## Update your environment variables
 

--- a/docs/guides/development/custom-sign-up-page.mdx
+++ b/docs/guides/development/custom-sign-up-page.mdx
@@ -27,7 +27,7 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
 
   Ensure the `/sign-up` route is accessible to all users, including unauthenticated users.
 
-  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating away from middleware-based auth checks](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher).
+  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating away from Middleware-based auth checks](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher).
 
   ## Update your environment variables
 

--- a/docs/guides/development/custom-sign-up-page.mdx
+++ b/docs/guides/development/custom-sign-up-page.mdx
@@ -27,7 +27,7 @@ To set up a single sign-in-or-up page, follow the [custom sign-in-or-up page gui
 
   Ensure the `/sign-up` route is accessible to all users, including unauthenticated users.
 
-  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating from middleware-based auth checks](/docs/reference/nextjs/clerk-middleware#migrating-from-middleware-based-auth-checks).
+  If your `clerkMiddleware()` includes auth checks, this pattern is no longer recommended. See [Migrating away from middleware-based auth checks](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher).
 
   ## Update your environment variables
 

--- a/docs/guides/development/upgrading/upgrade-guides/_partials/preserve-signed-out-ux.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/_partials/preserve-signed-out-ux.mdx
@@ -1,0 +1,41 @@
+> [!IMPORTANT]
+> The lint rule can't help you with this step. You need to verify this manually.
+
+If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware-based authentication check previously redirected signed-out users before that call happened, removing it _without adding a signed-out state_ can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
+
+Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to handle a signed-out user's experience.
+
+One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
+
+<Tabs items={["Client Component", "Layout"]}>
+  <Tab>
+    ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
+    'use client'
+
+    import { RedirectToSignIn, Show } from '@clerk/nextjs'
+
+    export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
+      return (
+        <>
+          <Show when="signed-in">{children}</Show>
+          <Show when="signed-out">
+            <RedirectToSignIn />
+          </Show>
+        </>
+      )
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
+
+    ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
+    import SignedOutRedirect from './SignedOutRedirect'
+
+    export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+      return <SignedOutRedirect>{children}</SignedOutRedirect>
+    }
+    ```
+  </Tab>
+</Tabs>

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -482,7 +482,7 @@ Keep the resource-level auth checks in place. This redirect should be safe to re
 > [!WARNING]
 > Adding the redirect back to the Proxy can make it harder to determine if the base resources are correctly protected.
 >
-> If you add the redirect behavior back to the Proxy, you should have a strategy for verifying the base resources are also protected, for example by installing the `require-auth-protection` lint rule or by setting up auth tests that skip the Proxy redirect.
+> If you add the redirect behavior back to the Proxy, you should have a strategy for verifying the base resources are also protected, for example by using the `require-auth-protection` lint rule or by setting up auth tests that skip the Proxy redirect.
 
 ## Motivations for deprecating `createRouteMatcher()`
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -460,7 +460,7 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
 
 Moving signed-out UX handling out of Middleware can raise a natural performance question: "Will signed-out users now have to wait longer for the redirect to happen, especially if it happens in a Client Component?"
 
-This is a fair concern. If this is something you want to optimize for, we recommend _first_ following the migration guide to ensure your application exhibits the correct behavior even without a Proxy redirect. After that, you can optionally add back an early redirect to the Proxy as a pure performance optimization.
+This is a fair concern. If this is something you want to optimize for, first follow this migration guide to ensure your application behaves correctly even without a Proxy redirect. After that, you can add back an early redirect to the Proxy as a pure performance optimization.
 
 ```tsx {{ filename: 'proxy.ts' }}
 import { clerkMiddleware } from '@clerk/nextjs/server'
@@ -477,7 +477,7 @@ export default clerkMiddleware(async (auth, req) => {
 })
 ```
 
-Keep the resource-level auth checks in place. This redirect should be safe to remove without exposing protected data, and without degrading the user experience besides performance.
+Keep the resource-level auth checks in place. This redirect should be safe to remove without exposing protected data. Removing it might affect performance, but it shouldn't change access control or the signed-out user experience.
 
 > [!WARNING]
 > Adding the redirect back to the Proxy can make it harder to determine if the base resources are correctly protected.

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -33,7 +33,7 @@ Use the following guides to learn how to protect different types of resources:
 To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/reference/nextjs/eslint-plugin), which includes `@clerk/next/require-auth-protection`, a lint rule that warns you when a resource is missing required protection. The package also includes the Bulk Fixer CLI, which can automatically add protection to your resources. You can also migrate manually if you prefer. Use the following tabs to choose your migration method.
 
 > [!WARNING]
-> The lint rule only works with App Router resources; if you use Pages Router, migrate those routes manually.
+> The lint rule only works with App Router resources. To protect Pages Router routes, use [`getAuth()`](/docs/reference/nextjs/pages-router/get-auth) in `getServerSideProps`.
 
 <Tabs items={["Use the lint rule", "Migrate manually"]}>
   <Tab>
@@ -69,7 +69,7 @@ To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/re
                     resources: {
                       routeHandlers: true,
                       serverFunctions: true,
-                      serverComponentEntrypoints: false, // Temporarily skip Server Component entrypoints so you can focus on Route Handlers and Server Functions first.
+                      serverComponentEntrypoints: false, // Skip for now.
                     },
                   },
                 ],
@@ -84,11 +84,23 @@ To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/re
         <Tab>
           If you're migrating the whole application at once, you can set `protected` to include all route groups:
 
-          ```js
-          const clerkProtection = {
-            protected: ['**'],
-            public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
-          }
+          ```js {{ filename: 'eslint.config.mjs' }}
+          import clerkNext from '@clerk/eslint-plugin/next'
+
+          export default [
+            {
+              plugins: { '@clerk/next': clerkNext },
+              rules: {
+                '@clerk/next/require-auth-protection': [
+                  'error',
+                  {
+                    protected: ['**'],
+                    public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+                  },
+                ],
+              },
+            },
+          ]
           ```
         </Tab>
       </Tabs>
@@ -105,7 +117,7 @@ To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/re
 
       <Include src="./_partials/preserve-signed-out-ux" />
 
-      ## Remove the Middleware gate
+      ## Remove the Middleware authentication checks
 
       After the server resources and signed-out states are handled, remove the authentication checks from `clerkMiddleware()`:
 
@@ -184,7 +196,7 @@ To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/re
       })
       ```
 
-      Move the auth check into each protected resource. The following examples use [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) to redirect unauthenticated users to the sign-in page. If you want more control over the response, or if you want to perform [authorization checks](!authorization-check) instead, see the relevant guides in the [Before you start](#before-you-start) section.
+      Move the auth check into each protected resource. The following examples use [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect), which redirects unauthenticated users to the sign-in page for document requests (such as pages), returns a `401` for Server Actions, and returns a `404` for other non-document requests (such as Route Handlers). If you want more control over the response, or if you want to perform [authorization checks](!authorization-check) instead, see the relevant guides in the [Before you start](#before-you-start) section.
 
       <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function"]}>
         ```tsx {{ filename: 'app/dashboard/page.tsx' }}
@@ -224,7 +236,7 @@ To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/re
 
       <Include src="./_partials/preserve-signed-out-ux" />
 
-      ## Remove the Middleware gate
+      ## Remove the Middleware authentication checks
 
       After the server resources and signed-out states are handled, remove the authentication checks from `clerkMiddleware()`:
 
@@ -287,7 +299,7 @@ Another example is the mapping of regular expressions first to URLs and then to 
 
 Differences between how `createRouteMatcher()` parses a path and how the framework resolves it can also lead to dangerous gaps. If Clerk normalizes a path one way and treats it as public, but the framework normalizes it differently and renders a protected path, that creates a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability. Future framework changes to path interpretation can introduce new vulnerabilities, and patching them inside `createRouteMatcher()` isn't sustainable without first-class framework support.
 
-On top of these concerns, in late 2025, several framework-level Middleware bypasses were publicly disclosed. In these cases, the request never goes through `createRouteMatcher()` at all, and all authentication checks at the Middleware level are bypassed.
+On top of these concerns, in 2025, several framework-level Middleware bypasses were publicly disclosed. In these cases, the request never goes through `createRouteMatcher()` at all, and all authentication checks at the Middleware level are bypassed.
 
 Together, these concerns led Clerk to deprecate `createRouteMatcher()` and recommend moving away from Middleware-level auth gating.
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -456,6 +456,34 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
   </Tab>
 </Tabs>
 
+## What about early redirects for signed-out users?
+
+Moving signed-out UX handling out of Middleware can raise a natural performance question: "Will signed-out users now have to wait longer for the redirect to happen, especially if it happens in a Client Component?"
+
+This is a fair concern. If this is something you want to optimize for, we recommend _first_ following the migration guide to ensure your application exhibits the correct behavior even without a Proxy redirect. After that, you can optionally add back an early redirect to the Proxy as a pure performance optimization.
+
+```tsx {{ filename: 'proxy.ts' }}
+import { clerkMiddleware } from '@clerk/nextjs/server'
+
+export default clerkMiddleware(async (auth, req) => {
+  // Important: This is not an auth guarantee, only
+  // a performance optimization for signed-out users.
+  const pathname = req.nextUrl.pathname
+  if (pathname === '/dashboard' || pathname.startsWith('/dashboard/')) {
+    const { isAuthenticated, redirectToSignIn } = await auth()
+
+    if (!isAuthenticated) return redirectToSignIn()
+  }
+})
+```
+
+Keep the resource-level auth checks in place. This redirect should be safe to remove without exposing protected data, and without degrading the user experience besides performance.
+
+> [!WARNING]
+> Adding the redirect back to the Proxy can make it harder to determine if the base resources are correctly protected.
+>
+> If you add the redirect behavior back to the Proxy, you should have a strategy for verifying the base resources are also protected, for example by installing the `require-auth-protection` lint rule or by setting up auth tests that skip the Proxy redirect.
+
 ## Motivations for deprecating `createRouteMatcher()`
 
 > [!NOTE]

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -4,9 +4,7 @@ description: Learn how to migrate away from Middleware-based auth checks with cr
 sdk: nextjs
 ---
 
-This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, routes, and Server Functions.
-
-Clerk previously didn't make an explicit recommendation about whether protection should happen at the Proxy or Middleware level, or at the individual resource level. For the reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher), Clerk is deprecating `createRouteMatcher()` and now recommends protecting individual resources instead of relying on Middleware-based authentication checks.
+This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, API routes, and Server Functions. Clerk is deprecating `createRouteMatcher()` and now recommends always protecting individual resources instead of relying on Middleware-based authentication checks.
 
 > [!TIP]
 > To help protect all resources, Clerk has developed a lint rule that warns you when a resource is missing required protection. Installing it is optional but recommended. See the separate `@clerk/eslint-plugin` documentation for setup instructions.{/*TODO: Add link*/}
@@ -186,13 +184,9 @@ export default clerkMiddleware()
 
 ### Handle client-only routes
 
-During the migration, consider both security and user experience.
+If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
 
-If a route only uses Client Components, there might be no server-side resource to protect as part of this migration. However, if the Middleware gate previously redirected signed-out users, removing that redirect without adding a signed-out state can make the UX worse.
-
-Most applications already use a combination of protected API endpoints and Middleware-level gating. In these cases, the Middleware gate runs first and provides the UX, usually by redirecting to `/sign-in`. Removing the Middleware gate can leave the application secure while still hurting the UX. For example, pages could fail with generic errors instead of redirecting correctly.
-
-In these cases, this migration is more about preserving the user experience than security, so verify both. Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
 
 One way to preserve the previous UX is to add the signed-out handling to a shared layout for the affected routes:
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -495,7 +495,7 @@ One main concern has always been that Middleware-level auth gating can lead to a
 
 Server Functions are one example. It can be tempting to think these are protected by Middleware checks, but they're called _by id_, not by path. If a Server Function that lives in `/protected/server-functions.ts` is called while visiting `/public/`, Middleware sees `/public/` and lets the request through, even if `/protected/:path*` is protected.
 
-Another example is the mapping of regular expressions to folders. Regular expressions have subtle caveats, and a mistake can leave a resource unprotected.
+Another example is the mapping of regular expressions first to urls and then to folders. Regular expressions have subtle caveats, and a mistake can leave a resource unprotected.
 
 Differences between how `createRouteMatcher()` parses a path and how the framework resolves it can also lead to dangerous gaps. If Clerk normalizes a path one way and treats it as public, but the framework normalizes it differently and renders a protected path, that creates a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability. Future framework changes to path interpretation can also introduce new vulnerabilities, which isn't a sustainable model without first-class framework support.
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -50,6 +50,15 @@ For smaller applications, you can migrate all resources in one pass. For larger 
 
 Note that you never remove `clerkMiddleware` entirely during this migration, it is still a key piece for Clerk to work correctly and you can keep any non-auth logic you have inside the proxy callback.
 
+### Identifying which resources needs protection
+
+TODO:
+
+- Look at current `createRouteMatcher()` patterns for a good starting point
+  - All `layout`, `template`, `default`, `page`, `?` files under protected folders
+  - All API routes that aren't public
+- All sensitive Server Functions
+
 ### Migrating a single server resource
 
 The following example shows how to migrate a middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but this principle applies to any authentication or authorization check that you want to move to the resource.

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -188,12 +188,22 @@ If a route only uses Client Components, the protected resource is often an API e
 
 Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
 
-One way to preserve the previous UX is to add the signed-out handling to a shared layout for the affected routes:
+One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
 
 ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
-import { RedirectToSignIn, Show } from '@clerk/nextjs'
+import SignedOutRedirect from './SignedOutRedirect'
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return <SignedOutRedirect>{children}</SignedOutRedirect>
+}
+```
+
+```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
+'use client'
+
+import { RedirectToSignIn, Show } from '@clerk/nextjs'
+
+export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Show when="signed-in">{children}</Show>
@@ -205,7 +215,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 }
 ```
 
-Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages.
+Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
 
 ## Motivations for deprecating `createRouteMatcher()`
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -4,7 +4,9 @@ description: Learn how to migrate away from Middleware-based auth checks with cr
 sdk: nextjs
 ---
 
-This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, API routes, and Server Functions. Clerk is deprecating `createRouteMatcher()` and now recommends protecting individual resources instead of relying on Middleware-based authentication checks.
+This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, API routes, and Server Functions. Middleware-based auth checks rely on path matching, which can diverge from how Next.js routes requests and leave protected resources reachable.
+
+Clerk is deprecating `createRouteMatcher()` and recommends protecting individual resources instead of relying on Middleware-based authentication checks, to learn more about why we made this decision, see [Motivations](#motivations-for-deprecating-create-route-matcher) at the end of this page.
 
 > [!TIP]
 > To help protect all resources, Clerk has launched [`@clerk/eslint-plugin`](/docs/reference/nextjs/eslint-plugin), which includes `@clerk/next/require-auth-protection`, a lint rule that warns you when a resource is missing required protection.

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -9,7 +9,7 @@ This guide describes how to migrate away from middleware-based auth checks with 
 For a long time, we had no explicit recommendations on whether protection should happen at the proxy/middleware level or at the individual resource level. For a number of reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher) at the bottom of this page, we are deprecating `createRouteMatcher()` and now recommend always protecting the individual resources rather than relying on middleware-based authentication checks.
 
 > [!TIP]
-> To help you protect all resources, we have developed a lint rule that warns you when a resource that should have protection is missing it. Installing it is optional but recommended, see the separate [`@clerk/eslint-plugin` documentation](#) for setup instructions.{/*TODO: Add link*/}
+> To help you protect all resources, we have developed a lint rule that warns you when a resource that should have protection is missing it. Installing it is optional but recommended. See the separate `@clerk/eslint-plugin` documentation for setup instructions.{/*TODO: Add link*/}
 
 ## Before you start
 
@@ -35,9 +35,7 @@ Use the following guides to learn how to protect different types of resources:
 
 To migrate away from middleware-based auth checks, you can follow this rough outline:
 
-{/*TODO: Add link */}
-
-- Optional: Follow [this guide](#) to set up the `@clerk/eslint-plugin` and the `require-auth-protection` lint rule
+- Optional: Set up the `@clerk/eslint-plugin` and the `require-auth-protection` lint rule
 - Identify the pages, API routes and Server Functions that need protection
 - For each resource:
   - Server side resource: Add explicit auth guard with the correct response

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -50,14 +50,20 @@ For smaller applications, you can migrate all resources in one pass. For larger 
 
 Note that you never remove `clerkMiddleware` entirely during this migration, it is still a key piece for Clerk to work correctly and you can keep any non-auth logic you have inside the proxy callback.
 
-### Identifying which resources needs protection
+### Identify resources that need protection
 
-TODO:
+It's good to start with having a clear picture of what needs protecting and not. If you have set up the lint rule, the `protected` and `public` patterns already represents the split. If not, looking at your current `createRouteMatcher()` patterns is a good start.
 
-- Look at current `createRouteMatcher()` patterns for a good starting point
-  - All `layout`, `template`, `default`, `page`, `?` files under protected folders
-  - All API routes that aren't public
-- All sensitive Server Functions
+In the folders that should require being signed in:
+
+- Protect all `layout`, `template`, `default`, `page` files
+  - It is not enough to protect only the layout files, as these do not always re-render when pages do
+- Protecting `loading` and `error` files is only necessary if they access sensitive resources
+  - These are usually mostly static and often does not need protecting, but there are exceptions
+- Protect exports from `route` files
+  - All functions named as HTTP verbs turn into API routes, protect these
+
+Server Functions need to be protected regardless of where they are located, audit these separately.
 
 ### Migrating a single server resource
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -4,22 +4,15 @@ description: Learn how to migrate away from Middleware-based auth checks with cr
 sdk: nextjs
 ---
 
-This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, API routes, and Server Functions. Middleware-based auth checks rely on path matching, which can diverge from how Next.js routes requests and leave protected resources reachable.
-
-Clerk is deprecating `createRouteMatcher()` and recommends protecting individual resources instead of relying on Middleware-based authentication checks, to learn more about why we made this decision, see [Motivations](#motivations-for-deprecating-create-route-matcher) at the end of this page.
-
-> [!TIP]
-> To help protect all resources, Clerk has launched [`@clerk/eslint-plugin`](/docs/reference/nextjs/eslint-plugin), which includes `@clerk/next/require-auth-protection`, a lint rule that warns you when a resource is missing required protection.
->
-> Installing it is optional but recommended. It can help with this migration, and more importantly, it can help ensure you keep all resources protected over time.
+Previously, authentication checks were often performed in `clerkMiddleware()` using `createRouteMatcher()`. Clerk is deprecating this approach and now recommends protecting each server-side resource (pages, API routes, Server Functions) individually, rather than relying on Middleware-based auth checks. This guide explains how to migrate to the new resource-based protection model. To learn more about why `createRouteMatcher()` is being deprecated, see [Motivations for deprecating `createRouteMatcher()`](#motivations-for-deprecating-create-route-matcher).
 
 ## Before you start
 
-Before you migrate, it's important to understand how resource protection works and how removing Middleware-based gating can affect your signed-out user experience.
+Before you migrate, it's important to understand how resource protection works and how removing Middleware-based authentication checks can affect your signed-out user experience.
 
-This migration is about both protecting server-side resources and preserving the signed-out user experience. Server-rendered pages, Route Handlers, Server Functions, API endpoints, and any other code that can access privileged data must include their own auth checks.
+This migration is about both protecting server-side resources and preserving the signed-out user experience. Server-rendered pages, Route Handlers, Server Functions, external API endpoints, and any other code that can access privileged data must include their own authentication checks.
 
-Client Components don't have privileged access to resources by themselves, but this migration still applies to routes that render Client Components. Client-only routes might need a signed-out state even if there is no server-side resource to protect.
+Client Components can't reach privileged data directly, but this migration still applies to routes that render Client Components. Client-only routes might need a signed-out state even if there is no server-side resource to protect.
 
 Use the following guides to learn how to protect different types of resources:
 
@@ -29,217 +22,97 @@ Use the following guides to learn how to protect different types of resources:
 - To understand how to protect external API endpoints, see the [guide on making authenticated requests](/docs/guides/development/making-requests) as well as the SDK reference for the programming language or framework your backend API uses.
 
 > [!TIP]
-> Before you start the migration, verify that all relevant Server Functions are protected. These are already unprotected by Middleware, so this step helps you start the migration from a safer baseline.
+> Before you start the migration, verify that all relevant Server Functions are protected. Server Functions can't be reliably protected by Middleware patterns — they're called by ID, not by path (see [Motivations for deprecating `createRouteMatcher()`](#motivations-for-deprecating-create-route-matcher)). Verifying their protection first gives you a safer baseline before removing Middleware checks elsewhere.
 >
 > The lint rule can help with this step, or you can search your codebase for `'use server'` to find your Server Functions.
 
 ## Migration guide
 
-For smaller applications, you can migrate all resources in one pass. For larger applications, migrate one slice of your application at a time.
+**Don't remove `clerkMiddleware()` entirely during this migration.** It's still required for Clerk to work correctly and can still be used for any non-auth logic, like redirects, headers, and other request handling.
 
-Don't remove `clerkMiddleware()` entirely during this migration. It's still required for Clerk to work correctly, and you can keep any non-auth logic inside the Proxy callback.
+To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/reference/nextjs/eslint-plugin), which includes `@clerk/next/require-auth-protection`, a lint rule that warns you when a resource is missing required protection. The package also includes the Bulk Fixer CLI, which can automatically add protection to your resources. You can also migrate manually if you prefer. Use the following tabs to choose your migration method.
+
+> [!WARNING]
+> The lint rule only works with App Router resources; if you use Pages Router, migrate those routes manually.
 
 <Tabs items={["Use the lint rule", "Migrate manually"]}>
   <Tab>
-    We recommend using the lint rule during migration because it has a bulk fixer CLI. You can also migrate manually if you prefer.
-
-    The lint rule checks App Router resources. If you use the Pages Router, migrate those routes manually.
-
     <Steps>
       ## Install and configure the lint rule
 
-      > [!TIP]
-      > See the [`@clerk/eslint-plugin` reference](/docs/reference/nextjs/eslint-plugin) for all options and advanced configuration, including how to set it up for monorepos.
-      >
-      > The reference also describes the exact patterns the lint rule recognizes, like how protection must always be at the top of the function.
-
-      Install `@clerk/eslint-plugin`:
+      Install `@clerk/eslint-plugin`. See the [`@clerk/eslint-plugin` reference](/docs/reference/nextjs/eslint-plugin) for all options and advanced configuration, including how to set it up for monorepos. The reference also describes the exact patterns the lint rule recognizes, like how protection must always be at the top of the function.
 
       ```npm
       npm install --save-dev @clerk/eslint-plugin
       ```
 
-      In your `eslint.config.mjs` file, register the Next.js plugin and declare which folders should contain protected resources. You can base the patterns on your current `createRouteMatcher()` patterns, but you need to convert them from URL-based patterns to folder-based patterns.
+      In your `eslint.config.mjs` file, register the Next.js plugin and the `@clerk/next/require-auth-protection` rule. The rule accepts a `protected` option which is an array of folder globs whose resources must perform an authentication check. You can base the patterns on your current `createRouteMatcher()` patterns, but you need to convert them from URL-based patterns to folder-based patterns.
 
-      During an incremental migration, scope `protected` to the slice you're migrating. You can also temporarily disable resource groups that you aren't ready to migrate yet. The following example scopes the rule to a dashboard slice and temporarily skips Server Component entrypoints so you can focus on Route Handlers and Server Functions first:
+      <Tabs items={["Incremental migration", "Migrate the whole application at once"]}>
+        <Tab>
+          It's recommended to **incrementally migrate your application**, starting with a small slice of your application and gradually adding more resources to the protected set. You can also temporarily disable resource groups that you aren't ready to migrate yet.
 
-      ```js {{ filename: 'eslint.config.mjs' }}
-      import clerkNext from '@clerk/eslint-plugin/next'
+          Scope `protected` to the slice you're migrating. The following example scopes the rule to a `/dashboard` folder and temporarily skips Server Component entrypoints so you can focus on Route Handlers and Server Functions first:
 
-      export default [
-        {
-          plugins: { '@clerk/next': clerkNext },
-          rules: {
-            '@clerk/next/require-auth-protection': [
-              'error',
-              {
-                protected: ['src/app/dashboard/**', 'src/actions/dashboard/**'],
-                public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
-                resources: {
-                  routeHandlers: true,
-                  serverFunctions: true,
-                  serverComponentEntrypoints: false,
-                },
+          ```js {{ filename: 'eslint.config.mjs' }}
+          import clerkNext from '@clerk/eslint-plugin/next'
+
+          export default [
+            {
+              plugins: { '@clerk/next': clerkNext },
+              rules: {
+                '@clerk/next/require-auth-protection': [
+                  'error',
+                  {
+                    protected: ['src/app/dashboard/**', 'src/actions/dashboard/**'],
+                    public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+                    resources: {
+                      routeHandlers: true,
+                      serverFunctions: true,
+                      serverComponentEntrypoints: false, // Temporarily skip Server Component entrypoints so you can focus on Route Handlers and Server Functions first.
+                    },
+                  },
+                ],
               },
-            ],
-          },
-        },
-      ]
-      ```
+            },
+          ]
+          ```
 
-      When you're ready to include pages, layouts, templates, and `default` files in the migration, set `serverComponentEntrypoints` to `true` or remove the `resources` option.
+          When you're ready to include pages, layouts, templates, and `default` files in the migration, set `serverComponentEntrypoints` to `true` or remove the `resources` option altogether.
+        </Tab>
 
-      If you're migrating the whole application at once, you can start with the final pattern instead, for example:
+        <Tab>
+          If you're migrating the whole application at once, you can set `protected` to include all route groups:
 
-      ```js
-      const clerkProtection = {
-        protected: ['**'],
-        public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
-      }
-      ```
-
-      Adapt the exact patterns to your application.
-
-      ## Run the bulk fixer
-
-      > [!TIP]
-      > You can run the fixer with `--dry-run` to see which files would be changed.
-      >
-      > Start from a clean git worktree so you can review the exact diff after running the fixer.
-
-      The lint rule doesn't use ESLint autofixes, because adding protection changes runtime behavior. Instead, Clerk provides a bulk fixer CLI you can run manually:
-
-      ```npm
-      npx clerk-next-fix-auth-protection
-      ```
-
-      Review the generated changes. The fixer adds `await auth.protect()` where it can do so safely, but you might still need to adjust resources that require custom unauthenticated handling or authorization checks.
-
-      ## Manually handle unresolved resources
-
-      Some resources can't be updated automatically, such as imported or wrapped exports. The fixer will warn about these. Add protection manually to those resources when they still need it.
-
-      If the resource is already protected by a wrapper or by code in another file, the rule can't currently verify that protection. In that case, add an ESLint disable comment with a reason:
-
-      ```tsx
-      // eslint-disable-next-line @clerk/next/require-auth-protection -- Protected by withAuth().
-      export const POST = withAuth(handler)
-      ```
-
-      The following examples demonstrate the resource-based checks that the fixer inserts.
-
-      <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function"]}>
-        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-        import { auth } from '@clerk/nextjs/server'
-
-        export default async function Page() {
-          await auth.protect()
-
-          return <h1>Dashboard</h1>
-        }
-        ```
-
-        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-        import { auth } from '@clerk/nextjs/server'
-
-        export async function GET() {
-          const { userId } = await auth.protect()
-
-          return Response.json({ userId })
-        }
-        ```
-
-        ```tsx {{ filename: 'app/dashboard/actions.ts' }}
-        'use server'
-
-        import { auth } from '@clerk/nextjs/server'
-
-        export async function updateDashboard() {
-          const { userId } = await auth.protect()
-
-          // Add your Server Function logic using the `userId`
-        }
-        ```
-      </CodeBlockTabs>
-
-      If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
-
-      <CodeBlockTabs options={["Server Component", "Route Handler"]}>
-        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-        import { auth } from '@clerk/nextjs/server'
-
-        export default async function Page() {
-          const { isAuthenticated, userId } = await auth()
-
-          if (!isAuthenticated) {
-            return <p>You must sign in to view this page.</p>
+          ```js
+          const clerkProtection = {
+            protected: ['**'],
+            public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
           }
+          ```
+        </Tab>
+      </Tabs>
 
-          return <h1>Dashboard for {userId}</h1>
-        }
-        ```
+      ## Run the Bulk Fixer CLI
 
-        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-        import { auth } from '@clerk/nextjs/server'
+      The lint rule doesn't use ESLint autofixes, because adding protection changes runtime behavior. Instead, you can run the [Bulk Fixer CLI](/docs/reference/nextjs/eslint-plugin#bulk-fixer-cli) to automatically add protection to your resources.
 
-        export async function GET() {
-          const { isAuthenticated, userId } = await auth()
+      The CLI runs ESLint with your existing config, respects your `protected`, `public`, and `resources` options, and applies the rule's `await auth.protect()` suggestion anywhere it can do so safely.
 
-          if (!isAuthenticated) {
-            return Response.json({ error: 'Unauthorized' }, { status: 401 })
-          }
-
-          return Response.json({ userId })
-        }
-        ```
-      </CodeBlockTabs>
+      <Include src="_partials/nextjs/bulk-fixer-cli" />
 
       ## Preserve signed-out UX for client-only routes
 
-      > [!NOTE]
-      > The lint rule can't help you with this step. You need to verify this manually.
-
-      If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
-
-      Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
-
-      One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
-
-      ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
-      import SignedOutRedirect from './SignedOutRedirect'
-
-      export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-        return <SignedOutRedirect>{children}</SignedOutRedirect>
-      }
-      ```
-
-      ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
-      'use client'
-
-      import { RedirectToSignIn, Show } from '@clerk/nextjs'
-
-      export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
-        return (
-          <>
-            <Show when="signed-in">{children}</Show>
-            <Show when="signed-out">
-              <RedirectToSignIn />
-            </Show>
-          </>
-        )
-      }
-      ```
-
-      Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
+      <Include src="./_partials/preserve-signed-out-ux" />
 
       ## Remove the Middleware gate
 
-      After the server resources and signed-out states are handled, remove the matching auth check from `clerkMiddleware()`:
+      After the server resources and signed-out states are handled, remove the authentication checks from `clerkMiddleware()`:
 
       ```tsx {{ filename: 'proxy.ts' }}
       import { clerkMiddleware } from '@clerk/nextjs/server'
 
-      // Keep clerkMiddleware(); it's still required. Only remove the auth gating.
+      // Keep clerkMiddleware(); it's still required. Only remove the authentication checks.
       export default clerkMiddleware()
       ```
 
@@ -251,7 +124,7 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
 
       ## Keep the lint rule enabled for ongoing protection
 
-      Once the migration is complete, tweak the lint rule configuration to include all folders by default, only opting out any public ones. Adapt the exact patterns to your application:
+      Once the migration is complete, broaden `protected` to cover your whole application, opting out only the public routes.
 
       ```js {{ filename: 'eslint.config.mjs' }}
       import clerkNext from '@clerk/eslint-plugin/next'
@@ -275,7 +148,7 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
   </Tab>
 
   <Tab>
-    Even if you prefer to migrate manually, we still recommend installing the lint rule to help ensure your resources stay protected over time.
+    If you prefer to migrate manually, it's still recommended to install the lint rule to help ensure your resources stay protected over time.
 
     <Steps>
       ## Identify a slice of your application to migrate
@@ -295,7 +168,7 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
 
       ## Add auth checks to server resources
 
-      The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or authorization check that you want to move to the resource.
+      The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or [authorization check](!authorization-check) that you want to move to the resource.
 
       <Include src="_partials/nextjs/nextjs-15-callout" />
 
@@ -311,141 +184,54 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
       })
       ```
 
-      Move the auth check into each protected resource:
+      Move the auth check into each protected resource. The following examples use [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) to redirect unauthenticated users to the sign-in page. If you want more control over the response, or if you want to perform [authorization checks](!authorization-check) instead, see the relevant guides in the [Before you start](#before-you-start) section.
 
-      <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function", "Pages Router"]}>
+      <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function"]}>
         ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-        import { auth } from '@clerk/nextjs/server'
+        + import { auth } from '@clerk/nextjs/server'
 
-        export default async function Page() {
-          await auth.protect()
+          export default async function Page() {
+        +   await auth.protect()
 
-          return <h1>Dashboard</h1>
-        }
+            return <h1>Dashboard</h1>
+          }
         ```
 
         ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-        import { auth } from '@clerk/nextjs/server'
+        + import { auth } from '@clerk/nextjs/server'
 
-        export async function GET() {
-          const { userId } = await auth.protect()
+          export async function GET() {
+        +   const { userId } = await auth.protect()
 
-          return Response.json({ userId })
-        }
+            return Response.json({ userId })
+          }
         ```
 
         ```tsx {{ filename: 'app/dashboard/actions.ts' }}
-        'use server'
+          'use server'
 
-        import { auth } from '@clerk/nextjs/server'
+        + import { auth } from '@clerk/nextjs/server'
 
-        export async function updateDashboard() {
-          const { userId } = await auth.protect()
+          export async function updateDashboard() {
+        +   const { userId } = await auth.protect()
 
-          // Add your Server Function logic using the `userId`
-        }
-        ```
-
-        ```tsx {{ filename: 'pages/dashboard.tsx' }}
-        import { buildClerkProps, getAuth } from '@clerk/nextjs/server'
-        import type { GetServerSideProps } from 'next'
-
-        export const getServerSideProps: GetServerSideProps = async (ctx) => {
-          const { isAuthenticated } = getAuth(ctx.req)
-
-          if (!isAuthenticated) {
-            return {
-              redirect: {
-                destination: '/sign-in',
-                permanent: false,
-              },
-            }
+            // Add your Server Function logic using the `userId`
           }
-
-          return { props: { ...buildClerkProps(ctx.req) } }
-        }
-
-        export default function Page() {
-          return <h1>Dashboard</h1>
-        }
-        ```
-      </CodeBlockTabs>
-
-      If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
-
-      <CodeBlockTabs options={["Server Component", "Route Handler"]}>
-        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-        import { auth } from '@clerk/nextjs/server'
-
-        export default async function Page() {
-          const { isAuthenticated, userId } = await auth()
-
-          if (!isAuthenticated) {
-            return <p>You must sign in to view this page.</p>
-          }
-
-          return <h1>Dashboard for {userId}</h1>
-        }
-        ```
-
-        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-        import { auth } from '@clerk/nextjs/server'
-
-        export async function GET() {
-          const { isAuthenticated, userId } = await auth()
-
-          if (!isAuthenticated) {
-            return Response.json({ error: 'Unauthorized' }, { status: 401 })
-          }
-
-          return Response.json({ userId })
-        }
         ```
       </CodeBlockTabs>
 
       ## Preserve signed-out UX for client-only routes
 
-      If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
-
-      Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
-
-      One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
-
-      ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
-      import SignedOutRedirect from './SignedOutRedirect'
-
-      export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-        return <SignedOutRedirect>{children}</SignedOutRedirect>
-      }
-      ```
-
-      ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
-      'use client'
-
-      import { RedirectToSignIn, Show } from '@clerk/nextjs'
-
-      export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
-        return (
-          <>
-            <Show when="signed-in">{children}</Show>
-            <Show when="signed-out">
-              <RedirectToSignIn />
-            </Show>
-          </>
-        )
-      }
-      ```
-
-      Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
+      <Include src="./_partials/preserve-signed-out-ux" />
 
       ## Remove the Middleware gate
 
-      After the server resources and signed-out states are handled, remove the matching auth check from `clerkMiddleware()`:
+      After the server resources and signed-out states are handled, remove the authentication checks from `clerkMiddleware()`:
 
       ```tsx {{ filename: 'proxy.ts' }}
       import { clerkMiddleware } from '@clerk/nextjs/server'
 
-      // Keep clerkMiddleware(); it's still required. Only remove the auth gating.
+      // Keep clerkMiddleware(); it's still required. Only remove the authentication checks.
       export default clerkMiddleware()
       ```
 
@@ -453,7 +239,7 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
 
       Test the migrated slice while signed out. Verify that protected resources reject unauthenticated requests and that pages still show the expected signed-out experience.
 
-      Repeat until you are no longer using `createRouteMatcher()`.
+      If you have more slices to migrate, start from the top of the guide and repeat the process until you are no longer using `createRouteMatcher()`.
     </Steps>
   </Tab>
 </Tabs>
@@ -462,7 +248,7 @@ Don't remove `clerkMiddleware()` entirely during this migration. It's still requ
 
 Moving signed-out UX handling out of Middleware can raise a natural performance question: "Will signed-out users now have to wait longer for the redirect to happen, especially if it happens in a Client Component?"
 
-This is a fair concern. If this is something you want to optimize for, first follow this migration guide to ensure your application behaves correctly even without a Proxy redirect. After that, you can add back an early redirect to the Proxy as a pure performance optimization.
+This is a fair concern. If this is something you want to optimize for, first follow this migration guide to ensure your application behaves correctly, even without the Middleware gate. After that, you can add back an early redirect to the Middleware gate as a pure performance optimization.
 
 ```tsx {{ filename: 'proxy.ts' }}
 import { clerkMiddleware } from '@clerk/nextjs/server'
@@ -479,29 +265,29 @@ export default clerkMiddleware(async (auth, req) => {
 })
 ```
 
-Keep the resource-level auth checks in place. This redirect should be safe to remove without exposing protected data. Removing it might affect performance, but it shouldn't change access control or the signed-out user experience.
+**Keep the resource-level auth checks in place.** Because the early redirect is a pure performance optimization, you can remove it at any time without exposing protected data or changing access control. The only impact of removing it is on signed-out users' perceived load time.
 
 > [!WARNING]
-> Adding the redirect back to the Proxy can make it harder to determine if the base resources are correctly protected.
+> Adding the redirect back to the Middleware can make it harder to determine if the base resources are correctly protected.
 >
-> If you add the redirect behavior back to the Proxy, you should have a strategy for verifying the base resources are also protected, for example by using the `require-auth-protection` lint rule or by setting up auth tests that skip the Proxy redirect.
+> If you add the redirect behavior back to the Middleware, you should have a strategy for verifying the base resources are also protected. For example, by using the `require-auth-protection` lint rule or by setting up auth tests that skip the Middleware redirect.
 
 ## Motivations for deprecating `createRouteMatcher()`
 
 > [!NOTE]
-> This section describes the motivations behind the new recommendations, and is optional reading for the curious.
+> This section provides the technical rationale for the updated recommendations. Reading this section is optional.
 
 The reasons for deprecating `createRouteMatcher()` are a mix of existing concerns and new ones.
 
 One main concern has always been that Middleware-level auth gating can lead to a false sense of security. It can be tempting to think, "I'm already guarding my entire application in Middleware, so I'm safe by default." In reality, Middleware checks can be bypassed in several ways, leaving resources unprotected.
 
-Server Functions are one example. It can be tempting to think these are protected by Middleware checks, but they're called _by id_, not by path. If a Server Function that lives in `/protected/server-functions.ts` is called while visiting `/public/`, Middleware sees `/public/` and lets the request through, even if `/protected/:path*` is protected.
+Server Functions are one example. It can be tempting to think these are protected by Middleware checks, but they're called _by ID_, not by path. If a Server Function that lives in `/protected/server-functions.ts` is called while visiting `/public/`, Middleware sees `/public/` and lets the request through, even if `/protected/:path*` is protected.
 
-Another example is the mapping of regular expressions first to urls and then to folders. Regular expressions have subtle caveats, and a mistake can leave a resource unprotected.
+Another example is the mapping of regular expressions first to URLs and then to folders. Regular expressions have subtle caveats, and a mistake can leave a resource unprotected.
 
-Differences between how `createRouteMatcher()` parses a path and how the framework resolves it can also lead to dangerous gaps. If Clerk normalizes a path one way and treats it as public, but the framework normalizes it differently and renders a protected path, that creates a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability. Future framework changes to path interpretation can also introduce new vulnerabilities, which isn't a sustainable model without first-class framework support.
+Differences between how `createRouteMatcher()` parses a path and how the framework resolves it can also lead to dangerous gaps. If Clerk normalizes a path one way and treats it as public, but the framework normalizes it differently and renders a protected path, that creates a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability. Future framework changes to path interpretation can introduce new vulnerabilities, and patching them inside `createRouteMatcher()` isn't sustainable without first-class framework support.
 
-On top of these concerns, several framework-level Proxy and Middleware bypasses have been disclosed recently. In these cases, the request never goes through `createRouteMatcher()` at all, and all auth gating at the Middleware level is bypassed.
+On top of these concerns, in late 2025, several framework-level Middleware bypasses were publicly disclosed. In these cases, the request never goes through `createRouteMatcher()` at all, and all authentication checks at the Middleware level are bypassed.
 
 Together, these concerns led Clerk to deprecate `createRouteMatcher()` and recommend moving away from Middleware-level auth gating.
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -1,12 +1,47 @@
 ---
-title: Migrating away from `createRouteMatcher()`
-description: Learn how to migrate away from middleware-based auth checks to resource-based auth checks.
+title: Migrating away from middleware-based auth checks
+description: Learn how to migrate away from middleware-based auth checks with createRouteMatcher to resource-based auth checks.
 sdk: nextjs
 ---
 
-## Migrating from middleware-based auth checks
+This guide describes how to migrate away from middleware-based auth checks with `createRouteMatcher()` and how to instead move protection to the individual pages, routes and Server Functions.
 
-If you're currently protecting routes in `clerkMiddleware()`, this approach is no longer recommended. Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
+For a long time, we had no explicit recommendations on if protection should happen at the proxy/middleware level or at the individual resource level. We have documented each approach, and most of our users have been doing a combination of both. For a number of reasons outlined in [Motivations](#motivations) at the bottom of this page, we now recommend always protecting the individual resources rather than relying on middleware-based auth.
+
+Before migrating, it's important to understand how protecting resources works.
+
+- To require a signed-in user, see the [guide on protecting content from unauthenticated users](/docs/guides/secure/protect-content).
+- To require a specific Role, Permission, Feature, or Plan, see the [guide on authorization checks](/docs/guides/secure/authorization-checks).
+- For machine requests (API keys, OAuth tokens, machine tokens), check the token type in the Route Handler with [`auth({ acceptsToken })`](/docs/reference/nextjs/app-router/auth#verify-machine-requests).
+- To understand how to protect External API endpoints, see the [guide on Making authenticated requests](/docs/guides/development/making-requests) as well as the SDK reference for the programming language or framework your backend API uses.
+
+---
+
+TODO (in no order, some of this can be copied from the old guide):
+
+> Remember we need to cover both app router and pages router
+
+- Note that this guide is both tackling security (enforcing protection) and UX (what happens when you don't have access)
+  - If you are already protecting your API endpoints, removing middleware gating will still possibly lead to worse UX (pages might error instead of redirect for example)
+- Show the old pattern we are migrating away from
+- Describe the high level process of migrating
+- Describe the process of migrating a single resource
+- Explain how to set up the lint rule
+
+---
+
+## Motivations
+
+> [!NOTE]
+> This section describes the motivations behind the new recommendations, and is optional reading for the curious.
+
+TODO:
+
+- Existing caveats - Server Functions
+- Recent Proxy bypasses
+- Structural argument
+
+{/* If you're currently protecting routes in `clerkMiddleware()`, this approach is no longer recommended. Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
 
 To migrate away from this approach:
 
@@ -90,4 +125,4 @@ If your middleware protects everything and allowlists public routes (the `!isPub
 
 1. **Add** resource-level checks (or `requireUser()`) to the routes that need them.
 1. **Verify** those routes still require sign-in.
-1. **Then** remove the gating from the middleware callback.
+1. **Then** remove the gating from the middleware callback. */}

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -6,61 +6,55 @@ sdk: nextjs
 
 This guide describes how to migrate away from middleware-based auth checks with `createRouteMatcher()` and instead move protection to the individual pages, routes and Server Functions.
 
-For a long time, we had no explicit recommendations on if protection should happen at the proxy/middleware level or at the individual resource level. For a number of reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher) at the bottom of this page, we now recommend always protecting the individual resources rather than relying on middleware-based auth.
+For a long time, we had no explicit recommendations on whether protection should happen at the proxy/middleware level or at the individual resource level. For a number of reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher) at the bottom of this page, we are deprecating `createRouteMatcher()` and now recommend always protecting the individual resources rather than relying on middleware-based authentication checks.
 
-Before migrating, it's important to understand how protecting resources works.
+> [!TIP]
+> To help you protect all resources, we have developed a lint rule that warns you when a resource that should have protection is missing it. Installing it is optional but recommended, see the separate [`@clerk/eslint-plugin` documentation](#) for setup instructions.{/*TODO: Add link*/}
+
+## Before you start
+
+Before migrating, it's important to understand both how protecting resources works and how removing middleware-based gating can affect your signed-out user experience.
+
+This migration is about both protecting server-side resources and preserving the signed-out user experience. Server-rendered pages, Route Handlers, Server Functions, API endpoints, and any other code that can access privileged data must have auth checks to be properly protected.
+
+Client Components don't have privileged access to resources by themselves, but this migration still applies to routes that render Client Components. Client-only routes might need a signed-out state even if there is no server-side resource to protect.
+
+Use the following guides to learn how to protect different types of resources:
 
 - To require a signed-in user, see the [guide on protecting content from unauthenticated users](/docs/guides/secure/protect-content).
 - To require a specific Role, Permission, Feature, or Plan, see the [guide on authorization checks](/docs/guides/secure/authorization-checks).
 - For machine requests (API keys, OAuth tokens, machine tokens), check the token type in the Route Handler with [`auth({ acceptsToken })`](/docs/reference/nextjs/app-router/auth#verify-machine-requests).
 - To understand how to protect External API endpoints, see the [guide on Making authenticated requests](/docs/guides/development/making-requests) as well as the SDK reference for the programming language or framework your backend API uses.
 
----
+> [!TIP]
+> Before starting the migration, we recommend that you verify that all relevant Server Functions are protected. These are already unprotected by the middleware, so this step is all about making sure you start the migration from a safe place.
+>
+> Setting up the lint rule can help with this step, or you can search your codebase for `'use server'` to find your Server Functions.
 
-TODO (in no order, some of this can be copied from the old guide):
+## Migration guide
 
-> Remember we need to cover both app router and pages router
+To migrate away from middleware-based auth checks, you can follow this rough outline:
 
-- Note that this guide is both tackling security (enforcing protection) and UX (what happens when you don't have access)
-  - If you are already protecting your API endpoints, removing middleware gating will still possibly lead to worse UX (pages might error instead of redirect for example)
-- Show the old pattern we are migrating away from
-- Describe the high level process of migrating
-- Describe the process of migrating a single resource
-- Explain how to set up the lint rule
+{/*TODO: Add link */}
 
----
+- Optional: Follow [this guide](#) to set up the `@clerk/eslint-plugin` and the `require-auth-protection` lint rule
+- Identify the pages, API routes and Server Functions that need protection
+- For each resource:
+  - Server side resource: Add explicit auth guard with the correct response
+  - Client side resource: Verify it has a signed out UI state/redirect
+  - Remove the gate in the middleware
+  - Test the resource when unauthenticated
+    - Is it protected?
+    - Does it have the expected user experience?
+- Verify you are no longer using `createRouteMatcher`
 
-## Motivations for deprecating `createRouteMatcher()`
+For smaller applications, you can migrate all resources in one pass. For larger applications, we recommend incrementally migrating a slice of your application at a time in a way that suits your application.
 
-> [!NOTE]
-> This section describes the motivations behind the new recommendations, and is optional reading for the curious.
+Note that you never remove `clerkMiddleware` entirely during this migration, it is still a key piece for Clerk to work correctly and you can keep any non-auth logic you have inside the proxy callback.
 
-The reasons for deprecating `createRouteMatcher()` are a mix of existing concerns and new ones.
+### Migrating a single server resource
 
-One main concern has always been that middleware level auth gating can lead to a false sense of security. It's easy to think "I'm already guarding my entire application in the middleware, so I'm safe by default", when in reality there are many reasons the the middleware checks might be bypassed, leaving you unprotected when you thought you were safe.
-
-One example of this is Server Functions. It's easy to think these are protected by the middleware checks, but in reality these are called _by id_, not by path. If you call a Server Function that lives in `/protected/server-functions.ts` when visiting `/public/`, the middleware will see `/public/` and let it through, even if you are protecting `/protected/:path*`.
-
-Another example of this is the mapping of regular expressions to folders. Regular expressions have subtle caveats, and any mistake you make can leave you open, when you thought you were safe.
-
-Also, any difference in how `createRouteMatcher()` parse and interpret a path, and how the framework ends up resolving it can lead to dangerous gaps. If we normalize a path one way and treat it as public, but the framework normalize it differently and ends up rendering a protected path, that leads to a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability we disclosed. Any future changes the framework makes to how it interprets path can lead to new vulnerabilities, which is not a sustainable model over time.
-
-On top of these concerns, there has recently been a number of framework level proxy/middleware bypasses disclosed. In these cases, the request never goes through `createRouteMatcher()` at all, and all auth gating at the middleware level is bypassed.
-
-All of these concerns together is what led us to deprecate `createRouteMatcher()` and stop recommending middleware level auth gating.
-
-{/* If you're currently protecting routes in `clerkMiddleware()`, this approach is no longer recommended. Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
-
-To migrate away from this approach:
-
-- Move the authentication or [authorization check](!authorization-check) into the resource: Add the resource checks first and remove the middleware gate last. If you remove the gate before the resources protect themselves, every route is briefly unprotected.
-- Keep `clerkMiddleware()`: It's required for Clerk configuration and is still the right place for redirects, headers, and other request handling.
-
-The line to hold: if deleting a piece of middleware would leave a resource unprotected, it was a gate and belongs at the resource. A cross-cutting redirect for incomplete [session tasks](/docs/guides/configure/session-tasks) or [onboarding](/docs/guides/development/add-onboarding-flow) can stay in middleware on that basis: the redirect only sends the user somewhere useful first while the resource runs the auth check.
-
-### Example
-
-The following example shows how to migrate a middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource using the `auth.protect()` method](/docs/guides/secure/protect-content#protect-a-page), but this principle applies to any authentication or authorization check that you want to move to the resource.
+The following example shows how to migrate a middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but this principle applies to any authentication or authorization check that you want to move to the resource.
 
 <Include src="_partials/nextjs/nextjs-15-callout" />
 
@@ -76,17 +70,97 @@ export default clerkMiddleware(async (auth, req) => {
 })
 ```
 
-You would move the auth check into the page itself:
+You would move the auth check into each protected resource itself:
 
-```tsx {{ filename: 'app/dashboard/page.tsx' }}
-import { auth } from '@clerk/nextjs/server'
+<CodeBlockTabs options={["Server Component", "API route", "Server Function", "Pages Router"]}>
+  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+  import { auth } from '@clerk/nextjs/server'
 
-export default async function Page() {
-  await auth.protect()
+  export default async function Page() {
+    await auth.protect()
 
-  return <h1>Dashboard</h1>
-}
-```
+    return <h1>Dashboard</h1>
+  }
+  ```
+
+  ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+  import { auth } from '@clerk/nextjs/server'
+
+  export async function GET() {
+    const { userId } = await auth.protect()
+
+    return Response.json({ userId })
+  }
+  ```
+
+  ```tsx {{ filename: 'app/dashboard/actions.ts' }}
+  'use server'
+
+  import { auth } from '@clerk/nextjs/server'
+
+  export async function updateDashboard() {
+    const { userId } = await auth.protect()
+
+    // Add your Server Function logic using the `userId`
+  }
+  ```
+
+  ```tsx {{ filename: 'pages/dashboard.tsx' }}
+  import { buildClerkProps, getAuth } from '@clerk/nextjs/server'
+  import type { GetServerSideProps } from 'next'
+
+  export const getServerSideProps: GetServerSideProps = async (ctx) => {
+    const { isAuthenticated } = getAuth(ctx.req)
+
+    if (!isAuthenticated) {
+      return {
+        redirect: {
+          destination: '/sign-in',
+          permanent: false,
+        },
+      }
+    }
+
+    return { props: { ...buildClerkProps(ctx.req) } }
+  }
+
+  export default function Page() {
+    return <h1>Dashboard</h1>
+  }
+  ```
+</CodeBlockTabs>
+
+If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
+
+<CodeBlockTabs options={["Server Component", "API route"]}>
+  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+  import { auth } from '@clerk/nextjs/server'
+
+  export default async function Page() {
+    const { isAuthenticated, userId } = await auth()
+
+    if (!isAuthenticated) {
+      return <p>You must sign in to view this page.</p>
+    }
+
+    return <h1>Dashboard for {userId}</h1>
+  }
+  ```
+
+  ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+  import { auth } from '@clerk/nextjs/server'
+
+  export async function GET() {
+    const { isAuthenticated, userId } = await auth()
+
+    if (!isAuthenticated) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    return Response.json({ userId })
+  }
+  ```
+</CodeBlockTabs>
 
 And then update your `clerkMiddleware()` to remove the auth check:
 
@@ -97,40 +171,52 @@ import { clerkMiddleware } from '@clerk/nextjs/server'
 export default clerkMiddleware()
 ```
 
-### Protect a whole subtree
+### Handle client-only routes
 
-If you were using `createRouteMatcher()` to protect an entire subtree, replicating that exact behavior isn't recommended. Auth checks need to be applied directly within each resource you want to protect. However, to make auth checks easier to manage, you can put the check in a small shared helper and call it from each protected resource.
+During the migration, it is important to not only consider security but also user experience.
 
-The following example shows a `requireUser()` helper that uses [`auth.protect()`](/docs/guides/secure/protect-content) to perform its auth check.
+If a route only uses Client Components, there may be no server-side resource to protect as part of this migration. However, if the middleware gate previously redirected signed-out users and you remove that redirect without adding a signed-out state, the UX can get worse.
 
-```tsx {{ filename: 'app/lib/auth.ts' }}
-import { auth } from '@clerk/nextjs/server'
+We expect most applications to already use a combination of protecting API endpoints and middleware level gating. In these cases, the middleware gating happens first and provides the UX, usually redirecting to `/sign-in`. While removing the middleware gating would technically leave the application safe, the UX would likely suffer. For example, pages could fail with generic errors instead of redirecting correctly.
 
-export async function requireUser() {
-  // Redirects to the sign-in route if the user is not signed in
-  const { userId } = await auth.protect()
+In these cases, this migration is more about preserving the user experience than the security, make sure you verify both. Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
 
-  return userId
+One way to preserve the previous UX is to add the signed-out handling to a shared layout for the affected routes:
+
+```tsx {{ filename: 'app/dashboard/layout.tsx' }}
+import { RedirectToSignIn, Show } from '@clerk/nextjs'
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Show when="signed-in">{children}</Show>
+      <Show when="signed-out">
+        <RedirectToSignIn />
+      </Show>
+    </>
+  )
 }
 ```
 
-Then call it from each resource in the subtree:
+Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages.
 
-```tsx {{ filename: 'app/dashboard/page.tsx' }}
-import { requireUser } from '../lib/auth'
+## Motivations for deprecating `createRouteMatcher()`
 
-export default async function Page() {
-  // Use the created helper to perform the auth check
-  const userId = await requireUser()
+> [!NOTE]
+> This section describes the motivations behind the new recommendations, and is optional reading for the curious.
 
-  return <h1>Dashboard</h1>
-}
-```
+The reasons for deprecating `createRouteMatcher()` are a mix of existing concerns and new ones.
 
-### Migrate "protect everything, allow a few public routes"
+One main concern has always been that middleware level auth gating can lead to a false sense of security. It's easy to think "I'm already guarding my entire application in the middleware, so I'm safe by default", when in reality there are many reasons the middleware checks might be bypassed, leaving you unprotected when you thought you were safe.
 
-If your middleware protects everything and allowlists public routes (the `!isPublicRoute` pattern), migrate in this order:
+One example of this is Server Functions. It's easy to think these are protected by the middleware checks, but in reality these are called _by id_, not by path. If you call a Server Function that lives in `/protected/server-functions.ts` when visiting `/public/`, the middleware will see `/public/` and let it through, even if you are protecting `/protected/:path*`.
 
-1. **Add** resource-level checks (or `requireUser()`) to the routes that need them.
-1. **Verify** those routes still require sign-in.
-1. **Then** remove the gating from the middleware callback. */}
+Another example of this is the mapping of regular expressions to folders. Regular expressions have subtle caveats, and any mistake you make can leave you open, when you thought you were safe.
+
+Also, any difference in how `createRouteMatcher()` parses and interprets a path, and how the framework ends up resolving it can lead to dangerous gaps. If we normalize a path one way and treat it as public, but the framework normalizes it differently and ends up rendering a protected path, that leads to a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability we disclosed. Any future changes the framework makes to how it interprets path can also lead to new vulnerabilities, which is not a sustainable model over time unless there is first-class framework support.
+
+On top of these concerns, there have been a number of framework level proxy/middleware bypasses disclosed recently. In these cases, the request never goes through `createRouteMatcher()` at all, and all auth gating at the middleware level is bypassed.
+
+All of these concerns together is what led us to deprecate `createRouteMatcher()` and to recommend moving away from middleware level auth gating.
+
+At Clerk, we strongly believe in being _secure by default_, and we believe this is the only decision that can give our customers those guarantees without a sense of false security.

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -31,191 +31,188 @@ Use the following guides to learn how to protect different types of resources:
 
 ## Migration guide
 
-To migrate away from Middleware-based auth checks, follow this outline:
-
-- Optional: Set up the `@clerk/eslint-plugin` and the `require-auth-protection` lint rule
-- Identify the pages, Route Handlers, and Server Functions that need protection
-- For each resource:
-  - Server-side resource: Add an explicit auth guard with the correct response
-  - Client-side resource: Verify that it has a signed-out UI state or redirect
-  - Remove the gate in Middleware
-  - Test the resource when unauthenticated
-    - Is it protected?
-    - Does it have the expected user experience?
-- Verify that you are no longer using `createRouteMatcher()`
-
 For smaller applications, you can migrate all resources in one pass. For larger applications, migrate one slice of your application at a time.
 
 Don't remove `clerkMiddleware()` entirely during this migration. It's still required for Clerk to work correctly, and you can keep any non-auth logic inside the Proxy callback.
 
-### Identify resources that need protection
+<Steps>
+  ## Identify a slice of your application to migrate
 
-Start by identifying what needs protection. If you set up the lint rule, the `protected` and `public` patterns already represent that split. Otherwise, use your current `createRouteMatcher()` patterns as a starting point.
+  Choose a route, route group, or feature area to migrate first. Within that slice, identify every resource that needs protection. You can use your current `createRouteMatcher()` patterns as a starting point.
 
-In folders that require signed-in users:
+  For routes that require signed-in users, check the following files:
 
-- Protect all `layout`, `template`, `default`, and `page` files
-  - Protecting only layout files isn't enough, because they don't always re-render when pages do
-- Protect `loading` and `error` files only if they access sensitive resources
-  - These files are usually mostly static and often don't need protection, but there are exceptions
-- Protect exports from `route` files
-  - All functions named as HTTP verbs turn into Route Handlers, so protect them
+  - Protect all `layout`, `template`, `default`, and `page` files
+    - Protecting only layout files isn't enough, because they don't always re-render when pages do
+  - Protect `loading` and `error` files only if they access sensitive resources
+    - These files are usually mostly static and often don't need protection, but there are exceptions
+  - Protect exports from `route` files
+    - All functions named as HTTP verbs turn into Route Handlers, so protect them
 
-Server Functions need protection regardless of where they are located, so audit them separately.
+  Server Functions need protection regardless of where they are located, so audit them separately.
 
-### Migrate a single server resource
+  ## Add auth checks to server resources
 
-The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or authorization check that you want to move to the resource.
+  The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or authorization check that you want to move to the resource.
 
-<Include src="_partials/nextjs/nextjs-15-callout" />
+  <Include src="_partials/nextjs/nextjs-15-callout" />
 
-If `clerkMiddleware()` protects a route:
+  If `clerkMiddleware()` protects a route:
 
-```tsx {{ filename: 'proxy.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+  ```tsx {{ filename: 'proxy.ts' }}
+  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isProtected = createRouteMatcher(['/dashboard/:path*'])
+  const isProtected = createRouteMatcher(['/dashboard/:path*'])
 
-export default clerkMiddleware(async (auth, req) => {
-  if (isProtected(req)) await auth.protect()
-})
-```
-
-Move the auth check into each protected resource:
-
-<CodeBlockTabs options={["Server Component", "Route Handler", "Server Function", "Pages Router"]}>
-  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-  import { auth } from '@clerk/nextjs/server'
-
-  export default async function Page() {
-    await auth.protect()
-
-    return <h1>Dashboard</h1>
-  }
+  export default clerkMiddleware(async (auth, req) => {
+    if (isProtected(req)) await auth.protect()
+  })
   ```
 
-  ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-  import { auth } from '@clerk/nextjs/server'
+  Move the auth check into each protected resource:
 
-  export async function GET() {
-    const { userId } = await auth.protect()
+  <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function", "Pages Router"]}>
+    ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+    import { auth } from '@clerk/nextjs/server'
 
-    return Response.json({ userId })
-  }
-  ```
+    export default async function Page() {
+      await auth.protect()
 
-  ```tsx {{ filename: 'app/dashboard/actions.ts' }}
-  'use server'
+      return <h1>Dashboard</h1>
+    }
+    ```
 
-  import { auth } from '@clerk/nextjs/server'
+    ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+    import { auth } from '@clerk/nextjs/server'
 
-  export async function updateDashboard() {
-    const { userId } = await auth.protect()
+    export async function GET() {
+      const { userId } = await auth.protect()
 
-    // Add your Server Function logic using the `userId`
-  }
-  ```
+      return Response.json({ userId })
+    }
+    ```
 
-  ```tsx {{ filename: 'pages/dashboard.tsx' }}
-  import { buildClerkProps, getAuth } from '@clerk/nextjs/server'
-  import type { GetServerSideProps } from 'next'
+    ```tsx {{ filename: 'app/dashboard/actions.ts' }}
+    'use server'
 
-  export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const { isAuthenticated } = getAuth(ctx.req)
+    import { auth } from '@clerk/nextjs/server'
 
-    if (!isAuthenticated) {
-      return {
-        redirect: {
-          destination: '/sign-in',
-          permanent: false,
-        },
+    export async function updateDashboard() {
+      const { userId } = await auth.protect()
+
+      // Add your Server Function logic using the `userId`
+    }
+    ```
+
+    ```tsx {{ filename: 'pages/dashboard.tsx' }}
+    import { buildClerkProps, getAuth } from '@clerk/nextjs/server'
+    import type { GetServerSideProps } from 'next'
+
+    export const getServerSideProps: GetServerSideProps = async (ctx) => {
+      const { isAuthenticated } = getAuth(ctx.req)
+
+      if (!isAuthenticated) {
+        return {
+          redirect: {
+            destination: '/sign-in',
+            permanent: false,
+          },
+        }
       }
+
+      return { props: { ...buildClerkProps(ctx.req) } }
     }
 
-    return { props: { ...buildClerkProps(ctx.req) } }
-  }
-
-  export default function Page() {
-    return <h1>Dashboard</h1>
-  }
-  ```
-</CodeBlockTabs>
-
-If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
-
-<CodeBlockTabs options={["Server Component", "Route Handler"]}>
-  ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-  import { auth } from '@clerk/nextjs/server'
-
-  export default async function Page() {
-    const { isAuthenticated, userId } = await auth()
-
-    if (!isAuthenticated) {
-      return <p>You must sign in to view this page.</p>
+    export default function Page() {
+      return <h1>Dashboard</h1>
     }
+    ```
+  </CodeBlockTabs>
 
-    return <h1>Dashboard for {userId}</h1>
-  }
-  ```
+  If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
 
-  ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-  import { auth } from '@clerk/nextjs/server'
+  <CodeBlockTabs options={["Server Component", "Route Handler"]}>
+    ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+    import { auth } from '@clerk/nextjs/server'
 
-  export async function GET() {
-    const { isAuthenticated, userId } = await auth()
+    export default async function Page() {
+      const { isAuthenticated, userId } = await auth()
 
-    if (!isAuthenticated) {
-      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+      if (!isAuthenticated) {
+        return <p>You must sign in to view this page.</p>
+      }
+
+      return <h1>Dashboard for {userId}</h1>
     }
+    ```
 
-    return Response.json({ userId })
+    ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+    import { auth } from '@clerk/nextjs/server'
+
+    export async function GET() {
+      const { isAuthenticated, userId } = await auth()
+
+      if (!isAuthenticated) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+
+      return Response.json({ userId })
+    }
+    ```
+  </CodeBlockTabs>
+
+  ## Preserve signed-out UX for client-only routes
+
+  If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
+
+  Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+
+  One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
+
+  ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
+  import SignedOutRedirect from './SignedOutRedirect'
+
+  export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+    return <SignedOutRedirect>{children}</SignedOutRedirect>
   }
   ```
-</CodeBlockTabs>
 
-Then update `clerkMiddleware()` to remove the auth check:
+  ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
+  'use client'
 
-```tsx {{ filename: 'proxy.ts' }}
-import { clerkMiddleware } from '@clerk/nextjs/server'
+  import { RedirectToSignIn, Show } from '@clerk/nextjs'
 
-// Keep clerkMiddleware(); it's still required. Only remove the auth gating.
-export default clerkMiddleware()
-```
+  export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
+    return (
+      <>
+        <Show when="signed-in">{children}</Show>
+        <Show when="signed-out">
+          <RedirectToSignIn />
+        </Show>
+      </>
+    )
+  }
+  ```
 
-### Handle client-only routes
+  Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
 
-If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
+  ## Remove the Middleware gate
 
-Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+  After the server resources and signed-out states are handled, remove the matching auth check from `clerkMiddleware()`:
 
-One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
+  ```tsx {{ filename: 'proxy.ts' }}
+  import { clerkMiddleware } from '@clerk/nextjs/server'
 
-```tsx {{ filename: 'app/dashboard/layout.tsx' }}
-import SignedOutRedirect from './SignedOutRedirect'
+  // Keep clerkMiddleware(); it's still required. Only remove the auth gating.
+  export default clerkMiddleware()
+  ```
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return <SignedOutRedirect>{children}</SignedOutRedirect>
-}
-```
+  ## Test and repeat
 
-```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
-'use client'
+  Test the migrated slice while signed out. Verify that protected resources reject unauthenticated requests and that pages still show the expected signed-out experience.
 
-import { RedirectToSignIn, Show } from '@clerk/nextjs'
-
-export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
-  return (
-    <>
-      <Show when="signed-in">{children}</Show>
-      <Show when="signed-out">
-        <RedirectToSignIn />
-      </Show>
-    </>
-  )
-}
-```
-
-Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
+  Repeat until you are no longer using `createRouteMatcher()`.
+</Steps>
 
 ## Motivations for deprecating `createRouteMatcher()`
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -4,7 +4,7 @@ description: Learn how to migrate away from Middleware-based auth checks with cr
 sdk: nextjs
 ---
 
-Previously, authentication checks were often performed in `clerkMiddleware()` using `createRouteMatcher()`. Clerk is deprecating this approach and now recommends protecting each server-side resource (pages, API routes, Server Functions) individually, rather than relying on Middleware-based auth checks. This guide explains how to migrate to the new resource-based protection model. To learn more about why `createRouteMatcher()` is being deprecated, see [Motivations for deprecating `createRouteMatcher()`](#motivations-for-deprecating-create-route-matcher).
+Previously, authentication checks were often performed in `clerkMiddleware()` using `createRouteMatcher()`. Clerk is deprecating this approach and now recommends protecting each server-side resource (pages, Route Handlers, and Server Functions, including Server Actions) individually, rather than relying on Middleware-based auth checks. This guide explains how to migrate to the new resource-based protection model. To learn more about why `createRouteMatcher()` is being deprecated, see [Motivations for deprecating `createRouteMatcher()`](#motivations-for-deprecating-create-route-matcher).
 
 ## Before you start
 
@@ -29,6 +29,8 @@ Use the following guides to learn how to protect different types of resources:
 ## Migration guide
 
 **Don't remove `clerkMiddleware()` entirely during this migration.** It's still required for Clerk to work correctly and can still be used for any non-auth logic, like redirects, headers, and other request handling.
+
+The line to hold: if deleting a piece of `clerkMiddleware()` logic would leave a resource unprotected, it was a gate and belongs at the resource. A cross-cutting redirect for incomplete [session tasks](/docs/guides/configure/session-tasks) or [onboarding](/docs/guides/development/add-onboarding-flow) can stay in `clerkMiddleware()` on that basis: the redirect only sends the user somewhere useful first, while the resource still runs the auth check.
 
 To help with the migration, Clerk has launched [`@clerk/eslint-plugin`](/docs/reference/nextjs/eslint-plugin), which includes `@clerk/next/require-auth-protection`, a lint rule that warns you when a resource is missing required protection. The package also includes the Bulk Fixer CLI, which can automatically add protection to your resources. You can also migrate manually if you prefer. Use the following tabs to choose your migration method.
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -1,0 +1,93 @@
+---
+title: Migrating away from `createRouteMatcher()`
+description: Learn how to migrate away from middleware-based auth checks to resource-based auth checks.
+sdk: nextjs
+---
+
+## Migrating from middleware-based auth checks
+
+If you're currently protecting routes in `clerkMiddleware()`, this approach is no longer recommended. Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
+
+To migrate away from this approach:
+
+- Move the authentication or [authorization check](!authorization-check) into the resource: Add the resource checks first and remove the middleware gate last. If you remove the gate before the resources protect themselves, every route is briefly unprotected.
+- Keep `clerkMiddleware()`: It's required for Clerk configuration and is still the right place for redirects, headers, and other request handling.
+
+The line to hold: if deleting a piece of middleware would leave a resource unprotected, it was a gate and belongs at the resource. A cross-cutting redirect for incomplete [session tasks](/docs/guides/configure/session-tasks) or [onboarding](/docs/guides/development/add-onboarding-flow) can stay in middleware on that basis: the redirect only sends the user somewhere useful first while the resource runs the auth check.
+
+### Example
+
+The following example shows how to migrate a middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource using the `auth.protect()` method](/docs/guides/secure/protect-content#protect-a-page), but this principle applies to any authentication or authorization check that you want to move to the resource.
+
+<Include src="_partials/nextjs/nextjs-15-callout" />
+
+If you had your `clerkMiddleware()` protecting a route:
+
+```tsx {{ filename: 'proxy.ts' }}
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+const isProtected = createRouteMatcher(['/dashboard/:path*'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtected(req)) await auth.protect()
+})
+```
+
+You would move the auth check into the page itself:
+
+```tsx {{ filename: 'app/dashboard/page.tsx' }}
+import { auth } from '@clerk/nextjs/server'
+
+export default async function Page() {
+  await auth.protect()
+
+  return <h1>Dashboard</h1>
+}
+```
+
+And then update your `clerkMiddleware()` to remove the auth check:
+
+```tsx {{ filename: 'proxy.ts' }}
+import { clerkMiddleware } from '@clerk/nextjs/server'
+
+// Keep clerkMiddleware(); it's still required. Only remove the auth gating.
+export default clerkMiddleware()
+```
+
+### Protect a whole subtree
+
+If you were using `createRouteMatcher()` to protect an entire subtree, replicating that exact behavior isn't recommended. Auth checks need to be applied directly within each resource you want to protect. However, to make auth checks easier to manage, you can put the check in a small shared helper and call it from each protected resource.
+
+The following example shows a `requireUser()` helper that uses [`auth.protect()`](/docs/guides/secure/protect-content) to perform its auth check.
+
+```tsx {{ filename: 'app/lib/auth.ts' }}
+import { auth } from '@clerk/nextjs/server'
+
+export async function requireUser() {
+  // Redirects to the sign-in route if the user is not signed in
+  const { userId } = await auth.protect()
+
+  return userId
+}
+```
+
+Then call it from each resource in the subtree:
+
+```tsx {{ filename: 'app/dashboard/page.tsx' }}
+import { requireUser } from '../lib/auth'
+
+export default async function Page() {
+  // Use the created helper to perform the auth check
+  const userId = await requireUser()
+
+  return <h1>Dashboard</h1>
+}
+```
+
+### Migrate "protect everything, allow a few public routes"
+
+If your middleware protects everything and allowlists public routes (the `!isPublicRoute` pattern), migrate in this order:
+
+1. **Add** resource-level checks (or `requireUser()`) to the routes that need them.
+1. **Verify** those routes still require sign-in.
+1. **Then** remove the gating from the middleware callback.

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -4,9 +4,9 @@ description: Learn how to migrate away from middleware-based auth checks with cr
 sdk: nextjs
 ---
 
-This guide describes how to migrate away from middleware-based auth checks with `createRouteMatcher()` and how to instead move protection to the individual pages, routes and Server Functions.
+This guide describes how to migrate away from middleware-based auth checks with `createRouteMatcher()` and instead move protection to the individual pages, routes and Server Functions.
 
-For a long time, we had no explicit recommendations on if protection should happen at the proxy/middleware level or at the individual resource level. We have documented each approach, and most of our users have been doing a combination of both. For a number of reasons outlined in [Motivations](#motivations) at the bottom of this page, we now recommend always protecting the individual resources rather than relying on middleware-based auth.
+For a long time, we had no explicit recommendations on if protection should happen at the proxy/middleware level or at the individual resource level. For a number of reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher) at the bottom of this page, we now recommend always protecting the individual resources rather than relying on middleware-based auth.
 
 Before migrating, it's important to understand how protecting resources works.
 
@@ -30,16 +30,24 @@ TODO (in no order, some of this can be copied from the old guide):
 
 ---
 
-## Motivations
+## Motivations for deprecating `createRouteMatcher()`
 
 > [!NOTE]
 > This section describes the motivations behind the new recommendations, and is optional reading for the curious.
 
-TODO:
+The reasons for deprecating `createRouteMatcher()` are a mix of existing concerns and new ones.
 
-- Existing caveats - Server Functions
-- Recent Proxy bypasses
-- Structural argument
+One main concern has always been that middleware level auth gating can lead to a false sense of security. It's easy to think "I'm already guarding my entire application in the middleware, so I'm safe by default", when in reality there are many reasons the the middleware checks might be bypassed, leaving you unprotected when you thought you were safe.
+
+One example of this is Server Functions. It's easy to think these are protected by the middleware checks, but in reality these are called _by id_, not by path. If you call a Server Function that lives in `/protected/server-functions.ts` when visiting `/public/`, the middleware will see `/public/` and let it through, even if you are protecting `/protected/:path*`.
+
+Another example of this is the mapping of regular expressions to folders. Regular expressions have subtle caveats, and any mistake you make can leave you open, when you thought you were safe.
+
+Also, any difference in how `createRouteMatcher()` parse and interpret a path, and how the framework ends up resolving it can lead to dangerous gaps. If we normalize a path one way and treat it as public, but the framework normalize it differently and ends up rendering a protected path, that leads to a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability we disclosed. Any future changes the framework makes to how it interprets path can lead to new vulnerabilities, which is not a sustainable model over time.
+
+On top of these concerns, there has recently been a number of framework level proxy/middleware bypasses disclosed. In these cases, the request never goes through `createRouteMatcher()` at all, and all auth gating at the middleware level is bypassed.
+
+All of these concerns together is what led us to deprecate `createRouteMatcher()` and stop recommending middleware level auth gating.
 
 {/* If you're currently protecting routes in `clerkMiddleware()`, this approach is no longer recommended. Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
 

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -1,21 +1,21 @@
 ---
-title: Migrating away from middleware-based auth checks
-description: Learn how to migrate away from middleware-based auth checks with createRouteMatcher to resource-based auth checks.
+title: Migrate away from Middleware-based auth checks
+description: Learn how to migrate away from Middleware-based auth checks with createRouteMatcher to resource-based auth checks.
 sdk: nextjs
 ---
 
-This guide describes how to migrate away from middleware-based auth checks with `createRouteMatcher()` and instead move protection to the individual pages, routes and Server Functions.
+This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, routes, and Server Functions.
 
-For a long time, we had no explicit recommendations on whether protection should happen at the proxy/middleware level or at the individual resource level. For a number of reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher) at the bottom of this page, we are deprecating `createRouteMatcher()` and now recommend always protecting the individual resources rather than relying on middleware-based authentication checks.
+Clerk previously didn't make an explicit recommendation about whether protection should happen at the Proxy or Middleware level, or at the individual resource level. For the reasons outlined in [Motivations](#motivations-for-deprecating-create-route-matcher), Clerk is deprecating `createRouteMatcher()` and now recommends protecting individual resources instead of relying on Middleware-based authentication checks.
 
 > [!TIP]
-> To help you protect all resources, we have developed a lint rule that warns you when a resource that should have protection is missing it. Installing it is optional but recommended. See the separate `@clerk/eslint-plugin` documentation for setup instructions.{/*TODO: Add link*/}
+> To help protect all resources, Clerk has developed a lint rule that warns you when a resource is missing required protection. Installing it is optional but recommended. See the separate `@clerk/eslint-plugin` documentation for setup instructions.{/*TODO: Add link*/}
 
 ## Before you start
 
-Before migrating, it's important to understand both how protecting resources works and how removing middleware-based gating can affect your signed-out user experience.
+Before you migrate, it's important to understand how resource protection works and how removing Middleware-based gating can affect your signed-out user experience.
 
-This migration is about both protecting server-side resources and preserving the signed-out user experience. Server-rendered pages, Route Handlers, Server Functions, API endpoints, and any other code that can access privileged data must have auth checks to be properly protected.
+This migration is about both protecting server-side resources and preserving the signed-out user experience. Server-rendered pages, Route Handlers, Server Functions, API endpoints, and any other code that can access privileged data must include their own auth checks.
 
 Client Components don't have privileged access to resources by themselves, but this migration still applies to routes that render Client Components. Client-only routes might need a signed-out state even if there is no server-side resource to protect.
 
@@ -24,54 +24,54 @@ Use the following guides to learn how to protect different types of resources:
 - To require a signed-in user, see the [guide on protecting content from unauthenticated users](/docs/guides/secure/protect-content).
 - To require a specific Role, Permission, Feature, or Plan, see the [guide on authorization checks](/docs/guides/secure/authorization-checks).
 - For machine requests (API keys, OAuth tokens, machine tokens), check the token type in the Route Handler with [`auth({ acceptsToken })`](/docs/reference/nextjs/app-router/auth#verify-machine-requests).
-- To understand how to protect External API endpoints, see the [guide on Making authenticated requests](/docs/guides/development/making-requests) as well as the SDK reference for the programming language or framework your backend API uses.
+- To understand how to protect external API endpoints, see the [guide on making authenticated requests](/docs/guides/development/making-requests) as well as the SDK reference for the programming language or framework your backend API uses.
 
 > [!TIP]
-> Before starting the migration, we recommend that you verify that all relevant Server Functions are protected. These are already unprotected by the middleware, so this step is all about making sure you start the migration from a safe place.
+> Before you start the migration, verify that all relevant Server Functions are protected. These are already unprotected by Middleware, so this step helps you start the migration from a safer baseline.
 >
-> Setting up the lint rule can help with this step, or you can search your codebase for `'use server'` to find your Server Functions.
+> The lint rule can help with this step, or you can search your codebase for `'use server'` to find your Server Functions.
 
 ## Migration guide
 
-To migrate away from middleware-based auth checks, you can follow this rough outline:
+To migrate away from Middleware-based auth checks, follow this outline:
 
 - Optional: Set up the `@clerk/eslint-plugin` and the `require-auth-protection` lint rule
-- Identify the pages, API routes and Server Functions that need protection
+- Identify the pages, Route Handlers, and Server Functions that need protection
 - For each resource:
-  - Server side resource: Add explicit auth guard with the correct response
-  - Client side resource: Verify it has a signed out UI state/redirect
-  - Remove the gate in the middleware
+  - Server-side resource: Add an explicit auth guard with the correct response
+  - Client-side resource: Verify that it has a signed-out UI state or redirect
+  - Remove the gate in Middleware
   - Test the resource when unauthenticated
     - Is it protected?
     - Does it have the expected user experience?
-- Verify you are no longer using `createRouteMatcher`
+- Verify that you are no longer using `createRouteMatcher()`
 
-For smaller applications, you can migrate all resources in one pass. For larger applications, we recommend incrementally migrating a slice of your application at a time in a way that suits your application.
+For smaller applications, you can migrate all resources in one pass. For larger applications, migrate one slice of your application at a time.
 
-Note that you never remove `clerkMiddleware` entirely during this migration, it is still a key piece for Clerk to work correctly and you can keep any non-auth logic you have inside the proxy callback.
+Don't remove `clerkMiddleware()` entirely during this migration. It's still required for Clerk to work correctly, and you can keep any non-auth logic inside the Proxy callback.
 
 ### Identify resources that need protection
 
-It's good to start with having a clear picture of what needs protecting and not. If you have set up the lint rule, the `protected` and `public` patterns already represents the split. If not, looking at your current `createRouteMatcher()` patterns is a good start.
+Start by identifying what needs protection. If you set up the lint rule, the `protected` and `public` patterns already represent that split. Otherwise, use your current `createRouteMatcher()` patterns as a starting point.
 
-In the folders that should require being signed in:
+In folders that require signed-in users:
 
-- Protect all `layout`, `template`, `default`, `page` files
-  - It is not enough to protect only the layout files, as these do not always re-render when pages do
-- Protecting `loading` and `error` files is only necessary if they access sensitive resources
-  - These are usually mostly static and often does not need protecting, but there are exceptions
+- Protect all `layout`, `template`, `default`, and `page` files
+  - Protecting only layout files isn't enough, because they don't always re-render when pages do
+- Protect `loading` and `error` files only if they access sensitive resources
+  - These files are usually mostly static and often don't need protection, but there are exceptions
 - Protect exports from `route` files
-  - All functions named as HTTP verbs turn into API routes, protect these
+  - All functions named as HTTP verbs turn into Route Handlers, so protect them
 
-Server Functions need to be protected regardless of where they are located, audit these separately.
+Server Functions need protection regardless of where they are located, so audit them separately.
 
-### Migrating a single server resource
+### Migrate a single server resource
 
-The following example shows how to migrate a middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but this principle applies to any authentication or authorization check that you want to move to the resource.
+The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or authorization check that you want to move to the resource.
 
 <Include src="_partials/nextjs/nextjs-15-callout" />
 
-If you had your `clerkMiddleware()` protecting a route:
+If `clerkMiddleware()` protects a route:
 
 ```tsx {{ filename: 'proxy.ts' }}
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
@@ -83,9 +83,9 @@ export default clerkMiddleware(async (auth, req) => {
 })
 ```
 
-You would move the auth check into each protected resource itself:
+Move the auth check into each protected resource:
 
-<CodeBlockTabs options={["Server Component", "API route", "Server Function", "Pages Router"]}>
+<CodeBlockTabs options={["Server Component", "Route Handler", "Server Function", "Pages Router"]}>
   ```tsx {{ filename: 'app/dashboard/page.tsx' }}
   import { auth } from '@clerk/nextjs/server'
 
@@ -145,7 +145,7 @@ You would move the auth check into each protected resource itself:
 
 If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
 
-<CodeBlockTabs options={["Server Component", "API route"]}>
+<CodeBlockTabs options={["Server Component", "Route Handler"]}>
   ```tsx {{ filename: 'app/dashboard/page.tsx' }}
   import { auth } from '@clerk/nextjs/server'
 
@@ -175,7 +175,7 @@ If a protected resource needs custom handling for unauthenticated requests, use 
   ```
 </CodeBlockTabs>
 
-And then update your `clerkMiddleware()` to remove the auth check:
+Then update `clerkMiddleware()` to remove the auth check:
 
 ```tsx {{ filename: 'proxy.ts' }}
 import { clerkMiddleware } from '@clerk/nextjs/server'
@@ -186,13 +186,13 @@ export default clerkMiddleware()
 
 ### Handle client-only routes
 
-During the migration, it is important to not only consider security but also user experience.
+During the migration, consider both security and user experience.
 
-If a route only uses Client Components, there may be no server-side resource to protect as part of this migration. However, if the middleware gate previously redirected signed-out users and you remove that redirect without adding a signed-out state, the UX can get worse.
+If a route only uses Client Components, there might be no server-side resource to protect as part of this migration. However, if the Middleware gate previously redirected signed-out users, removing that redirect without adding a signed-out state can make the UX worse.
 
-We expect most applications to already use a combination of protecting API endpoints and middleware level gating. In these cases, the middleware gating happens first and provides the UX, usually redirecting to `/sign-in`. While removing the middleware gating would technically leave the application safe, the UX would likely suffer. For example, pages could fail with generic errors instead of redirecting correctly.
+Most applications already use a combination of protected API endpoints and Middleware-level gating. In these cases, the Middleware gate runs first and provides the UX, usually by redirecting to `/sign-in`. Removing the Middleware gate can leave the application secure while still hurting the UX. For example, pages could fail with generic errors instead of redirecting correctly.
 
-In these cases, this migration is more about preserving the user experience than the security, make sure you verify both. Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+In these cases, this migration is more about preserving the user experience than security, so verify both. Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
 
 One way to preserve the previous UX is to add the signed-out handling to a shared layout for the affected routes:
 
@@ -220,16 +220,16 @@ Use this pattern in the layout for the affected route or route group, rather tha
 
 The reasons for deprecating `createRouteMatcher()` are a mix of existing concerns and new ones.
 
-One main concern has always been that middleware level auth gating can lead to a false sense of security. It's easy to think "I'm already guarding my entire application in the middleware, so I'm safe by default", when in reality there are many reasons the middleware checks might be bypassed, leaving you unprotected when you thought you were safe.
+One main concern has always been that Middleware-level auth gating can lead to a false sense of security. It can be tempting to think, "I'm already guarding my entire application in Middleware, so I'm safe by default." In reality, Middleware checks can be bypassed in several ways, leaving resources unprotected.
 
-One example of this is Server Functions. It's easy to think these are protected by the middleware checks, but in reality these are called _by id_, not by path. If you call a Server Function that lives in `/protected/server-functions.ts` when visiting `/public/`, the middleware will see `/public/` and let it through, even if you are protecting `/protected/:path*`.
+Server Functions are one example. It can be tempting to think these are protected by Middleware checks, but they're called _by id_, not by path. If a Server Function that lives in `/protected/server-functions.ts` is called while visiting `/public/`, Middleware sees `/public/` and lets the request through, even if `/protected/:path*` is protected.
 
-Another example of this is the mapping of regular expressions to folders. Regular expressions have subtle caveats, and any mistake you make can leave you open, when you thought you were safe.
+Another example is the mapping of regular expressions to folders. Regular expressions have subtle caveats, and a mistake can leave a resource unprotected.
 
-Also, any difference in how `createRouteMatcher()` parses and interprets a path, and how the framework ends up resolving it can lead to dangerous gaps. If we normalize a path one way and treat it as public, but the framework normalizes it differently and ends up rendering a protected path, that leads to a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability we disclosed. Any future changes the framework makes to how it interprets path can also lead to new vulnerabilities, which is not a sustainable model over time unless there is first-class framework support.
+Differences between how `createRouteMatcher()` parses a path and how the framework resolves it can also lead to dangerous gaps. If Clerk normalizes a path one way and treats it as public, but the framework normalizes it differently and renders a protected path, that creates a bypass. This is what happened in the [GHSA-vqx2-fgx2-5wq9](https://github.com/clerk/javascript/security/advisories/GHSA-vqx2-fgx2-5wq9) vulnerability. Future framework changes to path interpretation can also introduce new vulnerabilities, which isn't a sustainable model without first-class framework support.
 
-On top of these concerns, there have been a number of framework level proxy/middleware bypasses disclosed recently. In these cases, the request never goes through `createRouteMatcher()` at all, and all auth gating at the middleware level is bypassed.
+On top of these concerns, several framework-level Proxy and Middleware bypasses have been disclosed recently. In these cases, the request never goes through `createRouteMatcher()` at all, and all auth gating at the Middleware level is bypassed.
 
-All of these concerns together is what led us to deprecate `createRouteMatcher()` and to recommend moving away from middleware level auth gating.
+Together, these concerns led Clerk to deprecate `createRouteMatcher()` and recommend moving away from Middleware-level auth gating.
 
-At Clerk, we strongly believe in being _secure by default_, and we believe this is the only decision that can give our customers those guarantees without a sense of false security.
+Clerk strongly believes in being _secure by default_, and this change helps provide those guarantees without creating a false sense of security.

--- a/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher.mdx
@@ -4,10 +4,12 @@ description: Learn how to migrate away from Middleware-based auth checks with cr
 sdk: nextjs
 ---
 
-This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, API routes, and Server Functions. Clerk is deprecating `createRouteMatcher()` and now recommends always protecting individual resources instead of relying on Middleware-based authentication checks.
+This guide describes how to migrate away from Middleware-based auth checks with `createRouteMatcher()` and move protection to individual pages, API routes, and Server Functions. Clerk is deprecating `createRouteMatcher()` and now recommends protecting individual resources instead of relying on Middleware-based authentication checks.
 
 > [!TIP]
-> To help protect all resources, Clerk has developed a lint rule that warns you when a resource is missing required protection. Installing it is optional but recommended. See the separate `@clerk/eslint-plugin` documentation for setup instructions.{/*TODO: Add link*/}
+> To help protect all resources, Clerk has launched [`@clerk/eslint-plugin`](/docs/reference/nextjs/eslint-plugin), which includes `@clerk/next/require-auth-protection`, a lint rule that warns you when a resource is missing required protection.
+>
+> Installing it is optional but recommended. It can help with this migration, and more importantly, it can help ensure you keep all resources protected over time.
 
 ## Before you start
 
@@ -35,184 +37,424 @@ For smaller applications, you can migrate all resources in one pass. For larger 
 
 Don't remove `clerkMiddleware()` entirely during this migration. It's still required for Clerk to work correctly, and you can keep any non-auth logic inside the Proxy callback.
 
-<Steps>
-  ## Identify a slice of your application to migrate
+<Tabs items={["Use the lint rule", "Migrate manually"]}>
+  <Tab>
+    We recommend using the lint rule during migration because it has a bulk fixer CLI. You can also migrate manually if you prefer.
 
-  Choose a route, route group, or feature area to migrate first. Within that slice, identify every resource that needs protection. You can use your current `createRouteMatcher()` patterns as a starting point.
+    The lint rule checks App Router resources. If you use the Pages Router, migrate those routes manually.
 
-  For routes that require signed-in users, check the following files:
+    <Steps>
+      ## Install and configure the lint rule
 
-  - Protect all `layout`, `template`, `default`, and `page` files
-    - Protecting only layout files isn't enough, because they don't always re-render when pages do
-  - Protect `loading` and `error` files only if they access sensitive resources
-    - These files are usually mostly static and often don't need protection, but there are exceptions
-  - Protect exports from `route` files
-    - All functions named as HTTP verbs turn into Route Handlers, so protect them
+      > [!TIP]
+      > See the [`@clerk/eslint-plugin` reference](/docs/reference/nextjs/eslint-plugin) for all options and advanced configuration, including how to set it up for monorepos.
+      >
+      > The reference also describes the exact patterns the lint rule recognizes, like how protection must always be at the top of the function.
 
-  Server Functions need protection regardless of where they are located, so audit them separately.
+      Install `@clerk/eslint-plugin`:
 
-  ## Add auth checks to server resources
+      ```npm
+      npm install --save-dev @clerk/eslint-plugin
+      ```
 
-  The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or authorization check that you want to move to the resource.
+      In your `eslint.config.mjs` file, register the Next.js plugin and declare which folders should contain protected resources. You can base the patterns on your current `createRouteMatcher()` patterns, but you need to convert them from URL-based patterns to folder-based patterns.
 
-  <Include src="_partials/nextjs/nextjs-15-callout" />
+      During an incremental migration, scope `protected` to the slice you're migrating. You can also temporarily disable resource groups that you aren't ready to migrate yet. The following example scopes the rule to a dashboard slice and temporarily skips Server Component entrypoints so you can focus on Route Handlers and Server Functions first:
 
-  If `clerkMiddleware()` protects a route:
+      ```js {{ filename: 'eslint.config.mjs' }}
+      import clerkNext from '@clerk/eslint-plugin/next'
 
-  ```tsx {{ filename: 'proxy.ts' }}
-  import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
-
-  const isProtected = createRouteMatcher(['/dashboard/:path*'])
-
-  export default clerkMiddleware(async (auth, req) => {
-    if (isProtected(req)) await auth.protect()
-  })
-  ```
-
-  Move the auth check into each protected resource:
-
-  <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function", "Pages Router"]}>
-    ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-    import { auth } from '@clerk/nextjs/server'
-
-    export default async function Page() {
-      await auth.protect()
-
-      return <h1>Dashboard</h1>
-    }
-    ```
-
-    ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-    import { auth } from '@clerk/nextjs/server'
-
-    export async function GET() {
-      const { userId } = await auth.protect()
-
-      return Response.json({ userId })
-    }
-    ```
-
-    ```tsx {{ filename: 'app/dashboard/actions.ts' }}
-    'use server'
-
-    import { auth } from '@clerk/nextjs/server'
-
-    export async function updateDashboard() {
-      const { userId } = await auth.protect()
-
-      // Add your Server Function logic using the `userId`
-    }
-    ```
-
-    ```tsx {{ filename: 'pages/dashboard.tsx' }}
-    import { buildClerkProps, getAuth } from '@clerk/nextjs/server'
-    import type { GetServerSideProps } from 'next'
-
-    export const getServerSideProps: GetServerSideProps = async (ctx) => {
-      const { isAuthenticated } = getAuth(ctx.req)
-
-      if (!isAuthenticated) {
-        return {
-          redirect: {
-            destination: '/sign-in',
-            permanent: false,
+      export default [
+        {
+          plugins: { '@clerk/next': clerkNext },
+          rules: {
+            '@clerk/next/require-auth-protection': [
+              'error',
+              {
+                protected: ['src/app/dashboard/**', 'src/actions/dashboard/**'],
+                public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+                resources: {
+                  routeHandlers: true,
+                  serverFunctions: true,
+                  serverComponentEntrypoints: false,
+                },
+              },
+            ],
           },
+        },
+      ]
+      ```
+
+      When you're ready to include pages, layouts, templates, and `default` files in the migration, set `serverComponentEntrypoints` to `true` or remove the `resources` option.
+
+      If you're migrating the whole application at once, you can start with the final pattern instead, for example:
+
+      ```js
+      const clerkProtection = {
+        protected: ['**'],
+        public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+      }
+      ```
+
+      Adapt the exact patterns to your application.
+
+      ## Run the bulk fixer
+
+      > [!TIP]
+      > You can run the fixer with `--dry-run` to see which files would be changed.
+      >
+      > Start from a clean git worktree so you can review the exact diff after running the fixer.
+
+      The lint rule doesn't use ESLint autofixes, because adding protection changes runtime behavior. Instead, Clerk provides a bulk fixer CLI you can run manually:
+
+      ```npm
+      npx clerk-next-fix-auth-protection
+      ```
+
+      Review the generated changes. The fixer adds `await auth.protect()` where it can do so safely, but you might still need to adjust resources that require custom unauthenticated handling or authorization checks.
+
+      ## Manually handle unresolved resources
+
+      Some resources can't be updated automatically, such as imported or wrapped exports. The fixer will warn about these. Add protection manually to those resources when they still need it.
+
+      If the resource is already protected by a wrapper or by code in another file, the rule can't currently verify that protection. In that case, add an ESLint disable comment with a reason:
+
+      ```tsx
+      // eslint-disable-next-line @clerk/next/require-auth-protection -- Protected by withAuth().
+      export const POST = withAuth(handler)
+      ```
+
+      The following examples demonstrate the resource-based checks that the fixer inserts.
+
+      <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function"]}>
+        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export default async function Page() {
+          await auth.protect()
+
+          return <h1>Dashboard</h1>
         }
+        ```
+
+        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export async function GET() {
+          const { userId } = await auth.protect()
+
+          return Response.json({ userId })
+        }
+        ```
+
+        ```tsx {{ filename: 'app/dashboard/actions.ts' }}
+        'use server'
+
+        import { auth } from '@clerk/nextjs/server'
+
+        export async function updateDashboard() {
+          const { userId } = await auth.protect()
+
+          // Add your Server Function logic using the `userId`
+        }
+        ```
+      </CodeBlockTabs>
+
+      If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
+
+      <CodeBlockTabs options={["Server Component", "Route Handler"]}>
+        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export default async function Page() {
+          const { isAuthenticated, userId } = await auth()
+
+          if (!isAuthenticated) {
+            return <p>You must sign in to view this page.</p>
+          }
+
+          return <h1>Dashboard for {userId}</h1>
+        }
+        ```
+
+        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export async function GET() {
+          const { isAuthenticated, userId } = await auth()
+
+          if (!isAuthenticated) {
+            return Response.json({ error: 'Unauthorized' }, { status: 401 })
+          }
+
+          return Response.json({ userId })
+        }
+        ```
+      </CodeBlockTabs>
+
+      ## Preserve signed-out UX for client-only routes
+
+      > [!NOTE]
+      > The lint rule can't help you with this step. You need to verify this manually.
+
+      If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
+
+      Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+
+      One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
+
+      ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
+      import SignedOutRedirect from './SignedOutRedirect'
+
+      export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+        return <SignedOutRedirect>{children}</SignedOutRedirect>
       }
+      ```
 
-      return { props: { ...buildClerkProps(ctx.req) } }
-    }
+      ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
+      'use client'
 
-    export default function Page() {
-      return <h1>Dashboard</h1>
-    }
-    ```
-  </CodeBlockTabs>
+      import { RedirectToSignIn, Show } from '@clerk/nextjs'
 
-  If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
-
-  <CodeBlockTabs options={["Server Component", "Route Handler"]}>
-    ```tsx {{ filename: 'app/dashboard/page.tsx' }}
-    import { auth } from '@clerk/nextjs/server'
-
-    export default async function Page() {
-      const { isAuthenticated, userId } = await auth()
-
-      if (!isAuthenticated) {
-        return <p>You must sign in to view this page.</p>
+      export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
+        return (
+          <>
+            <Show when="signed-in">{children}</Show>
+            <Show when="signed-out">
+              <RedirectToSignIn />
+            </Show>
+          </>
+        )
       }
+      ```
 
-      return <h1>Dashboard for {userId}</h1>
-    }
-    ```
+      Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
 
-    ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
-    import { auth } from '@clerk/nextjs/server'
+      ## Remove the Middleware gate
 
-    export async function GET() {
-      const { isAuthenticated, userId } = await auth()
+      After the server resources and signed-out states are handled, remove the matching auth check from `clerkMiddleware()`:
 
-      if (!isAuthenticated) {
-        return Response.json({ error: 'Unauthorized' }, { status: 401 })
+      ```tsx {{ filename: 'proxy.ts' }}
+      import { clerkMiddleware } from '@clerk/nextjs/server'
+
+      // Keep clerkMiddleware(); it's still required. Only remove the auth gating.
+      export default clerkMiddleware()
+      ```
+
+      ## Test and repeat
+
+      Test the migrated slice while signed out. Verify that protected resources reject unauthenticated requests and that pages still show the expected signed-out experience.
+
+      If you have more slices to migrate, start from the top of the guide and add more patterns to the lint rule. Repeat until you are no longer using `createRouteMatcher()`.
+
+      ## Keep the lint rule enabled for ongoing protection
+
+      Once the migration is complete, tweak the lint rule configuration to include all folders by default, only opting out any public ones. Adapt the exact patterns to your application:
+
+      ```js {{ filename: 'eslint.config.mjs' }}
+      import clerkNext from '@clerk/eslint-plugin/next'
+
+      export default [
+        {
+          plugins: { '@clerk/next': clerkNext },
+          rules: {
+            '@clerk/next/require-auth-protection': [
+              'error',
+              {
+                protected: ['**'],
+                public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+              },
+            ],
+          },
+        },
+      ]
+      ```
+    </Steps>
+  </Tab>
+
+  <Tab>
+    Even if you prefer to migrate manually, we still recommend installing the lint rule to help ensure your resources stay protected over time.
+
+    <Steps>
+      ## Identify a slice of your application to migrate
+
+      Choose a route, route group, or feature area to migrate first. Within that slice, identify every resource that needs protection. You can use your current `createRouteMatcher()` patterns as a starting point.
+
+      For routes that require signed-in users, check the following files:
+
+      - Protect all `layout`, `template`, `default`, and `page` files.
+        - Protecting only layout files isn't enough, because they don't always re-render when pages do.
+      - Protect `loading` and `error` files only if they access sensitive resources.
+        - These files are usually mostly static and often don't need protection, but there are exceptions.
+      - Protect exports from `route` files.
+        - All functions named as HTTP verbs turn into Route Handlers, so protect them.
+
+      Server Functions need protection regardless of where they are located, so audit them separately.
+
+      ## Add auth checks to server resources
+
+      The following example shows how to migrate a Middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource](/docs/guides/secure/protect-content#protect-a-page), but the same principle applies to any authentication or authorization check that you want to move to the resource.
+
+      <Include src="_partials/nextjs/nextjs-15-callout" />
+
+      If `clerkMiddleware()` protects a route:
+
+      ```tsx {{ filename: 'proxy.ts' }}
+      import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+
+      const isProtected = createRouteMatcher(['/dashboard/:path*'])
+
+      export default clerkMiddleware(async (auth, req) => {
+        if (isProtected(req)) await auth.protect()
+      })
+      ```
+
+      Move the auth check into each protected resource:
+
+      <CodeBlockTabs options={["Server Component", "Route Handler", "Server Function", "Pages Router"]}>
+        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export default async function Page() {
+          await auth.protect()
+
+          return <h1>Dashboard</h1>
+        }
+        ```
+
+        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export async function GET() {
+          const { userId } = await auth.protect()
+
+          return Response.json({ userId })
+        }
+        ```
+
+        ```tsx {{ filename: 'app/dashboard/actions.ts' }}
+        'use server'
+
+        import { auth } from '@clerk/nextjs/server'
+
+        export async function updateDashboard() {
+          const { userId } = await auth.protect()
+
+          // Add your Server Function logic using the `userId`
+        }
+        ```
+
+        ```tsx {{ filename: 'pages/dashboard.tsx' }}
+        import { buildClerkProps, getAuth } from '@clerk/nextjs/server'
+        import type { GetServerSideProps } from 'next'
+
+        export const getServerSideProps: GetServerSideProps = async (ctx) => {
+          const { isAuthenticated } = getAuth(ctx.req)
+
+          if (!isAuthenticated) {
+            return {
+              redirect: {
+                destination: '/sign-in',
+                permanent: false,
+              },
+            }
+          }
+
+          return { props: { ...buildClerkProps(ctx.req) } }
+        }
+
+        export default function Page() {
+          return <h1>Dashboard</h1>
+        }
+        ```
+      </CodeBlockTabs>
+
+      If a protected resource needs custom handling for unauthenticated requests, use `auth()` directly instead of `auth.protect()`:
+
+      <CodeBlockTabs options={["Server Component", "Route Handler"]}>
+        ```tsx {{ filename: 'app/dashboard/page.tsx' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export default async function Page() {
+          const { isAuthenticated, userId } = await auth()
+
+          if (!isAuthenticated) {
+            return <p>You must sign in to view this page.</p>
+          }
+
+          return <h1>Dashboard for {userId}</h1>
+        }
+        ```
+
+        ```tsx {{ filename: 'app/api/dashboard/route.ts' }}
+        import { auth } from '@clerk/nextjs/server'
+
+        export async function GET() {
+          const { isAuthenticated, userId } = await auth()
+
+          if (!isAuthenticated) {
+            return Response.json({ error: 'Unauthorized' }, { status: 401 })
+          }
+
+          return Response.json({ userId })
+        }
+        ```
+      </CodeBlockTabs>
+
+      ## Preserve signed-out UX for client-only routes
+
+      If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
+
+      Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+
+      One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
+
+      ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
+      import SignedOutRedirect from './SignedOutRedirect'
+
+      export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+        return <SignedOutRedirect>{children}</SignedOutRedirect>
       }
+      ```
 
-      return Response.json({ userId })
-    }
-    ```
-  </CodeBlockTabs>
+      ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
+      'use client'
 
-  ## Preserve signed-out UX for client-only routes
+      import { RedirectToSignIn, Show } from '@clerk/nextjs'
 
-  If a route only uses Client Components, the protected resource is often an API endpoint that the client calls. If the Middleware gate previously redirected signed-out users before that call happened, removing it without adding a signed-out state can make the UX worse. For example, a page that previously redirected might now show a generic error page instead.
+      export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
+        return (
+          <>
+            <Show when="signed-in">{children}</Show>
+            <Show when="signed-out">
+              <RedirectToSignIn />
+            </Show>
+          </>
+        )
+      }
+      ```
 
-  Use client-side controls such as [`<Show when="signed-out">`](/docs/reference/components/control/show) to render sign-in prompts or other signed-out experiences where appropriate.
+      Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
 
-  One way to preserve the previous UX is to render signed-out handling from the shared layout for the affected routes. Keep this logic in a Client Component so it can respond to client-side auth state changes.
+      ## Remove the Middleware gate
 
-  ```tsx {{ filename: 'app/dashboard/layout.tsx' }}
-  import SignedOutRedirect from './SignedOutRedirect'
+      After the server resources and signed-out states are handled, remove the matching auth check from `clerkMiddleware()`:
 
-  export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-    return <SignedOutRedirect>{children}</SignedOutRedirect>
-  }
-  ```
+      ```tsx {{ filename: 'proxy.ts' }}
+      import { clerkMiddleware } from '@clerk/nextjs/server'
 
-  ```tsx {{ filename: 'app/dashboard/SignedOutRedirect.tsx' }}
-  'use client'
+      // Keep clerkMiddleware(); it's still required. Only remove the auth gating.
+      export default clerkMiddleware()
+      ```
 
-  import { RedirectToSignIn, Show } from '@clerk/nextjs'
+      ## Test and repeat
 
-  export default function SignedOutRedirect({ children }: { children: React.ReactNode }) {
-    return (
-      <>
-        <Show when="signed-in">{children}</Show>
-        <Show when="signed-out">
-          <RedirectToSignIn />
-        </Show>
-      </>
-    )
-  }
-  ```
+      Test the migrated slice while signed out. Verify that protected resources reject unauthenticated requests and that pages still show the expected signed-out experience.
 
-  Use this pattern in the layout for the affected route or route group, rather than in a root layout that also renders public pages. This preserves the signed-out experience, but it doesn't replace auth checks in the API endpoints the client calls.
-
-  ## Remove the Middleware gate
-
-  After the server resources and signed-out states are handled, remove the matching auth check from `clerkMiddleware()`:
-
-  ```tsx {{ filename: 'proxy.ts' }}
-  import { clerkMiddleware } from '@clerk/nextjs/server'
-
-  // Keep clerkMiddleware(); it's still required. Only remove the auth gating.
-  export default clerkMiddleware()
-  ```
-
-  ## Test and repeat
-
-  Test the migrated slice while signed out. Verify that protected resources reject unauthenticated requests and that pages still show the expected signed-out experience.
-
-  Repeat until you are no longer using `createRouteMatcher()`.
-</Steps>
+      Repeat until you are no longer using `createRouteMatcher()`.
+    </Steps>
+  </Tab>
+</Tabs>
 
 ## Motivations for deprecating `createRouteMatcher()`
 

--- a/docs/guides/secure/protect-content.mdx
+++ b/docs/guides/secure/protect-content.mdx
@@ -16,6 +16,9 @@ To protect your application, every resource that reads or mutates protected data
 > [!TIP]
 > To check whether a user is [**authorized** (has a specific Role, Permission, Feature, or Plan)](!authorization-check) in addition to being signed in, see [Authorization checks](/docs/guides/secure/authorization-checks). This guide focuses on **authentication** (whether a user is signed in).
 
+> [!TIP]
+> To help verify that protected Next.js resources keep their own auth checks over time, see the [`@clerk/eslint-plugin` reference](/docs/reference/nextjs/eslint-plugin).
+
 ## Server-side
 
 [`auth()`](/docs/reference/nextjs/app-router/auth) is an App Router-specific helper that you can use inside of your Route Handlers, Server Components, and Server Actions.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1730,6 +1730,10 @@
                                 "href": "/docs/guides/development/upgrading/upgrade-guides/nextjs-v6"
                               },
                               {
+                                "title": "Migrating away from `createRouteMatcher()`",
+                                "href": "/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher"
+                              },
+                              {
                                 "title": "API Version 2025-11-10",
                                 "href": "/docs/guides/development/upgrading/upgrade-guides/2025-11-10"
                               }

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1899,6 +1899,10 @@
                           "href": "/docs/reference/nextjs/clerk-middleware"
                         },
                         {
+                          "title": "`@clerk/eslint-plugin`",
+                          "href": "/docs/reference/nextjs/eslint-plugin"
+                        },
+                        {
                           "title": "App Router",
                           "items": [
                             [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1730,7 +1730,7 @@
                                 "href": "/docs/guides/development/upgrading/upgrade-guides/nextjs-v6"
                               },
                               {
-                                "title": "Migrating away from `createRouteMatcher()`",
+                                "title": "Migrate away from `createRouteMatcher()`",
                                 "href": "/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher"
                               },
                               {

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -36,118 +36,16 @@ export const config = {
 }
 ```
 
-## `createRouteMatcher()`
-
-`createRouteMatcher()` is a Clerk helper function that accepts an array of routes and checks if the route the user is trying to visit matches one of the routes passed to it. The paths provided to this helper can be in the same format as the paths provided to the Next.js Middleware matcher.
-
-The `createRouteMatcher()` helper returns a function that, if called with the `req` object from the Middleware, will return `true` if the user is trying to access a route that matches one of the routes passed to `createRouteMatcher()`.
-
-> [!NOTE]
-> When matching a subtree of routes, prefer the `:path*` form: it maps directly to how the router matches path segments. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
-
-```tsx
-import { createRouteMatcher } from '@clerk/nextjs/server'
-
-const isDashboardRoute = createRouteMatcher(['/dashboard/:path*'])
-```
-
-For non-auth path logic in your proxy, use the framework's native matching (`config.matcher` and `req.nextUrl.pathname`). For an example, see [Geo blocking](/docs/guides/development/geo-blocking).
-
 ## Protecting routes
 
-**Protect access as close to the resource as possible**, in the code that reads or mutates the data. This way, the same code that touches the data also enforces who can reach it.
+The middleware is not the best place to protect routes, instead **protect access as close to the resource as possible**, in the code that reads or mutates the data. This way, the same code that touches the data also enforces who can reach it.
 
 - To require a signed-in user, see the [guide on protecting content from unauthenticated users](/docs/guides/secure/protect-content).
 - To require a specific Role, Permission, Feature, or Plan, see the [guide on authorization checks](/docs/guides/secure/authorization-checks).
 - For machine requests (API keys, OAuth tokens, machine tokens), check the token type in the Route Handler with [`auth({ acceptsToken })`](/docs/reference/nextjs/app-router/auth#verify-machine-requests).
 
-### Migrating from middleware-based auth checks
-
-If you're currently protecting routes in `clerkMiddleware()`, this approach is no longer recommended. Middleware is the wrong layer to decide who may see a resource: to gate a route there, Clerk has to match the request URL the same way your framework and host route it, which means maintaining a second model of your routes, separate from the pages, handlers, and actions they map to. That model has to stay in sync as routes, rewrites, and hosting change, and when it drifts, the check can fail to apply where you intend.
-
-To migrate away from this approach:
-
-- Move the authentication or [authorization check](!authorization-check) into the resource: Add the resource checks first and remove the middleware gate last. If you remove the gate before the resources protect themselves, every route is briefly unprotected.
-- Keep `clerkMiddleware()`: It's required for Clerk configuration and is still the right place for redirects, headers, and other request handling.
-
-The line to hold: if deleting a piece of middleware would leave a resource unprotected, it was a gate and belongs at the resource. A cross-cutting redirect for incomplete [session tasks](/docs/guides/configure/session-tasks) or [onboarding](/docs/guides/development/add-onboarding-flow) can stay in middleware on that basis: the redirect only sends the user somewhere useful first while the resource runs the auth check.
-
-### Example
-
-The following example shows how to migrate a middleware-based auth check to a resource-based auth check. This example performs [an authentication check on the resource using the `auth.protect()` method](/docs/guides/secure/protect-content#protect-a-page), but this principle applies to any authentication or authorization check that you want to move to the resource.
-
-<Include src="_partials/nextjs/nextjs-15-callout" />
-
-If you had your `clerkMiddleware()` protecting a route:
-
-```tsx {{ filename: 'proxy.ts' }}
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
-
-const isProtected = createRouteMatcher(['/dashboard/:path*'])
-
-export default clerkMiddleware(async (auth, req) => {
-  if (isProtected(req)) await auth.protect()
-})
-```
-
-You would move the auth check into the page itself:
-
-```tsx {{ filename: 'app/dashboard/page.tsx' }}
-import { auth } from '@clerk/nextjs/server'
-
-export default async function Page() {
-  await auth.protect()
-
-  return <h1>Dashboard</h1>
-}
-```
-
-And then update your `clerkMiddleware()` to remove the auth check:
-
-```tsx {{ filename: 'proxy.ts' }}
-import { clerkMiddleware } from '@clerk/nextjs/server'
-
-// Keep clerkMiddleware(); it's still required. Only remove the auth gating.
-export default clerkMiddleware()
-```
-
-### Protect a whole subtree
-
-If you were using `createRouteMatcher()` to protect an entire subtree, replicating that exact behavior isn't recommended. Auth checks need to be applied directly within each resource you want to protect. However, to make auth checks easier to manage, you can put the check in a small shared helper and call it from each protected resource.
-
-The following example shows a `requireUser()` helper that uses [`auth.protect()`](/docs/guides/secure/protect-content) to perform its auth check.
-
-```tsx {{ filename: 'app/lib/auth.ts' }}
-import { auth } from '@clerk/nextjs/server'
-
-export async function requireUser() {
-  // Redirects to the sign-in route if the user is not signed in
-  const { userId } = await auth.protect()
-
-  return userId
-}
-```
-
-Then call it from each resource in the subtree:
-
-```tsx {{ filename: 'app/dashboard/page.tsx' }}
-import { requireUser } from '../lib/auth'
-
-export default async function Page() {
-  // Use the created helper to perform the auth check
-  const userId = await requireUser()
-
-  return <h1>Dashboard</h1>
-}
-```
-
-### Migrate "protect everything, allow a few public routes"
-
-If your middleware protects everything and allowlists public routes (the `!isPublicRoute` pattern), migrate in this order:
-
-1. **Add** resource-level checks (or `requireUser()`) to the routes that need them.
-1. **Verify** those routes still require sign-in.
-1. **Then** remove the gating from the middleware callback.
+> [!TIP]
+> If you are currently relying on `createRouteMatcher()` to protect routes, we recommend migrating to resource-based auth checks. See the [guide on migrating away from `createRouteMatcher()`](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for more information.
 
 ## Debug your Middleware
 
@@ -344,3 +242,20 @@ export default clerkMiddleware(
 ### `OrganizationSyncOptions`
 
 <Include src="_partials/organization-sync-options" />
+
+## `createRouteMatcher()`
+
+`createRouteMatcher()` is a Clerk helper function that accepts an array of routes and checks if the route the user is trying to visit matches one of the routes passed to it. The paths provided to this helper can be in the same format as the paths provided to the Next.js Middleware matcher.
+
+The `createRouteMatcher()` helper returns a function that, if called with the `req` object from the Middleware, will return `true` if the user is trying to access a route that matches one of the routes passed to `createRouteMatcher()`.
+
+> [!NOTE]
+> When matching a subtree of routes, prefer the `:path*` form: it maps directly to how the router matches path segments. For example, use `/dashboard/:path*` instead of `/dashboard(.*)`.
+
+```tsx
+import { createRouteMatcher } from '@clerk/nextjs/server'
+
+const isDashboardRoute = createRouteMatcher(['/dashboard/:path*'])
+```
+
+We do not recommend using `createRouteMatcher()` as the main way to protect routes. If you are currently doing that, we recommend migrating to resource-based auth checks. See the [guide on migrating away from `createRouteMatcher()`](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for more information.

--- a/docs/reference/nextjs/clerk-middleware.mdx
+++ b/docs/reference/nextjs/clerk-middleware.mdx
@@ -38,14 +38,14 @@ export const config = {
 
 ## Protecting routes
 
-The middleware is not the best place to protect routes, instead **protect access as close to the resource as possible**, in the code that reads or mutates the data. This way, the same code that touches the data also enforces who can reach it.
+Middleware is not the best place to protect routes. Instead, **protect access as close to the resource as possible**, in the code that reads or mutates the data. This way, the same code that touches the data also enforces who can reach it.
 
 - To require a signed-in user, see the [guide on protecting content from unauthenticated users](/docs/guides/secure/protect-content).
 - To require a specific Role, Permission, Feature, or Plan, see the [guide on authorization checks](/docs/guides/secure/authorization-checks).
 - For machine requests (API keys, OAuth tokens, machine tokens), check the token type in the Route Handler with [`auth({ acceptsToken })`](/docs/reference/nextjs/app-router/auth#verify-machine-requests).
 
 > [!TIP]
-> If you are currently relying on `createRouteMatcher()` to protect routes, we recommend migrating to resource-based auth checks. See the [guide on migrating away from `createRouteMatcher()`](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for more information.
+> If you're currently relying on `createRouteMatcher()` to protect routes, it's recommended to migrate to resource-based auth checks. See the [guide on migrating away from `createRouteMatcher()`](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for more information.
 
 ## Debug your Middleware
 
@@ -258,4 +258,6 @@ import { createRouteMatcher } from '@clerk/nextjs/server'
 const isDashboardRoute = createRouteMatcher(['/dashboard/:path*'])
 ```
 
-We do not recommend using `createRouteMatcher()` as the main way to protect routes. If you are currently doing that, we recommend migrating to resource-based auth checks. See the [guide on migrating away from `createRouteMatcher()`](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for more information.
+For non-auth path logic in your Middleware, use the framework's native matching (`config.matcher` and `req.nextUrl.pathname`). For an example, see [Geo blocking](/docs/guides/development/geo-blocking).
+
+It's not recommended to use `createRouteMatcher()` as the main way to protect routes. If you're currently doing that, it's recommended to migrate to resource-based auth checks. See the [guide on migrating away from `createRouteMatcher()`](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for more information.

--- a/docs/reference/nextjs/eslint-plugin.mdx
+++ b/docs/reference/nextjs/eslint-plugin.mdx
@@ -77,11 +77,11 @@ Globs support a small syntax:
 - `*` matches one path segment.
 - `**` matches any number of path segments.
 
-Patterns must use `/` separators, must be relative, and can't contain empty path segments, `.` segments, `..` segments, or brace expansion.
+Patterns must use `/` separators and must be relative. The dialect doesn't support empty path segments, `.` segments, `..` segments, or brace expansion; patterns that use them are matched literally and won't behave as intended.
 
 When a folder matches both `protected` and `public`, the most specific pattern wins. If both patterns have the same specificity, `protected` wins.
 
-Clerk recommends protecting all resources by default, then exempting public routes:
+It's recommended to protect all resources by default, then exempting public routes:
 
 ```js
 const clerkProtection = {

--- a/docs/reference/nextjs/eslint-plugin.mdx
+++ b/docs/reference/nextjs/eslint-plugin.mdx
@@ -4,22 +4,18 @@ description: Learn how to use Clerk's ESLint plugin to find unprotected Next.js 
 sdk: nextjs
 ---
 
-`@clerk/eslint-plugin` provides lint rules for Clerk patterns across JavaScript frameworks. It currently includes one Next.js App Router rule, `@clerk/next/require-auth-protection`, which helps verify that resources in protected folders guard themselves.
-
-The rule is designed for apps that protect resources directly with [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect), or with an equivalent `auth()` check, instead of relying on Middleware-based route matching.
-
-> [!NOTE]
-> The `require-auth-protection` rule is experimental. Pin the package version if you try it, as breaking changes might ship in minor versions before `v1`.
-
-> [!IMPORTANT]
-> The rule configuration declares intent for tooling. It doesn't protect anything at runtime. A resource is only protected when it calls `await auth.protect()` or performs an equivalent auth check.
->
-> This rule verifies that protected resources require authentication. It doesn't verify that your authorization logic uses the correct Role, Permission, Feature, or Plan. For more guidance on protecting resources, see [Protect content from unauthenticated users](/docs/guides/secure/protect-content).
+`@clerk/eslint-plugin` provides lint rules for Clerk patterns across JavaScript frameworks. It currently includes one Next.js App Router rule, `@clerk/next/require-auth-protection`, which flags server-side resources that are missing an authentication check with either [`await auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) or an equivalent [`auth()`](/docs/reference/nextjs/app-router/auth) check for signed-out users. It also includes a [Bulk Fixer CLI](#bulk-fixer-cli) for automatically adding protection to your resources.
 
 > [!TIP]
-> Migrating away from Middleware-based auth checks? See the [migration guide](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for a step-by-step flow that uses this rule and the bulk fixer.
+> Migrating away from Middleware-based authentication checks? See the [migration guide](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for a step-by-step flow that uses this rule and the Bulk Fixer CLI.
+
+> [!TIP]
+> For runtime protection guidance, see the guide on [protecting content from unauthenticated users](/docs/guides/secure/protect-content).
 
 ## Setup
+
+> [!TIP]
+> The `require-auth-protection` rule is experimental. [Pin](/docs/pinning) the package version if you try it, as breaking changes might ship in minor versions before `v1`.
 
 Install `@clerk/eslint-plugin` as a development dependency:
 
@@ -27,9 +23,9 @@ Install `@clerk/eslint-plugin` as a development dependency:
 npm install --save-dev @clerk/eslint-plugin
 ```
 
-The plugin requires ESLint `>=9` and the flat config format. It can also run with Oxlint when configured as a JavaScript plugin. The rule has ESLint as a peer dependency for the bulk auto-fixer to work.
+The plugin requires ESLint `>=9` and the flat config format. It can also run with Oxlint when configured as a JavaScript plugin.  ESLint is required even in Oxlint setups, because the Bulk Fixer CLI runs against an ESLint instance.
 
-Configure the plugin in your lint config. The following examples protect all resources by default and opt out public sign-in and sign-up routes:
+Configure the plugin in your lint config. The following examples protect all resources by default and opt out of public sign-in and sign-up routes; adapt the `protected` and `public` paths to your application structure. See the [Rule options](#rule-options) section for all options.
 
 <CodeBlockTabs options={["ESLint", "Oxlint"]}>
   ```js {{ filename: 'eslint.config.mjs' }}
@@ -72,9 +68,72 @@ Configure the plugin in your lint config. The following examples protect all res
   ```
 </CodeBlockTabs>
 
-Adapt the `protected` and `public` paths to your application structure.
+### Path matching
 
-## Rule options
+`protected` and `public` patterns are folder globs relative to `rootDir`. Use `app/**` for a root `app` directory, `src/app/**` for a `src/app` directory, and `src/**` or `shared/**` for other project folders.
+
+Globs support a small syntax:
+
+- `*` matches one path segment.
+- `**` matches any number of path segments.
+
+Patterns must use `/` separators, must be relative, and can't contain empty path segments, `.` segments, `..` segments, or brace expansion.
+
+When a folder matches both `protected` and `public`, the most specific pattern wins. If both patterns have the same specificity, `protected` wins.
+
+Clerk recommends protecting all resources by default, then exempting public routes:
+
+```js
+const clerkProtection = {
+  protected: ['**'],
+  public: ['src/app/sign-in/**', 'src/app/sign-up/**', 'src/actions/public/**'],
+}
+```
+
+You can make the default public and opt into protected folders, but Clerk doesn't recommend using `public: ['**']`. A Server Function file imported from a folder matched by public is skipped, even when it's called from a protected page.
+
+If you need a public default for routes, prefer a narrower public pattern:
+
+```js
+const clerkProtection = {
+  public: ['src/app/**'],
+  protected: [
+    // Protect everything outside src/app/.
+    '**',
+    // Or opt into protection for a specific route group in `src/app/`.
+    'src/app/(dashboard)/**',
+  ],
+}
+```
+
+### Monorepos
+
+If each application has its own `eslint.config.*` file, the rule can usually resolve paths without extra configuration.
+
+If your monorepo has a single top-level ESLint config, define the rule once for each application and set `rootDir` to that application's root:
+
+```js {{ filename: 'eslint.config.mjs' }}
+import clerkNext from '@clerk/eslint-plugin/next'
+
+export default [
+  {
+    files: ['apps/web/src/**/*.{ts,tsx}'],
+    plugins: { '@clerk/next': clerkNext },
+    rules: {
+      '@clerk/next/require-auth-protection': [
+        'error',
+        {
+          rootDir: 'apps/web',
+          protected: ['**'],
+          public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+        },
+      ],
+    },
+  },
+]
+```
+
+### Rule options
 
 The `@clerk/next/require-auth-protection` rule accepts one options object.
 
@@ -107,7 +166,7 @@ The `@clerk/next/require-auth-protection` rule accepts one options object.
   - `mixedScopeLayouts?`
   - `'auto' | string[]`
 
-  Layouts and templates that intentionally wrap both protected and public descendants. Defaults to `'auto'`, which skips these files silently. Set this option to an array to require each mixed-scope layout or template folder to be acknowledged explicitly. This makes the rule warn when when it detects new unacknowledged mixed-scope layouts, for example when adding a new public descendant to a previously protected folder.
+  Layouts and templates that intentionally wrap both protected and public descendants. Defaults to `'auto'`, which skips these files silently. Set this option to an array to require each mixed-scope layout or template folder to be acknowledged explicitly. This makes the rule warn when it detects new unacknowledged mixed-scope layouts, for example when adding a new public descendant to a previously protected folder.
 
   ---
 
@@ -117,74 +176,13 @@ The `@clerk/next/require-auth-protection` rule accepts one options object.
   Project root used to resolve project-relative folder globs. Defaults to the nearest ancestor `eslint.config.*` file, then ESLint's current working directory. Set this to `import.meta.dirname` or to an application directory when config auto-discovery doesn't match your project structure. Relative paths are resolved against `cwd`.
 </Properties>
 
-## Path matching
+## How the rule works
 
-`protected` and `public` patterns are folder globs relative to `rootDir`. Use `app/**` for a root `app` directory, `src/app/**` for a `src/app` directory, and `src/**` or `shared/**` for other project folders.
+### What the rule checks
 
-Globs support a small syntax:
+You tell the rule which folders should require authentication (`protected`) and which are exempt (`public`); the rule then verifies that every server-side resource inside a protected folder actually performs that check. It runs at lint time only — it doesn't enforce anything at runtime, and it doesn't check [authorization](!authorization-check).
 
-- `*` matches one path segment.
-- `**` matches any number of path segments.
-
-Patterns must use `/` separators, must be relative, and can't contain empty path segments, `.` segments, `..` segments, or brace expansion.
-
-When a folder matches both `protected` and `public`, the most specific pattern wins. If both patterns have the same specificity, `protected` wins.
-
-Clerk recommends protecting all resources by default, then exempting public routes:
-
-```js
-const clerkProtection = {
-  protected: ['**'],
-  public: ['src/app/sign-in/**', 'src/app/sign-up/**', 'src/actions/public/**'],
-}
-```
-
-You can make the default public and opt into protected folders, but Clerk doesn't recommend using `public: ['**']`. Doing so can hide Server Functions in shared folders from the rule.
-
-If you need a public default for routes, prefer a narrower public pattern:
-
-```js
-const clerkProtection = {
-  public: ['src/app/**'],
-  protected: [
-    // Protect everything outside src/app/.
-    '**',
-    // Opt into protection for part of src/app/.
-    'src/app/(dashboard)/**',
-  ],
-}
-```
-
-## Monorepos
-
-If each application has its own `eslint.config.*` file, the rule can usually resolve paths without extra configuration.
-
-If your monorepo has a single top-level ESLint config, define the rule once for each application and set `rootDir` to that application's root:
-
-```js {{ filename: 'eslint.config.mjs' }}
-import clerkNext from '@clerk/eslint-plugin/next'
-
-export default [
-  {
-    files: ['apps/web/src/**/*.{ts,tsx}'],
-    plugins: { '@clerk/next': clerkNext },
-    rules: {
-      '@clerk/next/require-auth-protection': [
-        'error',
-        {
-          rootDir: 'apps/web',
-          protected: ['**'],
-          public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
-        },
-      ],
-    },
-  },
-]
-```
-
-## What the rule checks
-
-Within folders configured as protected, the rule checks the following resources when their resource group is enabled:
+Within folders configured as `protected`, the rule checks the following `resources` when their resource group is enabled:
 
 - `serverComponentEntrypoints`: Default exports from `page`, `layout`, `template`, and `default` files.
 - `routeHandlers`: HTTP method exports from `route` files, such as `GET`, `POST`, `PUT`, and `DELETE`.
@@ -197,26 +195,28 @@ The rule doesn't check:
 - Arbitrary Server Components that are imported into pages.
 - External API endpoints called by your application.
 
-Client Components aren't checked because they don't have privileged access to resources by themselves. Protect the resources they receive as props and the Route Handlers or external API endpoints they call.
+Client Components aren't checked because they can't reach privileged data directly — they go through Server Functions or Route Handlers, which the rule checks separately. Protect the resources they receive as props and the Route Handlers or external API endpoints they call instead.
 
-The rule only verifies whether a resource has a protection check. You're still responsible for verifying that the check enforces the correct authorization requirements.
+### What counts as an authentication check
 
-## What counts as protected
+> [!TIP]
+> Authentication checks must happen at the top of the function, after directives and TypeScript-only declarations.
 
-The rule accepts a narrow set of protection patterns. The most direct pattern is `auth.protect()` at the top of the relevant function:
+The rule accepts a narrow set of authentication checks. The most direct pattern is [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect) at the top of the relevant function:
 
 ```ts
 import { auth } from '@clerk/nextjs/server'
 
 export default async function Page() {
+  // Redirects unauthenticated users to the sign-in page.
   await auth.protect()
 
-  // A narrower Role or Permission check also works.
+  // Passing an authorization check, such as a Role or Permission, also works.
   await auth.protect({ role: 'org:admin' })
 }
 ```
 
-It also accepts an early-exit check derived from `auth()` that returns, throws, or redirects signed-out users:
+It also accepts authentication checks derived from [`auth()`](/docs/reference/nextjs/app-router/auth) that returns, throws, or redirects signed-out users. The `auth()` destructure must be immediately followed by the authentication check.
 
 ```ts
 import { auth } from '@clerk/nextjs/server'
@@ -230,9 +230,7 @@ export default async function Page() {
 }
 ```
 
-General protection must happen at the top of the function, after directives and TypeScript-only declarations. For custom checks, the `auth()` destructure must be immediately followed by the unauthenticated guard. Additional authorization checks can happen later in the function.
-
-## Wrapped or imported handlers
+### Wrapped or imported handlers
 
 The rule doesn't follow protection across files or through wrapper calls. For example, it can't verify that a handler is protected when you re-export it from another file, or when you wrap it with a helper such as `withAuth(handler)`.
 
@@ -250,38 +248,17 @@ For imported handlers, either add a local wrapper that calls `await auth.protect
 export { handler as GET } from './handler'
 ```
 
-## Editor suggestions
+### Editor suggestions
 
 When the rule finds an unprotected resource, it offers an editor quick-fix suggestion that inserts `await auth.protect()` at the top of the function. When needed, the suggestion also makes the function `async` and adds `import { auth } from '@clerk/nextjs/server'`.
 
-These suggestions are opt-in. They appear in your editor's quick-fix menu and aren't applied by `eslint --fix`, because adding a protection check changes runtime behavior.
+These suggestions are opt-in. They appear in your editor's quick-fix menu and aren't applied by `eslint --fix`, because adding an authentication check changes runtime behavior.
 
-## Bulk auto-fixer
+## Bulk Fixer CLI
 
-The package includes a bulk auto-fixer for migrations or large cleanups. It runs ESLint with your existing config, respects your `protected`, `public`, and `resources` options, and applies the rule's `await auth.protect()` suggestion anywhere it can do so safely.
+The package includes the Bulk Fixer CLI for migrations or large cleanups. It runs ESLint with your existing config, respects your `protected`, `public`, and `resources` options, and applies the rule's `await auth.protect()` suggestion anywhere it can do so safely.
 
-> [!WARNING]
-> Applying these fixes changes your application's runtime behavior. It enforces authentication where there potentially was none, and it might override custom auth checks that were already in place. Review the changes and test your application after running the fixer.
-
-Run the fixer with `npx`:
-
-```npm
-# Fix everything under the current directory.
-npx clerk-next-fix-auth-protection
-
-# Preview without writing files.
-npx clerk-next-fix-auth-protection --dry-run
-
-# Scope fixes to a specific path or glob.
-npx clerk-next-fix-auth-protection "src/**"
-```
-
-The command exits with a non-zero status when:
-
-- `--dry-run` reports changes that would be made.
-- Some resources need manual attention.
-
-Resources can require manual attention when the rule can't safely add a protection check, such as imported or wrapped exports, or mixed-scope layouts that require explicit acknowledgement.
+<Include src="_partials/nextjs/bulk-fixer-cli" />
 
 ### CLI options
 
@@ -307,12 +284,12 @@ clerk-next-fix-auth-protection [patterns...] [options]
   - `-h`, `--help`
   - `boolean`
 
-  Shows command help.
+  Shows command line help.
 </Properties>
 
 ### Programmatic API
 
-You can also run the same fixer from a Node script:
+You can also run the Bulk Fixer programmatically from a Node script:
 
 ```ts
 import { fixAuthProtection } from '@clerk/eslint-plugin/next/fix-auth-protection'
@@ -350,7 +327,7 @@ const { fixed, unresolved } = await fixAuthProtection({
   - `eslint?`
   - `ESLint`
 
-  Advanced option for passing a preconfigured ESLint instance. If omitted, the fixer creates an ESLint instance using the provided `cwd`.
+  Advanced option for passing a preconfigured ESLint instance. If omitted, the Bulk Fixer CLI creates an ESLint instance using the provided `cwd`.
 
   ---
 

--- a/docs/reference/nextjs/eslint-plugin.mdx
+++ b/docs/reference/nextjs/eslint-plugin.mdx
@@ -1,0 +1,391 @@
+---
+title: '`@clerk/eslint-plugin`'
+description: Learn how to use Clerk's ESLint plugin to find unprotected Next.js resources.
+sdk: nextjs
+---
+
+`@clerk/eslint-plugin` provides lint rules for Clerk patterns across JavaScript frameworks. It currently includes one Next.js App Router rule, `@clerk/next/require-auth-protection`, which helps verify that resources in protected folders guard themselves.
+
+The rule is designed for apps that protect resources directly with [`auth.protect()`](/docs/reference/nextjs/app-router/auth#auth-protect), or with an equivalent `auth()` check, instead of relying on Middleware-based route matching.
+
+> [!NOTE]
+> The `require-auth-protection` rule is experimental. Pin the package version if you try it, as breaking changes might ship in minor versions before `v1`.
+
+> [!IMPORTANT]
+> The rule configuration declares intent for tooling. It doesn't protect anything at runtime. A resource is only protected when it calls `await auth.protect()` or performs an equivalent auth check.
+>
+> This rule verifies that protected resources require authentication. It doesn't verify that your authorization logic uses the correct Role, Permission, Feature, or Plan. For more guidance on protecting resources, see [Protect content from unauthenticated users](/docs/guides/secure/protect-content).
+
+> [!TIP]
+> Migrating away from Middleware-based auth checks? See the [migration guide](/docs/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher) for a step-by-step flow that uses this rule and the bulk fixer.
+
+## Setup
+
+Install `@clerk/eslint-plugin` as a development dependency:
+
+```npm
+npm install --save-dev @clerk/eslint-plugin
+```
+
+The plugin requires ESLint `>=9` and the flat config format. It can also run with Oxlint when configured as a JavaScript plugin. The rule has ESLint as a peer dependency for the bulk auto-fixer to work.
+
+Configure the plugin in your lint config. The following examples protect all resources by default and opt out public sign-in and sign-up routes:
+
+<CodeBlockTabs options={["ESLint", "Oxlint"]}>
+  ```js {{ filename: 'eslint.config.mjs' }}
+  import clerkNext from '@clerk/eslint-plugin/next'
+
+  export default [
+    {
+      plugins: { '@clerk/next': clerkNext },
+      rules: {
+        '@clerk/next/require-auth-protection': [
+          'error',
+          {
+            protected: ['**'],
+            public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+          },
+        ],
+      },
+    },
+  ]
+  ```
+
+  ```json {{ filename: '.oxlintrc.json' }}
+  {
+    "jsPlugins": [
+      {
+        "name": "@clerk/next",
+        "specifier": "@clerk/eslint-plugin/next"
+      }
+    ],
+    "rules": {
+      "@clerk/next/require-auth-protection": [
+        "error",
+        {
+          "protected": ["**"],
+          "public": ["src/app/sign-in/**", "src/app/sign-up/**"]
+        }
+      ]
+    }
+  }
+  ```
+</CodeBlockTabs>
+
+Adapt the `protected` and `public` paths to your application structure.
+
+## Rule options
+
+The `@clerk/next/require-auth-protection` rule accepts one options object.
+
+<Properties>
+  - `protected`
+  - `string[]`
+
+  Required. Project-relative folder globs whose resources must be guarded.
+
+  ---
+
+  - `public?`
+  - `string[]`
+
+  Project-relative folder globs that are exempt. Defaults to `[]`.
+
+  ---
+
+  - `resources?`
+  - `{ routeHandlers?: boolean, serverFunctions?: boolean, serverComponentEntrypoints?: boolean }`
+
+  Resource groups to check. All resource groups are enabled by default.
+
+  - `routeHandlers`: Checks HTTP method exports in `route` files.
+  - `serverFunctions`: Checks exported Server Functions in `'use server'` files and inline Server Functions.
+  - `serverComponentEntrypoints`: Checks default exports from `page`, `layout`, `template`, and `default` files.
+
+  ---
+
+  - `mixedScopeLayouts?`
+  - `'auto' | string[]`
+
+  Layouts and templates that intentionally wrap both protected and public descendants. Defaults to `'auto'`, which skips these files silently. Set this option to an array to require each mixed-scope layout or template folder to be acknowledged explicitly. This makes the rule warn when when it detects new unacknowledged mixed-scope layouts, for example when adding a new public descendant to a previously protected folder.
+
+  ---
+
+  - `rootDir?`
+  - `string`
+
+  Project root used to resolve project-relative folder globs. Defaults to the nearest ancestor `eslint.config.*` file, then ESLint's current working directory. Set this to `import.meta.dirname` or to an application directory when config auto-discovery doesn't match your project structure. Relative paths are resolved against `cwd`.
+</Properties>
+
+## Path matching
+
+`protected` and `public` patterns are folder globs relative to `rootDir`. Use `app/**` for a root `app` directory, `src/app/**` for a `src/app` directory, and `src/**` or `shared/**` for other project folders.
+
+Globs support a small syntax:
+
+- `*` matches one path segment.
+- `**` matches any number of path segments.
+
+Patterns must use `/` separators, must be relative, and can't contain empty path segments, `.` segments, `..` segments, or brace expansion.
+
+When a folder matches both `protected` and `public`, the most specific pattern wins. If both patterns have the same specificity, `protected` wins.
+
+Clerk recommends protecting all resources by default, then exempting public routes:
+
+```js
+const clerkProtection = {
+  protected: ['**'],
+  public: ['src/app/sign-in/**', 'src/app/sign-up/**', 'src/actions/public/**'],
+}
+```
+
+You can make the default public and opt into protected folders, but Clerk doesn't recommend using `public: ['**']`. Doing so can hide Server Functions in shared folders from the rule.
+
+If you need a public default for routes, prefer a narrower public pattern:
+
+```js
+const clerkProtection = {
+  public: ['src/app/**'],
+  protected: [
+    // Protect everything outside src/app/.
+    '**',
+    // Opt into protection for part of src/app/.
+    'src/app/(dashboard)/**',
+  ],
+}
+```
+
+## Monorepos
+
+If each application has its own `eslint.config.*` file, the rule can usually resolve paths without extra configuration.
+
+If your monorepo has a single top-level ESLint config, define the rule once for each application and set `rootDir` to that application's root:
+
+```js {{ filename: 'eslint.config.mjs' }}
+import clerkNext from '@clerk/eslint-plugin/next'
+
+export default [
+  {
+    files: ['apps/web/src/**/*.{ts,tsx}'],
+    plugins: { '@clerk/next': clerkNext },
+    rules: {
+      '@clerk/next/require-auth-protection': [
+        'error',
+        {
+          rootDir: 'apps/web',
+          protected: ['**'],
+          public: ['src/app/sign-in/**', 'src/app/sign-up/**'],
+        },
+      ],
+    },
+  },
+]
+```
+
+## What the rule checks
+
+Within folders configured as protected, the rule checks the following resources when their resource group is enabled:
+
+- `serverComponentEntrypoints`: Default exports from `page`, `layout`, `template`, and `default` files.
+- `routeHandlers`: HTTP method exports from `route` files, such as `GET`, `POST`, `PUT`, and `DELETE`.
+- `serverFunctions`: All exports from files with `'use server'` at the top, and all inline functions with `'use server'` at the top of the function body.
+
+The rule doesn't check:
+
+- Files with `'use client'` at the top.
+- `loading` or `error` files.
+- Arbitrary Server Components that are imported into pages.
+- External API endpoints called by your application.
+
+Client Components aren't checked because they don't have privileged access to resources by themselves. Protect the resources they receive as props and the Route Handlers or external API endpoints they call.
+
+The rule only verifies whether a resource has a protection check. You're still responsible for verifying that the check enforces the correct authorization requirements.
+
+## What counts as protected
+
+The rule accepts a narrow set of protection patterns. The most direct pattern is `auth.protect()` at the top of the relevant function:
+
+```ts
+import { auth } from '@clerk/nextjs/server'
+
+export default async function Page() {
+  await auth.protect()
+
+  // A narrower Role or Permission check also works.
+  await auth.protect({ role: 'org:admin' })
+}
+```
+
+It also accepts an early-exit check derived from `auth()` that returns, throws, or redirects signed-out users:
+
+```ts
+import { auth } from '@clerk/nextjs/server'
+
+export default async function Page() {
+  const { isAuthenticated, redirectToSignIn } = await auth()
+
+  if (!isAuthenticated) return redirectToSignIn()
+
+  // ...
+}
+```
+
+General protection must happen at the top of the function, after directives and TypeScript-only declarations. For custom checks, the `auth()` destructure must be immediately followed by the unauthenticated guard. Additional authorization checks can happen later in the function.
+
+## Wrapped or imported handlers
+
+The rule doesn't follow protection across files or through wrapper calls. For example, it can't verify that a handler is protected when you re-export it from another file, or when you wrap it with a helper such as `withAuth(handler)`.
+
+If the resource is already protected by code the rule can't inspect, add an ESLint disable comment with a reason:
+
+```ts
+// eslint-disable-next-line @clerk/next/require-auth-protection -- Protected by withAuth().
+export const POST = withAuth(handler)
+```
+
+For imported handlers, either add a local wrapper that calls `await auth.protect()`, or disable the rule after verifying that the imported handler protects itself:
+
+```ts
+// eslint-disable-next-line @clerk/next/require-auth-protection -- `handler` calls auth.protect().
+export { handler as GET } from './handler'
+```
+
+## Editor suggestions
+
+When the rule finds an unprotected resource, it offers an editor quick-fix suggestion that inserts `await auth.protect()` at the top of the function. When needed, the suggestion also makes the function `async` and adds `import { auth } from '@clerk/nextjs/server'`.
+
+These suggestions are opt-in. They appear in your editor's quick-fix menu and aren't applied by `eslint --fix`, because adding a protection check changes runtime behavior.
+
+## Bulk auto-fixer
+
+The package includes a bulk auto-fixer for migrations or large cleanups. It runs ESLint with your existing config, respects your `protected`, `public`, and `resources` options, and applies the rule's `await auth.protect()` suggestion anywhere it can do so safely.
+
+> [!WARNING]
+> Applying these fixes changes your application's runtime behavior. It enforces authentication where there potentially was none, and it might override custom auth checks that were already in place. Review the changes and test your application after running the fixer.
+
+Run the fixer with `npx`:
+
+```npm
+# Fix everything under the current directory.
+npx clerk-next-fix-auth-protection
+
+# Preview without writing files.
+npx clerk-next-fix-auth-protection --dry-run
+
+# Scope fixes to a specific path or glob.
+npx clerk-next-fix-auth-protection "src/**"
+```
+
+The command exits with a non-zero status when:
+
+- `--dry-run` reports changes that would be made.
+- Some resources need manual attention.
+
+Resources can require manual attention when the rule can't safely add a protection check, such as imported or wrapped exports, or mixed-scope layouts that require explicit acknowledgement.
+
+### CLI options
+
+```txt
+clerk-next-fix-auth-protection [patterns...] [options]
+```
+
+<Properties>
+  - `patterns`
+  - `string[]`
+
+  Files, directories, or globs to scan. Defaults to `['.']`.
+
+  ---
+
+  - `--dry-run`
+  - `boolean`
+
+  Reports what would change without writing files.
+
+  ---
+
+  - `-h`, `--help`
+  - `boolean`
+
+  Shows command help.
+</Properties>
+
+### Programmatic API
+
+You can also run the same fixer from a Node script:
+
+```ts
+import { fixAuthProtection } from '@clerk/eslint-plugin/next/fix-auth-protection'
+
+const { fixed, unresolved } = await fixAuthProtection({
+  patterns: ['src/**'],
+  dryRun: false,
+})
+```
+
+`fixAuthProtection()` accepts the following options:
+
+<Properties>
+  - `patterns?`
+  - `string[]`
+
+  Files, directories, or globs to scan. Defaults to `['.']`.
+
+  ---
+
+  - `cwd?`
+  - `string`
+
+  Working directory that ESLint resolves config and files against. Defaults to `process.cwd()`.
+
+  ---
+
+  - `dryRun?`
+  - `boolean`
+
+  Computes changes without writing them to disk.
+
+  ---
+
+  - `eslint?`
+  - `ESLint`
+
+  Advanced option for passing a preconfigured ESLint instance. If omitted, the fixer creates an ESLint instance using the provided `cwd`.
+
+  ---
+
+  - `onConfigResolved?`
+  - `(configFilePath: string | undefined) => void`
+
+  Called before scanning with the ESLint config file path that will be used.
+
+  ---
+
+  - `onScanComplete?`
+  - `(fileCount: number) => void`
+
+  Called after linting finishes and before per-file fixing begins.
+
+  ---
+
+  - `onFileFixed?`
+  - `(file: FixedFile) => void`
+
+  Called after each file is fixed, or after each file that would be fixed in dry-run mode.
+</Properties>
+
+`fixAuthProtection()` returns:
+
+<Properties>
+  - `fixed`
+  - `{ filePath: string, protections: number }[]`
+
+  Files that were modified, or that would be modified in dry-run mode.
+
+  ---
+
+  - `unresolved`
+  - `{ filePath: string, issues: { line: number, column: number, message: string }[] }[]`
+
+  Files with flagged resources that have no safe automatic fix.
+</Properties>

--- a/docs/reference/nextjs/eslint-plugin.mdx
+++ b/docs/reference/nextjs/eslint-plugin.mdx
@@ -23,7 +23,7 @@ Install `@clerk/eslint-plugin` as a development dependency:
 npm install --save-dev @clerk/eslint-plugin
 ```
 
-The plugin requires ESLint `>=9` and the flat config format. It can also run with Oxlint when configured as a JavaScript plugin.  ESLint is required even in Oxlint setups, because the Bulk Fixer CLI runs against an ESLint instance.
+The plugin requires ESLint `>=9` and the flat config format. It can also run with Oxlint when configured as a JavaScript plugin. ESLint is required even in Oxlint setups, because the Bulk Fixer CLI runs against an ESLint instance.
 
 Configure the plugin in your lint config. The following examples protect all resources by default and opt out of public sign-in and sign-up routes; adapt the `protected` and `public` paths to your application structure. See the [Rule options](#rule-options) section for all options.
 


### PR DESCRIPTION
> Builds on and is targeted at: https://github.com/clerk/clerk-docs/pull/3426

> [!IMPORTANT]
> This does not represent a PR that is ready to merge to main. My intent is to merge it into https://github.com/clerk/clerk-docs/pull/3426
>
> That PR represents what we will finally merge for the `createRouteMatcher` deprecation and will require more work.

### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/fredrik-crm-migration-guide/guides/development/upgrading/upgrade-guides/migrating-from-create-route-matcher
- https://clerk.com/docs/pr/fredrik-crm-migration-guide/reference/nextjs/eslint-plugin
- https://clerk.com/docs/pr/fredrik-crm-migration-guide/reference/nextjs/clerk-middleware

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

* Moves `createRouteMatcher` docs to the bottom of the `clerkMiddleware` reference
* Rewrites the `createRouteMatcher()` migration guide and moves it to the Upgrades section
  * Now includes two paths, one for when using the lint rule, one manual flow
* Adds a reference page for the eslint rule

Note that in contrast to https://github.com/clerk/clerk-docs/pull/3426 I decided to include the wording that `createRouteMatcher` is deprecated here, as I know expect that deprecation to land first, with these docs as an immediate follow-up.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
