### PR TITLE
Soften mentions of Beta in regards to Clerk Billing

### DIFF
--- a/clerk-typedoc/react/plan-details-button.mdx
+++ b/clerk-typedoc/react/plan-details-button.mdx
@@ -1,4 +1,5 @@
-A button component that opens the Clerk Plan Details drawer when clicked.
+A button component that opens the Clerk Plan Details drawer when clicked. This component is part of
+Clerk's Billing feature which is available under a public beta.
 
 ## Parameters
 

--- a/clerk-typedoc/react/plan-details-button.mdx
+++ b/clerk-typedoc/react/plan-details-button.mdx
@@ -1,5 +1,4 @@
-A button component that opens the Clerk Plan Details drawer when clicked. This component is part of
-Clerk's Billing feature which is available under a public beta.
+A button component that opens the Clerk Plan Details drawer when clicked.
 
 ## Parameters
 

--- a/docs/_partials/billing/billing-experimental.mdx
+++ b/docs/_partials/billing/billing-experimental.mdx
@@ -1,3 +1,3 @@
-> [!INFORMATION]
+> [!IMPORTANT]
 >
 > Billing is under active development, and regularly introduces new features and UI changes to our components. If you'd like to remain on a specific version of our components or SDK, you can follow the steps in the [pinning](/docs/pinning) documentation.

--- a/docs/_partials/billing/billing-experimental.mdx
+++ b/docs/_partials/billing/billing-experimental.mdx
@@ -1,3 +1,3 @@
-> [!WARNING]
+> [!INFORMATION]
 >
-> Billing is currently in Beta and its APIs are experimental and may undergo breaking changes. To mitigate potential disruptions, we recommend [pinning](/docs/pinning) your SDK and `clerk-js` package versions.
+> Billing is under active development, and regularly introduces new features and UI changes to our components. If you'd like to remain on a specific version of our components or SDK, you can follow the steps in the [pinning](/docs/pinning) documentation.

--- a/docs/_partials/billing/billing-experimental.mdx
+++ b/docs/_partials/billing/billing-experimental.mdx
@@ -1,3 +1,3 @@
 > [!IMPORTANT]
 >
-> Billing is under active development, and regularly introduces new features and UI changes to our components. If you'd like to remain on a specific version of our components or SDK, you can follow the steps in the [pinning](/docs/pinning) documentation.
+> Billing regularly introduces new features and UI changes to Clerk's components. If you'd like to remain on a specific version of Clerk's components or SDK, you can follow the steps in the [pinning](/docs/pinning) documentation.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2356,38 +2356,31 @@
                         },
                         {
                           "title": "`useCheckout()`",
-                          "href": "/docs/reference/hooks/use-checkout",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-checkout"
                         },
                         {
                           "title": "`usePaymentElement()`",
-                          "href": "/docs/reference/hooks/use-payment-element",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-payment-element"
                         },
                         {
                           "title": "`usePaymentMethods()`",
-                          "href": "/docs/reference/hooks/use-payment-methods",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-payment-methods"
                         },
                         {
                           "title": "`usePlans()`",
-                          "href": "/docs/reference/hooks/use-plans",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-plans"
                         },
                         {
                           "title": "`useSubscription()`",
-                          "href": "/docs/reference/hooks/use-subscription",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-subscription"
                         },
                         {
                           "title": "`usePaymentAttempts()`",
-                          "href": "/docs/reference/hooks/use-payment-attempts",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-payment-attempts"
                         },
                         {
                           "title": "`useStatements()`",
-                          "href": "/docs/reference/hooks/use-statements",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/hooks/use-statements"
                         },
                         {
                           "title": "`useAPIKeys()`",
@@ -2462,8 +2455,7 @@
                         },
                         {
                           "title": "`Billing`",
-                          "href": "/docs/reference/objects/billing",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/objects/billing"
                         }
                       ]
                     ]
@@ -3754,18 +3746,15 @@
                         },
                         {
                           "title": "`<CheckoutButton />`",
-                          "href": "/docs/reference/components/billing/checkout-button",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/components/billing/checkout-button"
                         },
                         {
                           "title": "`<PlanDetailsButton />`",
-                          "href": "/docs/reference/components/billing/plan-details-button",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/components/billing/plan-details-button"
                         },
                         {
                           "title": "`<SubscriptionDetailsButton />`",
-                          "href": "/docs/reference/components/billing/subscription-details-button",
-                          "tag": "(Beta)"
+                          "href": "/docs/reference/components/billing/subscription-details-button"
                         }
                       ]
                     ]

--- a/docs/pinning.mdx
+++ b/docs/pinning.mdx
@@ -11,7 +11,7 @@ Another range operator is the tilde (\~) symbol for more restrictive versioning.
 
 When you **pin a dependency**, you specify the exact version **without any range operators**. For example, `"@clerk/nextjs": "1.1.0"` means "use exactly version 1.1.0, no other version." This approach gives you complete control over which version your application uses.
 
-With Clerk, we recommend pinning your Clerk SDK in **both** of these ways:
+With Clerk, we recommend pinning your Clerk SDK in **all three** of these ways:
 
 1. Pin your Clerk SDK in your `package.json` file to a specific version (no range operators).
    ```json {{ filename: 'package.json', prettier: false }}
@@ -20,4 +20,13 @@ With Clerk, we recommend pinning your Clerk SDK in **both** of these ways:
 1. Set the `clerkJsVersion` property when you initialize the Clerk integration. For most SDKs, this is done in the `<ClerkProvider>` component. For SDKs like Astro or Nuxt, this is done in the configuration file.
    ```tsx {{ prettier: false }}
    <ClerkProvider clerkJsVersion="1.1.0">
+   ```
+1. Install and import the `@clerk/ui` package. More information can be found in the [component versioning](/docs/reference/components/versioning) documentation.
+   ```tsx {{ prettier: false }}
+   import { ClerkProvider } from '@clerk/nextjs' // or '@clerk/react'
+   import { ui } from '@clerk/ui'
+
+   export default function Layout({ children }) {
+     return <ClerkProvider ui={ui}>{children}</ClerkProvider>
+   }
    ```

--- a/docs/pinning.mdx
+++ b/docs/pinning.mdx
@@ -21,7 +21,7 @@ With Clerk, we recommend pinning your Clerk SDK in **all three** of these ways:
    ```tsx {{ prettier: false }}
    <ClerkProvider clerkJsVersion="1.1.0">
    ```
-1. Install and import the `@clerk/ui` package. More information can be found in the [component versioning](/docs/reference/components/versioning) documentation.
+1. If you use Clerk's prebuilt components, also install and import the `@clerk/ui` package to pin the component layer. More information can be found in the [component versioning](/docs/reference/components/versioning) documentation.
    ```tsx {{ prettier: false }}
    import { ClerkProvider } from '@clerk/nextjs' // or '@clerk/react'
    import { ui } from '@clerk/ui'


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/dsfix-billing-beta/guides/billing/overview
- https://clerk.com/docs/pr/dsfix-billing-beta/pinning

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- This PR removes the "Beta" label from Clerk Billing features and adjusts the warning on Billing documentation pages into an important alert (instead of a warning) with softer language to better reflect our intentions around stability in the Billing product.

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- no rush

### Other resources

- JS PR for typedoc change: https://github.com/clerk/javascript/pull/8952
