### PR TITLE
Generate Backend docs - Sessions, Client, and Invitations APIs

### DIFF
--- a/docs/reference/backend/client/get-client.mdx
+++ b/docs/reference/backend/client/get-client.mdx
@@ -3,24 +3,9 @@ title: '`getClient()`'
 description: Use the getClient() method to retrieve a single client by its ID.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/ClientApi.ts#L19 */}
+<Typedoc src="backend/client-api/methods/get-client" />
 
-Retrieves a single [`Client`](/docs/reference/objects/client).
-
-```ts
-function getClient(clientId: string): Promise<Client>
-```
-
-## Parameters
-
-<Properties>
-  - `clientId`
-  - `string`
-
-  The ID of the client to retrieve.
-</Properties>
-
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/client/get-client.mdx
+++ b/docs/reference/backend/client/get-client.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`getClient()`'
-description: Use the getClient() method to retrieve a single client by its ID.
+description: Use the getClient() method to get a single client by its ID.
 ---
 
 <Typedoc src="backend/client-api/methods/get-client" />

--- a/docs/reference/backend/client/verify-client.mdx
+++ b/docs/reference/backend/client/verify-client.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`verifyClient()`'
-description: Use the verifyClient() method to retrieve a client for a given session token, if the session is active.
+description: Use the verifyClient() method to get a client for a given session token, if the session is active.
 ---
 
 <Typedoc src="backend/client-api/methods/verify-client" />

--- a/docs/reference/backend/client/verify-client.mdx
+++ b/docs/reference/backend/client/verify-client.mdx
@@ -3,24 +3,9 @@ title: '`verifyClient()`'
 description: Use the verifyClient() method to retrieve a client for a given session token, if the session is active.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/ClientApi.ts#L27 */}
+<Typedoc src="backend/client-api/methods/verify-client" />
 
-Verifies the [`Client`](/docs/reference/objects/client) in the provided token.
-
-```ts
-function verifyClient(token: string): Promise<Client>
-```
-
-## Parameters
-
-<Properties>
-  - `token`
-  - `string`
-
-  The session token to verify.
-</Properties>
-
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/invitations/create-invitation-bulk.mdx
+++ b/docs/reference/backend/invitations/create-invitation-bulk.mdx
@@ -3,81 +3,13 @@ title: '`createInvitationBulk()`'
 description: Use the createInvitationBulk() method to create multiple invitations for the given email addresses, and send the invitation emails.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L69 */}
-
-Creates multiple [`Invitation`](/docs/reference/backend/types/backend-invitation)s in bulk for the given email addresses and sends the invitation emails.
-
-If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
-
 > [!CAUTION]
 >
-> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **25 requests per hour** per application instance.
+> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **25 requests per minute** per application instance.
 
-```ts
-function createInvitationBulk(params: CreateBulkParams): Promise<Invitation[]>
-```
+<Typedoc src="backend/invitation-api/methods/create-invitation-bulk" />
 
-## Parameters
-
-<Properties>
-  - `params`
-  - [`CreateBulkParams[]`](#create-bulk-params)
-
-  An array of objects, each representing a single invitation.
-</Properties>
-
-## `CreateBulkParams`
-
-<Properties>
-  - `emailAddress`
-  - `string`
-
-  The email address of the user to invite.
-
-  ---
-
-  - `redirectUrl?`
-  - `string`
-
-  The full URL or path where the user is redirected upon visiting the invitation link, where they can accept the invitation. Required if you have implemented a [custom flow for handling application invitations](/docs/guides/development/custom-flows/authentication/application-invitations).
-
-  ---
-
-  - `publicMetadata?`
-  - [`UserPublicMetadata`](/docs/reference/types/metadata#user-public-metadata)
-
-  Metadata that can be read from both the Frontend API and [Backend API](/docs/reference/backend-api){{ target: '_blank' }}, but can be set only from the Backend API. Once the user accepts the invitation and signs up, these metadata will end up in the user's public metadata.
-
-  ---
-
-  - `notify?`
-  - `boolean`
-
-  Whether an email invitation should be sent to the given email address. Defaults to `true`.
-
-  ---
-
-  - `ignoreExisting?`
-  - `boolean`
-
-  Whether an invitation should be created if there is already an existing invitation for this email address, or if the email address already exists in the application. Defaults to `false`.
-
-  ---
-
-  - `expiresInDays?`
-  - `number`
-
-  The number of days the invitation will be valid for. By default, the invitation expires after 30 days.
-
-  ---
-
-  - `templateSlug?`
-  - `'invitation' | 'waitlist_invitation'`
-
-  The slug of the email template to use for the invitation email. Defaults to `invitation`.
-</Properties>
-
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/invitations/create-invitation-bulk.mdx
+++ b/docs/reference/backend/invitations/create-invitation-bulk.mdx
@@ -5,7 +5,7 @@ description: Use the createInvitationBulk() method to create multiple invitation
 
 > [!CAUTION]
 >
-> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **25 requests per minute** per application instance.
+> This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **25 requests per hour** per application instance.
 
 <Typedoc src="backend/invitation-api/methods/create-invitation-bulk" />
 

--- a/docs/reference/backend/invitations/create-invitation.mdx
+++ b/docs/reference/backend/invitations/create-invitation.mdx
@@ -3,70 +3,11 @@ title: '`createInvitation()`'
 description: Use the createInvitation() method to create a new invitation for the given email address, and send the invitation email.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L42 */}
-
-Creates a new [`Invitation`](/docs/reference/backend/types/backend-invitation) for the given email address and sends the invitation email.
-
-If an email address has already been invited or already exists in your application, trying to create a new invitation will return an error. To bypass this error and create a new invitation anyways, set `ignoreExisting` to `true`.
-
 > [!CAUTION]
 >
 > This endpoint is [rate limited](/docs/guides/how-clerk-works/system-limits#backend-api-requests) to **100 requests per hour** per application instance.
 
-```ts
-function createInvitation(params: CreateParams): Promise<Invitation>
-```
-
-## `CreateParams`
-
-<Properties>
-  - `emailAddress`
-  - `string`
-
-  The email address of the user to invite.
-
-  ---
-
-  - `redirectUrl?`
-  - `string`
-
-  The full URL or path where the user is redirected upon visiting the invitation link, where they can accept the invitation. Required if you have implemented a [custom flow for handling application invitations](/docs/guides/development/custom-flows/authentication/application-invitations).
-
-  ---
-
-  - `publicMetadata?`
-  - [`UserPublicMetadata`](/docs/reference/types/metadata#user-public-metadata)
-
-  Metadata that can be read from both the Frontend API and [Backend API](/docs/reference/backend-api){{ target: '_blank' }}, but can be set only from the Backend API. Once the user accepts the invitation and signs up, these metadata will end up in the user's public metadata.
-
-  ---
-
-  - `notify?`
-  - `boolean`
-
-  Whether an email invitation should be sent to the given email address. Defaults to `true`.
-
-  ---
-
-  - `ignoreExisting?`
-  - `boolean`
-
-  Whether an invitation should be created if there is already an existing invitation for this email address, or if the email address already exists in the application. Defaults to `false`.
-
-  ---
-
-  - `expiresInDays?`
-  - `number`
-
-  The number of days the invitation will be valid for. By default, the invitation expires after 30 days.
-
-  ---
-
-  - `templateSlug?`
-  - `'invitation' | 'waitlist_invitation'`
-
-  The slug of the email template to use for the invitation email. Defaults to `invitation`.
-</Properties>
+<Typedoc src="backend/invitation-api/methods/create-invitation" />
 
 ## Usage
 

--- a/docs/reference/backend/invitations/get-invitation-list.mdx
+++ b/docs/reference/backend/invitations/get-invitation-list.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`getInvitationList()`'
-description: Use the getInvitationList() method to retrieve a list of non-revoked invitations for your application.
+description: Use the getInvitationList() method to get a list of non-revoked invitations for your application.
 ---
 
 <Typedoc src="backend/invitation-api/methods/get-invitation-list" />
@@ -26,7 +26,7 @@ const response = await clerkClient.invitations.getInvitationList({ status: 'revo
 
 ### Limit the number of results
 
-Gets a list of invitations that have been revoked that is filtered by the number of results.
+Gets a list of revoked invitations, limited to the specified number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.invitations.getInvitationList({
@@ -38,7 +38,7 @@ const { data, totalCount } = await clerkClient.invitations.getInvitationList({
 
 ### Skip results
 
-Gets a list of invitations that have been revoked that is filtered by the number of results to skip.
+Gets a list of revoked invitations, skipping the specified number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.invitations.getInvitationList({

--- a/docs/reference/backend/invitations/get-invitation-list.mdx
+++ b/docs/reference/backend/invitations/get-invitation-list.mdx
@@ -3,40 +3,9 @@ title: '`getInvitationList()`'
 description: Use the getInvitationList() method to retrieve a list of non-revoked invitations for your application.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L34 */}
+<Typedoc src="backend/invitation-api/methods/get-invitation-list" />
 
-Retrieves a list of non-revoked invitations for your application, sorted by descending creation date. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`Invitation`](/docs/reference/backend/types/backend-invitation) objects, and a `totalCount` property that indicates the total number of invitations in the system.
-
-```ts
-function getInvitationList(
-  params: GetInvitationListParams,
-): Promise<PaginatedResourceResponse<Invitation[]>>
-```
-
-## `GetInvitationListParams`
-
-<Properties>
-  - `status?`
-  - `accepted | pending | revoked`
-
-  Filter by invitation status.
-
-  ---
-
-  - `limit?`
-  - `number`
-
-  The number of results to return. Must be an integer greater than zero and less than 501. Can be used for paginating the results together with `offset`. Defaults to `10`.
-
-  ---
-
-  - `offset?`
-  - `number`
-
-  Skip the first `offset` results when paginating. Needs to be an integer greater or equal to zero. To be used in conjunction with `limit`. Defaults to `0`.
-</Properties>
-
-## Examples
+## Usage
 
 ### Basic
 

--- a/docs/reference/backend/invitations/get-invitation-list.mdx
+++ b/docs/reference/backend/invitations/get-invitation-list.mdx
@@ -17,7 +17,7 @@ const response = await clerkClient.invitations.getInvitationList()
 
 ### Filter by invitation status
 
-Retrieves list of invitations that have been revoked.
+Gets a list of invitations that have been revoked.
 
 ```tsx
 // get all revoked invitations
@@ -26,7 +26,7 @@ const response = await clerkClient.invitations.getInvitationList({ status: 'revo
 
 ### Limit the number of results
 
-Retrieves list of invitations that have been revoked that is filtered by the number of results.
+Gets a list of invitations that have been revoked that is filtered by the number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.invitations.getInvitationList({
@@ -38,7 +38,7 @@ const { data, totalCount } = await clerkClient.invitations.getInvitationList({
 
 ### Skip results
 
-Retrieves list of invitations that have been revoked that is filtered by the number of results to skip.
+Gets a list of invitations that have been revoked that is filtered by the number of results to skip.
 
 ```tsx
 const { data, totalCount } = await clerkClient.invitations.getInvitationList({

--- a/docs/reference/backend/invitations/revoke-invitation.mdx
+++ b/docs/reference/backend/invitations/revoke-invitation.mdx
@@ -3,26 +3,7 @@ title: '`revokeInvitation()`'
 description: Use the revokeInvitation() method to revoke an invitation.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/InvitationApi.ts#L50 */}
-
-Revokes an [`Invitation`](/docs/reference/backend/types/backend-invitation).
-
-Revoking an invitation makes the invitation email link unusable. However, it doesn't prevent the user from signing up if they follow the sign up flow.
-
-Only active (i.e. non-revoked) invitations can be revoked.
-
-```ts
-function revokeInvitation(invitationId: string): Promise<Invitation>
-```
-
-## Parameters
-
-<Properties>
-  - `invitationId`
-  - `string`
-
-  The ID of the invitation to revoke.
-</Properties>
+<Typedoc src="backend/invitation-api/methods/revoke-invitation" />
 
 ## Usage
 

--- a/docs/reference/backend/sessions/get-session-list.mdx
+++ b/docs/reference/backend/sessions/get-session-list.mdx
@@ -3,81 +3,9 @@ title: '`getSessionList()`'
 description: Use the getSessionList() method to retrieve a list of sessions.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/SessionApi.ts/#L18 */}
+<Typedoc src="backend/session-api/methods/get-session-list" />
 
-Retrieves a list of sessions. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`Session`](/docs/reference/backend/types/backend-session) objects, and a `totalCount` property that indicates the total number of sessions for the specified user.
-
-```ts
-function getSessionList(
-  queryParams: SessionListParams,
-): Promise<PaginatedResourceResponse<Session[]>>
-```
-
-## `SessionListParams`
-
-`getSessionList()` requires either `clientId` or `userId` to be provided.
-
-<Properties>
-  - `clientId?`
-  - `string`
-
-  The client ID to retrieve the list of sessions for.
-
-  ---
-
-  - `userId?`
-  - `string`
-
-  The user ID to retrieve the list of sessions for.
-
-  ---
-
-  - `status?`
-  - [`SessionStatus`](#session-status)
-
-  The status of the session.
-
-  ---
-
-  - `limit?`
-  - `number`
-
-  The number of results to return. Must be an integer greater than zero and less than 501. Can be used for paginating the results together with `offset`. Defaults to `10`.
-
-  ---
-
-  - `offset?`
-  - `number`
-
-  Skip the first `offset` results when paginating. Needs to be an integer greater or equal to zero. To be used in conjunction with `limit`. Defaults to `0`.
-</Properties>
-
-### `SessionStatus`
-
-```tsx
-type SessionStatus =
-  | 'abandoned'
-  | 'active'
-  | 'pending'
-  | 'ended'
-  | 'expired'
-  | 'removed'
-  | 'replaced'
-  | 'revoked'
-```
-
-| Value | Description |
-| - | - |
-| `abandoned` | The session was abandoned client-side. |
-| `active` | The session is valid and all activity is allowed. |
-| `pending` | The user has signed in but hasn't completed [session tasks](/docs/guides/configure/session-tasks). |
-| `ended` | The user signed out of the session, but the `Session` remains in the `Client` object. |
-| `expired` | The period of allowed activity for this session has passed. |
-| `removed` | The user signed out of the session and the `Session` was removed from the `Client` object. |
-| `replaced` | The session has been replaced by another one, but the `Session` remains in the `Client` object. |
-| `revoked` | The application ended the session and the `Session` was removed from the `Client` object. |
-
-## Examples
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/sessions/get-session-list.mdx
+++ b/docs/reference/backend/sessions/get-session-list.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`getSessionList()`'
-description: Use the getSessionList() method to retrieve a list of sessions.
+description: Use the getSessionList() method to get a list of sessions.
 ---
 
 <Typedoc src="backend/session-api/methods/get-session-list" />
@@ -9,7 +9,7 @@ description: Use the getSessionList() method to retrieve a list of sessions.
 
 <Include src="_partials/backend/usage" />
 
-Retrieve a list of sessions for a specific `userId`:
+Get a list of sessions for a specific `userId`:
 
 ```tsx
 const userId = 'user_123'

--- a/docs/reference/backend/sessions/get-session.mdx
+++ b/docs/reference/backend/sessions/get-session.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`getSession()`'
-description: Use the getSession() method to retrieve a single session by its ID.
+description: Use the getSession() method to get a single session by its ID.
 ---
 
 <Typedoc src="backend/session-api/methods/get-session" />

--- a/docs/reference/backend/sessions/get-session.mdx
+++ b/docs/reference/backend/sessions/get-session.mdx
@@ -3,24 +3,9 @@ title: '`getSession()`'
 description: Use the getSession() method to retrieve a single session by its ID.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/SessionApi.ts/#L26 */}
+<Typedoc src="backend/session-api/methods/get-session" />
 
-Retrieves a single [`Session`](/docs/reference/backend/types/backend-session).
-
-```ts
-function getSession(sessionId: string): Promise<Session>
-```
-
-## Parameters
-
-<Properties>
-  - `sessionId`
-  - `string`
-
-  The ID of the session to retrieve.
-</Properties>
-
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/sessions/get-token.mdx
+++ b/docs/reference/backend/sessions/get-token.mdx
@@ -3,38 +3,9 @@ title: '`getToken()`'
 description: Use the getToken() method to retrieve a token for a JWT template that is defined in the Clerk Dashboard.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/SessionApi.ts/#L51 */}
+<Typedoc src="backend/session-api/methods/get-token" />
 
-Retrieves a session token or generate a JWT using a specified template that is defined on the [**JWT templates**](https://dashboard.clerk.com/~/jwt-templates) page in the Clerk Dashboard.
-
-```ts
-function getToken(sessionId: string, template: string): Promise<Token>
-```
-
-## Parameters
-
-<Properties>
-  - `sessionId`
-  - `string`
-
-  The ID of the session to retrieve a token for.
-
-  ---
-
-  - `expiresInSeconds?`
-  - `number`
-
-  The expiration time for the token in seconds. If not provided, uses the default expiration time for the JWT template.
-
-  ---
-
-  - `template?`
-  - `string`
-
-  The name of the JWT template from the [Clerk Dashboard](https://dashboard.clerk.com/~/jwt-templates) to generate a new token from. For example: 'firebase', 'grafbase', or your custom template's name.
-</Properties>
-
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/sessions/get-token.mdx
+++ b/docs/reference/backend/sessions/get-token.mdx
@@ -1,6 +1,6 @@
 ---
 title: '`getToken()`'
-description: Use the getToken() method to retrieve a token for a JWT template that is defined in the Clerk Dashboard.
+description: Use the getToken() method to get a token for a JWT template that is defined in the Clerk Dashboard.
 ---
 
 <Typedoc src="backend/session-api/methods/get-token" />

--- a/docs/reference/backend/sessions/revoke-session.mdx
+++ b/docs/reference/backend/sessions/revoke-session.mdx
@@ -3,26 +3,9 @@ title: '`revokeSession()`'
 description: Use the revokeSession() method to revoke a session given its ID.
 ---
 
-{/* clerk/javascript file: https://github.com/clerk/javascript/blob/main/packages/backend/src/api/endpoints/SessionApi.ts/#L34 */}
+<Typedoc src="backend/session-api/methods/revoke-session" />
 
-Revokes a [`Session`](/docs/reference/backend/types/backend-session).
-
-User will be signed out from the particular client the referred to.
-
-```ts
-function revokeSession(sessionId: string): Promise<Session>
-```
-
-## Parameters
-
-<Properties>
-  - `sessionId`
-  - `string`
-
-  The ID of the session to revoke.
-</Properties>
-
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/sessions/verify-session.mdx
+++ b/docs/reference/backend/sessions/verify-session.mdx
@@ -8,7 +8,7 @@ description: Use the verifySession() method to verify whether a session with a g
 
 Verifies whether a session with a given ID corresponds to the provided session token. Throws an error if the provided ID is invalid.
 
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 


### PR DESCRIPTION
### What does this solve? What changed?

Replaces the hand-written Backend reference pages for Sessions, Client, and Invitations with `<Typedoc />` includes sourced from https://github.com/clerk/javascript/pull/8853, so the reference stays in sync with the SDK going forward.

- Sessions: `get-session-list`, `get-session`, `get-token`, `revoke-session`, `verify-session`
- Client: `get-client`, `verify-client`
- Invitations: `create-invitation`, `create-invitation-bulk`, `get-invitation-list`, `revoke-invitation`
- Renames `Example` → `Usage` sections

Stacked on #3445 (`aa/DOCS-10984`).

### Deadline

- No rush

### Other resources

-
