### PR TITLE
docs(ai): add Clerk and Eve integration guide group

### DIFF
--- a/docs/guides/ai/eve/api-keys-and-m2m.mdx
+++ b/docs/guides/ai/eve/api-keys-and-m2m.mdx
@@ -1,10 +1,10 @@
 ---
 title: API keys & M2M
-description: Authenticate Clerk API key callers and agent-to-agent M2M traffic in an Eve agent — from creating the machines in Clerk to verifying the inbound tokens.
+description: Authenticate Clerk API key callers and agent-to-agent M2M traffic in an eve agent — from creating the machines in Clerk to verifying the inbound tokens.
 sdk: nextjs
 ---
 
-This page covers two token types from the [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) chain: **[API keys](/docs/guides/development/machine-auth/api-keys)** for programmatic callers, and **[M2M tokens](/docs/guides/development/machine-auth/m2m-tokens)** for cross-agent communication.
+**[API keys](/docs/guides/development/machine-auth/api-keys)** authenticate programmatic callers; **[M2M tokens](/docs/guides/development/machine-auth/m2m-tokens)** authenticate calls between your agents. Both extend the [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) chain. Create each token in Clerk, then verify it at your agent's channel.
 
 > [!TIP]
 > Skip the manual setup — install `clerkAuth()` (channel auth) and `clerkM2MToken()` (for subagent delegation) via shadcn.
@@ -13,11 +13,13 @@ This page covers two token types from the [Custom channel auth](/docs/guides/ai/
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
-## Build it from scratch
+The sections below set up both token types by hand: API key authentication first, then agent-to-agent M2M.
 
-### API key authentication
+## API key authentication
 
-#### Create an API key
+An API key authenticates a known programmatic caller — a script, a cron job, a partner's backend — as a Clerk user or org. Create one, then verify it at your channel.
+
+### Create an API key
 
 <Tabs items={["Clerk CLI", "Backend API"]}>
   <Tab>
@@ -43,13 +45,13 @@ bunx --bun shadcn@latest add clerk/eve-agents/auth
   </Tab>
 </Tabs>
 
-The returned `secret` is shown once. Hand it to the caller as a bearer token.
+Clerk returns the `secret` once. Hand it to the caller as a bearer token.
 
-#### Verify the API key in the channel
+### Verify the API key in the channel
 
 Set `acceptsToken: 'api_key'` and map the result.
 
-```ts {{ filename: 'agent/channels/eve.ts' }}
+```ts {{ filename: 'agent/channels/eve.ts', mark: [11] }}
 import { createClerkClient } from '@clerk/backend'
 import type { AuthFn } from 'eve/channels/auth'
 import { eveChannel } from 'eve/channels/eve'
@@ -88,7 +90,7 @@ export default eveChannel({
 
 API keys are scoped to either a user or an org, never both — pass through whichever Clerk populated.
 
-#### Verify required scopes
+### Verify required scopes
 
 Check `auth.scopes` and decide where to enforce. Reject at the channel boundary when the scope is required to talk to the agent at all. Check inside a tool when the scope only matters for that tool, and return a structured error the model can relay to the caller.
 
@@ -136,11 +138,11 @@ Check `auth.scopes` and decide where to enforce. Reject at the channel boundary 
   </Tab>
 </Tabs>
 
-### Agent-to-agent M2M
+## Agent-to-agent M2M
 
-Agents on different deployments can communicate securely using M2M auth. To do this, each agent has to be associated with a Clerk machine. The caller mints with its own machine secret; the receiver verifies with its own. Agent-to-agent relationships are modeled as Clerk **scopes** — granting `main-agent → project-agent` lets the main agent mint tokens the project agent will accept. Revoking the scope is a runtime kill switch.
+M2M auth lets agents on separate deployments call each other. Each agent gets a Clerk **machine**: the caller mints a token with its own machine secret, and the receiver verifies with its own. A one-way **scope** models the relationship. Grant `main-agent → project-agent` and the main agent can mint tokens the project agent accepts. Remove the scope and it's a runtime kill switch.
 
-#### Create the machines
+### Create the machines
 
 <Tabs items={["Clerk CLI", "Backend API"]}>
   <Tab>
@@ -160,7 +162,7 @@ Agents on different deployments can communicate securely using M2M auth. To do t
   </Tab>
 
   <Tab>
-    ```ts
+    ```ts {{ mark: [8] }}
     import { createClerkClient } from '@clerk/backend'
 
     const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY! })
@@ -180,11 +182,11 @@ Scopes are one-way. For two-way calls, create the reverse scope too. Copy each m
 CLERK_MACHINE_SECRET_KEY=ak_...
 ```
 
-#### Outbound: mint a token in the calling agent
+### Outbound: mint a token in the calling agent
 
 Declare the receiver as a remote subagent. Mint with [`m2m.createToken()`](/docs/reference/backend/m2m-tokens/create-token), then hand the lazy resolver to [`bearer()`](https://eve.dev/docs/guides/remote-agents#outbound-auth).
 
-```ts {{ filename: 'agent/subagents/project.ts' }}
+```ts {{ filename: 'agent/subagents/project.ts', mark: [21] }}
 import { createClerkClient } from '@clerk/backend'
 import { defineRemoteAgent } from 'eve'
 import { bearer } from 'eve/agents/auth'
@@ -209,13 +211,13 @@ export default defineRemoteAgent({
 })
 ```
 
-`bearer(resolver)` runs the resolver on every outbound request, so each call carries a valid token — Clerk reuses the current one while it has at least `minRemainingTtlSeconds` left and mints a new one otherwise.
+`bearer(resolver)` runs the resolver on every outbound request, so each call carries a valid token. Clerk reuses the current one while it has at least `minRemainingTtlSeconds` left and mints a new one otherwise.
 
-#### Inbound: verify the token in the receiving agent
+### Inbound: verify the token in the receiving agent
 
-Same channel pattern as before — pass `machineSecretKey` and set `acceptsToken: 'm2m_token'`. Clerk does the signature and scope checks before this code sees the principal.
+Verify like any other channel token: pass `machineSecretKey` and set `acceptsToken: 'm2m_token'`. Clerk runs the signature and scope checks before your code sees the principal.
 
-```ts {{ filename: 'agent/channels/eve.ts' }}
+```ts {{ filename: 'agent/channels/eve.ts', mark: [4, 5] }}
 const clerkAuth: AuthFn<Request> = async (request) => {
   const state = await clerk
     .authenticateRequest(request, {
@@ -243,13 +245,13 @@ const clerkAuth: AuthFn<Request> = async (request) => {
 
 A missing or revoked scope rejects the token with `401`.
 
-#### Runtime decoupling
+### Runtime decoupling
 
-Remove a scope in the Dashboard — or via [`machines.deleteScope()`](/docs/reference/backend/machines/delete-scope) — and the next minted token fails verification. No code change, no redeploy.
+Remove a scope in the **Clerk Dashboard** — or via [`machines.deleteScope()`](/docs/reference/backend/machines/delete-scope) — and the next minted token fails verification. No code change, no redeploy.
 
-## Next steps
+## Related guides
 
-- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — the multi-token auth chain this page builds on.
-- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate tool invocations against permissions and scopes.
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — the multi-token auth chain these tokens build on.
+- [Authorize tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate tool invocations against permissions and scopes.
 - [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens) — full reference for machines, scopes, and token claims.
 - [Token formats](/docs/guides/development/machine-auth/token-formats) — when to choose JWT M2M tokens over opaque ones.

--- a/docs/guides/ai/eve/api-keys-and-m2m.mdx
+++ b/docs/guides/ai/eve/api-keys-and-m2m.mdx
@@ -58,7 +58,7 @@ const clerk = createClerkClient({
   secretKey: process.env.CLERK_SECRET_KEY,
 })
 
-const apiKeyAuth: AuthFn<Request> = async request => {
+const apiKeyAuth: AuthFn<Request> = async (request) => {
   const state = await clerk
     .authenticateRequest(request, { acceptsToken: 'api_key' })
     .catch(() => null)
@@ -216,7 +216,7 @@ export default defineRemoteAgent({
 Same channel pattern as before — pass `machineSecretKey` and set `acceptsToken: 'm2m_token'`. Clerk does the signature and scope checks before this code sees the principal.
 
 ```ts {{ filename: 'agent/channels/eve.ts' }}
-const clerkAuth: AuthFn<Request> = async request => {
+const clerkAuth: AuthFn<Request> = async (request) => {
   const state = await clerk
     .authenticateRequest(request, {
       acceptsToken: 'm2m_token',

--- a/docs/guides/ai/eve/api-keys-and-m2m.mdx
+++ b/docs/guides/ai/eve/api-keys-and-m2m.mdx
@@ -13,6 +13,8 @@ sdk: nextjs
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
+---
+
 The sections below set up both token types by hand: API key authentication first, then agent-to-agent M2M.
 
 ## API key authentication

--- a/docs/guides/ai/eve/api-keys-and-m2m.mdx
+++ b/docs/guides/ai/eve/api-keys-and-m2m.mdx
@@ -182,7 +182,7 @@ CLERK_MACHINE_SECRET_KEY=ak_...
 
 #### Outbound: mint a token in the calling agent
 
-Declare the receiver as a remote subagent. Mint with [`m2m.createToken()`](/docs/reference/backend/m2m-tokens/create-token), then hand the lazy resolver to [`bearer()`](https://eve.dev/docs/guides/auth-and-route-protection#bearer).
+Declare the receiver as a remote subagent. Mint with [`m2m.createToken()`](/docs/reference/backend/m2m-tokens/create-token), then hand the lazy resolver to [`bearer()`](https://eve.dev/docs/guides/remote-agents#outbound-auth).
 
 ```ts {{ filename: 'agent/subagents/project.ts' }}
 import { createClerkClient } from '@clerk/backend'
@@ -209,7 +209,7 @@ export default defineRemoteAgent({
 })
 ```
 
-`bearer(resolver)` runs the resolver per outbound request, so every call carries a fresh token.
+`bearer(resolver)` runs the resolver on every outbound request, so each call carries a valid token — Clerk reuses the current one while it has at least `minRemainingTtlSeconds` left and mints a new one otherwise.
 
 #### Inbound: verify the token in the receiving agent
 

--- a/docs/guides/ai/eve/api-keys-and-m2m.mdx
+++ b/docs/guides/ai/eve/api-keys-and-m2m.mdx
@@ -1,0 +1,255 @@
+---
+title: API keys & M2M
+description: Authenticate Clerk API key callers and agent-to-agent M2M traffic in an Eve agent — from creating the machines in Clerk to verifying the inbound tokens.
+sdk: nextjs
+---
+
+This page covers two token types from the [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) chain: **[API keys](/docs/guides/development/machine-auth/api-keys)** for programmatic callers, and **[M2M tokens](/docs/guides/development/machine-auth/m2m-tokens)** for cross-agent communication.
+
+> [!TIP]
+> Skip the manual setup — install `clerkAuth()` (channel auth) and `clerkM2MToken()` (for subagent delegation) via shadcn.
+
+```bash {{ filename: 'terminal', prompt: '$' }}
+bunx --bun shadcn@latest add clerk/eve-agents/auth
+```
+
+## Build it from scratch
+
+### API key authentication
+
+#### Create an API key
+
+<Tabs items={["Clerk CLI", "Backend API"]}>
+  <Tab>
+    ```bash {{ filename: 'terminal', prompt: '$' }}
+    clerk api /api_keys \
+      -d '{"name":"Chat API key","subject":"<user_id>","scopes":["chat:send"]}' \
+      --yes
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts
+    import { createClerkClient } from '@clerk/backend'
+
+    const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
+
+    const apiKey = await clerk.apiKeys.create({
+      name: 'Chat API key',
+      subject: userId,
+      scopes: ['chat:send'],
+    })
+    ```
+  </Tab>
+</Tabs>
+
+The returned `secret` is shown once. Hand it to the caller as a bearer token.
+
+#### Verify the API key in the channel
+
+Set `acceptsToken: 'api_key'` and map the result.
+
+```ts {{ filename: 'agent/channels/eve.ts' }}
+import { createClerkClient } from '@clerk/backend'
+import type { AuthFn } from 'eve/channels/auth'
+import { eveChannel } from 'eve/channels/eve'
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+})
+
+const apiKeyAuth: AuthFn<Request> = async request => {
+  const state = await clerk
+    .authenticateRequest(request, { acceptsToken: 'api_key' })
+    .catch(() => null)
+
+  if (!state?.isAuthenticated) return null
+
+  const auth = state.toAuth()
+
+  return {
+    authenticator: 'clerk',
+    principalType: 'machine',
+    principalId: auth.subject,
+    subject: auth.subject,
+    attributes: {
+      tokenType: auth.tokenType,
+      ...(auth.scopes?.length && { scopes: auth.scopes }),
+      ...(auth.userId && { userId: auth.userId }),
+      ...(auth.orgId && { orgId: auth.orgId }),
+    },
+  }
+}
+
+export default eveChannel({
+  auth: [apiKeyAuth],
+})
+```
+
+API keys are scoped to either a user or an org, never both — pass through whichever Clerk populated.
+
+#### Verify required scopes
+
+Check `auth.scopes` and decide where to enforce. Reject at the channel boundary when the scope is required to talk to the agent at all. Check inside a tool when the scope only matters for that tool, and return a structured error the model can relay to the caller.
+
+<Tabs items={["In channel auth", "Inside a tool"]}>
+  <Tab>
+    Throw [`ForbiddenError`](https://eve.dev/docs/guides/auth-and-route-protection) from the `AuthFn` to reject the request with a `403` before the agent runs.
+
+    ```ts {{ filename: 'agent/channels/eve.ts' }}
+    import { ForbiddenError } from 'eve/channels/auth'
+
+    const REQUIRED_SCOPES = ['chat:send']
+
+    const scopes = auth.scopes ?? []
+    for (const scope of REQUIRED_SCOPES) {
+      if (!scopes.includes(scope)) {
+        throw new ForbiddenError({ message: `Missing required scope: ${scope}` })
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    Return a structured error from `execute`. The model relays the message to the caller and the rest of the agent keeps running.
+
+    ```ts {{ filename: 'agent/tools/send_chat.ts' }}
+    import { defineTool } from 'eve/tools'
+    import { z } from 'zod'
+
+    export default defineTool({
+      description: 'Send a chat message.',
+      inputSchema: z.object({ message: z.string() }),
+      execute: async ({ message }, ctx) => {
+        const auth = ctx.session.auth.current
+        const scopes = auth?.attributes.scopes
+
+        if (!Array.isArray(scopes) || !scopes.includes('chat:send')) {
+          return { error: true, message: 'API key is missing the chat:send scope.' }
+        }
+
+        // ... send the chat message
+        return { ok: true }
+      },
+    })
+    ```
+  </Tab>
+</Tabs>
+
+### Agent-to-agent M2M
+
+Agents on different deployments can communicate securely using M2M auth. To do this, each agent has to be associated with a Clerk machine. The caller mints with its own machine secret; the receiver verifies with its own. Agent-to-agent relationships are modeled as Clerk **scopes** — granting `main-agent → project-agent` lets the main agent mint tokens the project agent will accept. Revoking the scope is a runtime kill switch.
+
+#### Create the machines
+
+<Tabs items={["Clerk CLI", "Backend API"]}>
+  <Tab>
+    Create `project-agent` first (its ID is needed to scope `main-agent`):
+
+    ```bash {{ filename: 'terminal', prompt: '$' }}
+    clerk api /machines -d '{"name":"project-agent"}' --yes
+    ```
+
+    Then create `main-agent` scoped to it:
+
+    ```bash {{ filename: 'terminal', prompt: '$' }}
+    clerk api /machines \
+      -d '{"name":"main-agent","scoped_machines":["<project_machine_id>"]}' \
+      --yes
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts
+    import { createClerkClient } from '@clerk/backend'
+
+    const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY! })
+
+    const project = await clerk.machines.create({ name: 'project-agent' })
+    const main = await clerk.machines.create({
+      name: 'main-agent',
+      scopedMachines: [project.id],
+    })
+    ```
+  </Tab>
+</Tabs>
+
+Scopes are one-way. For two-way calls, create the reverse scope too. Copy each machine's secret key into the matching agent's environment:
+
+```env {{ filename: '.env' }}
+CLERK_MACHINE_SECRET_KEY=ak_...
+```
+
+#### Outbound: mint a token in the calling agent
+
+Declare the receiver as a remote subagent. Mint with [`m2m.createToken()`](/docs/reference/backend/m2m-tokens/create-token), then hand the lazy resolver to [`bearer()`](https://eve.dev/docs/guides/auth-and-route-protection#bearer).
+
+```ts {{ filename: 'agent/subagents/project.ts' }}
+import { createClerkClient } from '@clerk/backend'
+import { defineRemoteAgent } from 'eve'
+import { bearer } from 'eve/agents/auth'
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+})
+
+const mintProjectAgentToken = async (): Promise<string> => {
+  const m2m = await clerk.m2m.createToken({
+    machineSecretKey: process.env.CLERK_MACHINE_SECRET_KEY,
+    secondsUntilExpiration: 300,
+    minRemainingTtlSeconds: 60,
+  })
+  return m2m.token as string
+}
+
+export default defineRemoteAgent({
+  url: process.env.PROJECT_AGENT_URL ?? 'http://127.0.0.1:3002',
+  description: 'Delegates project management tasks to the project agent.',
+  auth: bearer(mintProjectAgentToken),
+})
+```
+
+`bearer(resolver)` runs the resolver per outbound request, so every call carries a fresh token.
+
+#### Inbound: verify the token in the receiving agent
+
+Same channel pattern as before — pass `machineSecretKey` and set `acceptsToken: 'm2m_token'`. Clerk does the signature and scope checks before this code sees the principal.
+
+```ts {{ filename: 'agent/channels/eve.ts' }}
+const clerkAuth: AuthFn<Request> = async request => {
+  const state = await clerk
+    .authenticateRequest(request, {
+      acceptsToken: 'm2m_token',
+      machineSecretKey: process.env.CLERK_MACHINE_SECRET_KEY,
+    })
+    .catch(() => null)
+
+  if (!state?.isAuthenticated) return null
+
+  const auth = state.toAuth()
+
+  return {
+    authenticator: 'clerk',
+    principalType: 'machine',
+    principalId: auth.subject,
+    subject: auth.subject,
+    attributes: {
+      tokenType: auth.tokenType,
+      ...(auth.scopes?.length && { scopes: auth.scopes }),
+    },
+  }
+}
+```
+
+A missing or revoked scope rejects the token with `401`.
+
+#### Runtime decoupling
+
+Remove a scope in the Dashboard — or via [`machines.deleteScope()`](/docs/reference/backend/machines/delete-scope) — and the next minted token fails verification. No code change, no redeploy.
+
+## Next steps
+
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — the multi-token auth chain this page builds on.
+- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate tool invocations against permissions and scopes.
+- [Using M2M tokens](/docs/guides/development/machine-auth/m2m-tokens) — full reference for machines, scopes, and token claims.
+- [Token formats](/docs/guides/development/machine-auth/token-formats) — when to choose JWT M2M tokens over opaque ones.

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -99,7 +99,7 @@ if (auth?.principalType === 'machine' && auth.attributes.tokenType === 'api_key'
 
 ### OAuth via Clerk brokered connections
 
-For tools that call a provider API, Clerk can [broker the OAuth handshake](/docs/guides/configure/auth-strategies/social-connections/overview) and store the access token. Eve drives the consent flow when the token's missing through an [`AuthorizationDefinition`](https://eve.dev/docs/guides/interactive-tool-auth) on the tool. The three callbacks on [`defineInteractiveAuthorization`](https://eve.dev/docs/guides/interactive-tool-auth):
+For tools that call a provider API, Clerk can [broker the OAuth handshake](/docs/guides/configure/auth-strategies/social-connections/overview) and store the access token. Eve drives the consent flow when the token's missing through an [`AuthorizationDefinition`](https://eve.dev/docs/connections#self-hosted-interactive-oauth) on the tool. The three callbacks on [`defineInteractiveAuthorization`](https://eve.dev/docs/connections#self-hosted-interactive-oauth):
 
 - `getToken({ principal })` — return the stored token, or throw to request authorization.
 - `startAuthorization({ callbackUrl })` — return a challenge URL to send the user through consent.
@@ -244,7 +244,7 @@ export default defineTool({
 
 #### The dashboard `/connect/[provider]` route
 
-The challenge URL points at a dashboard page that runs Clerk's frontend [`createExternalAccount`](https://clerk.com/docs/components/user/connect-external-account) and redirects back to the `return` URL. Making the route dynamic on `[provider]` lets one page handle every provider you pass to `clerkConnect`.
+The challenge URL points at a dashboard page that runs Clerk's frontend [`createExternalAccount`](/docs/reference/objects/user#create-external-account) and redirects back to the `return` URL. Making the route dynamic on `[provider]` lets one page handle every provider you pass to `clerkConnect`.
 
 ```tsx {{ filename: 'app/connect/[provider]/page.tsx' }}
 'use client'

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -1,0 +1,328 @@
+---
+title: Authorizing tool calls
+description: Authorize individual Eve tool calls — permission gating from the auth context, plus brokered OAuth for tools that need an external provider token.
+sdk: nextjs
+---
+
+This page covers gating tool calls against Clerk permissions and scopes, plus brokering OAuth for tools that need a provider token.
+
+> [!TIP]
+> Skip the OAuth boilerplate — install the `clerkConnect()` and `clerkOAuthToken()` helpers via shadcn.
+
+```bash {{ filename: 'terminal', prompt: '$' }}
+bunx --bun shadcn@latest add clerk/eve-agents/auth
+```
+
+## Build it from scratch
+
+### Permission gating inside a tool
+
+Read the authenticated principal off Eve's session context and, if the caller is a user, check their permissions. See [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth#adding-attributes) for how permissions and scopes get populated.
+
+Factor the guards into helpers so the tool reads as a sequence of small checks. `requireUserPrincipal` returns an agent error if the caller isn't a signed-in user; `requirePermissions` returns one if any of the required permissions are missing.
+
+<Tabs items={["lib/agent-errors.ts", "agent/tools/archive_project.ts"]}>
+  <Tab>
+    ```ts {{ filename: 'lib/agent-errors.ts' }}
+    import type { SessionAuthContext } from 'eve/context'
+
+    export type AgentError = { error: true; message: string }
+
+    export function requireUserPrincipal(
+      auth: SessionAuthContext | null,
+      message: string,
+    ): AgentError | null {
+      if (auth?.principalType !== 'user') {
+        return { error: true, message }
+      }
+      return null
+    }
+
+    export function requirePermissions(
+      auth: SessionAuthContext | null,
+      required: readonly string[],
+    ): AgentError | null {
+      const granted = auth?.attributes.permissions
+      const missing = Array.isArray(granted)
+        ? required.filter(p => !granted.includes(p))
+        : required
+      if (missing.length === 0) return null
+      return {
+        error: true,
+        message: `Missing required permission: ${missing.join(', ')}.`,
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts {{ filename: 'agent/tools/archive_project.ts' }}
+    import { defineTool } from 'eve/tools'
+    import { z } from 'zod'
+    import { requirePermissions, requireUserPrincipal } from '@/lib/agent-errors'
+
+    export default defineTool({
+      description: 'Archive a project.',
+      inputSchema: z.object({ projectId: z.string() }),
+      execute: async ({ projectId }, ctx) => {
+        const auth = ctx.session.auth.current
+
+        const userError = requireUserPrincipal(
+          auth,
+          'Only signed-in users can archive projects.',
+        )
+        if (userError) return userError
+
+        const permError = requirePermissions(auth, ['org:projects:archive'])
+        if (permError) return permError
+
+        // ... perform the archive in your data layer
+        return { ok: true, projectId }
+      },
+    })
+    ```
+  </Tab>
+</Tabs>
+
+Always return a structured error rather than throwing — the model relays the string to the user. Throwing aborts the tool loop and reaches the user only as a generic failure.
+
+Same shape for API key scopes:
+
+```ts
+const auth = ctx.session.auth.current
+const scopes = auth?.attributes.scopes
+
+if (
+  auth?.principalType === 'machine' &&
+  auth.attributes.tokenType === 'api_key'
+) {
+  if (
+    !Array.isArray(scopes) ||
+    !scopes.includes('projects:write')
+  ) {
+    return {
+      error: true,
+      message: 'API key is missing the projects:write scope.',
+    }
+  }
+}
+```
+
+### OAuth via Clerk brokered connections
+
+For tools that call a provider API, Clerk can [broker the OAuth handshake](/docs/guides/configure/auth-strategies/social-connections/overview) and store the access token. Eve drives the consent flow when the token's missing through an [`AuthorizationDefinition`](https://eve.dev/docs/guides/interactive-tool-auth) on the tool. The three callbacks on [`defineInteractiveAuthorization`](https://eve.dev/docs/guides/interactive-tool-auth):
+
+- `getToken({ principal })` — return the stored token, or throw to request authorization.
+- `startAuthorization({ callbackUrl })` — return a challenge URL to send the user through consent.
+- `completeAuthorization({ principal })` — re-read the token after the redirect.
+
+Wrap the three callbacks in a reusable `clerkConnect(provider, options)` factory. This guide uses GitHub as the example, but the same factory works for any [Clerk-brokered OAuth provider](/docs/guides/configure/auth-strategies/social-connections/overview) — swap the provider name and adjust the scopes.
+
+Start with a helper that reads Clerk's stored token for a given user and provider. It returns `null` if the token is missing or doesn't cover the required scopes, which sends the caller back through the connect flow to grant them.
+
+```ts {{ filename: 'lib/clerk-connect.ts' }}
+import { createClerkClient } from '@clerk/backend'
+
+const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
+
+export async function readProviderToken(
+  userId: string,
+  provider: string,
+  requiredScopes: readonly string[],
+): Promise<string | null> {
+  const res = await clerk.users.getUserOauthAccessToken(userId, provider)
+  const entry = res.data[0]
+  if (!entry?.token) return null
+
+  if (requiredScopes.length) {
+    const granted = new Set(entry.scopes ?? [])
+    if (!requiredScopes.every(s => granted.has(s))) return null
+  }
+
+  return entry.token
+}
+```
+
+`getToken` runs first on every tool call. Return the token if Clerk already has one for the caller. Throw `ConnectionAuthorizationRequiredError` to trigger the consent flow.
+
+```ts {{ filename: 'lib/clerk-connect.ts' }}
+import {
+  type AuthorizationDefinition,
+  ConnectionAuthorizationFailedError,
+  ConnectionAuthorizationRequiredError,
+  defineInteractiveAuthorization,
+} from 'eve/connections'
+
+type ClerkConnectOptions = {
+  readonly scopes?: readonly string[]
+}
+
+export function clerkConnect(
+  provider: string,
+  options: ClerkConnectOptions = {},
+): AuthorizationDefinition {
+  const scopes = options.scopes ?? []
+
+  return defineInteractiveAuthorization({
+    displayName: provider,
+
+    getToken: async ({ principal }) => {
+      if (principal.type !== 'user') {
+        throw new ConnectionAuthorizationRequiredError(provider, {
+          message: `Connecting ${provider} requires a signed-in user.`,
+        })
+      }
+
+      const token = await readProviderToken(principal.id, provider, scopes)
+      if (!token) {
+        throw new ConnectionAuthorizationRequiredError(provider, {
+          message: `Connect your ${provider} account to continue.`,
+        })
+      }
+
+      return { token }
+    },
+
+    // startAuthorization and completeAuthorization continue below
+  })
+}
+```
+
+`startAuthorization` builds the URL Eve sends the user to. Forward `callbackUrl` so the dashboard page can redirect back when consent finishes, and pass any required scopes.
+
+```ts {{ filename: 'lib/clerk-connect.ts' }}
+// Inside defineInteractiveAuthorization({...})
+startAuthorization: async ({ callbackUrl }) => {
+  const params = new URLSearchParams({ return: callbackUrl })
+  if (scopes.length) params.set('scopes', scopes.join(' '))
+  params.set('prompt', 'select_account consent')
+
+  return {
+    challenge: {
+      url: `/connect/${provider}?${params.toString()}`,
+      displayName: provider,
+    },
+  }
+},
+```
+
+After the redirect, `completeAuthorization` re-reads the stored token. If consent succeeded, the token is now there; if not, throw to fail the flow.
+
+```ts {{ filename: 'lib/clerk-connect.ts' }}
+// Inside defineInteractiveAuthorization({...})
+completeAuthorization: async ({ principal }) => {
+  if (principal.type !== 'user') {
+    throw new ConnectionAuthorizationFailedError(provider, {
+      message: `Connect flow finished without a signed-in user.`,
+      reason: 'no_user',
+      retryable: false,
+    })
+  }
+
+  const token = await readProviderToken(principal.id, provider, scopes)
+  if (!token) {
+    throw new ConnectionAuthorizationFailedError(provider, {
+      message: `${provider} did not return an access token after connecting.`,
+      reason: 'no_token',
+      retryable: false,
+    })
+  }
+
+  return { token }
+},
+```
+
+Now any tool can opt into Clerk-brokered OAuth with one line: `auth: clerkConnect('github', { scopes: ['repo'] })`. By the time tool execution reaches `ctx.getToken()`, Eve has already driven the consent flow if it needed to.
+
+```ts {{ filename: 'agent/tools/list_repos.ts' }}
+import { defineTool } from 'eve/tools'
+import { z } from 'zod'
+import { clerkConnect } from '@/lib/clerk-connect'
+
+export default defineTool({
+  description: "List the caller's GitHub repositories.",
+  inputSchema: z.object({}),
+  auth: clerkConnect('github', { scopes: ['repo'] }),
+  execute: async (_input, ctx) => {
+    const { token } = await ctx.getToken()
+    const res = await fetch('https://api.github.com/user/repos', {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    return await res.json()
+  },
+})
+```
+
+#### The dashboard `/connect/[provider]` route
+
+The challenge URL points at a dashboard page that runs Clerk's frontend [`createExternalAccount`](https://clerk.com/docs/components/user/connect-external-account) and redirects back to the `return` URL. Making the route dynamic on `[provider]` lets one page handle every provider you pass to `clerkConnect`.
+
+```tsx {{ filename: 'app/connect/[provider]/page.tsx' }}
+'use client'
+
+import { useUser } from '@clerk/nextjs'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function ConnectProviderPage() {
+  const { user, isLoaded } = useUser()
+  const { provider } = useParams<{ provider: string }>()
+  const params = useSearchParams()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isLoaded || !user) return
+
+    const returnUrl = params.get('return')
+    const additionalScopes = params.get('scopes')?.split(' ') ?? []
+    const oidcPrompt = params.get('prompt') ?? undefined
+
+    user
+      .createExternalAccount({
+        strategy: `oauth_${provider}` as `oauth_${string}`,
+        additionalScopes,
+        oidcPrompt,
+        redirectUrl: returnUrl ?? '/',
+      })
+      .then(account => {
+        const redirectUrl = account.verification?.externalVerificationRedirectURL
+        if (redirectUrl) router.push(redirectUrl.toString())
+      })
+  }, [isLoaded, user, params, provider, router])
+
+  return <p>Connecting {provider}…</p>
+}
+```
+
+#### Fallback for API key callers
+
+API keys can't drive a browser consent flow, but the user *behind* the key may already have connected. Read their stored token directly inside `execute` using the exported `readProviderToken`.
+
+```ts {{ filename: 'agent/tools/list_repos.ts' }}
+import { readProviderToken } from '@/lib/clerk-connect'
+
+execute: async (_input, ctx) => {
+  const auth = ctx.session.auth.current
+  let token: string | null = null
+
+  if (auth?.principalType === 'user') {
+    ;({ token } = await ctx.getToken())
+  } else if (
+    auth?.principalType === 'machine' &&
+    auth.attributes.tokenType === 'api_key' &&
+    typeof auth.attributes.userId === 'string'
+  ) {
+    token = await readProviderToken(auth.attributes.userId, 'github', ['repo'])
+  }
+
+  if (!token) {
+    return { error: true, message: 'Connect your GitHub account to list repositories.' }
+  }
+  // ... call the provider API with `token`
+},
+```
+
+## Next steps
+
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — populate the `permissions` and `scopes` attributes this page reads.
+- [Social connections](/docs/guides/configure/auth-strategies/social-connections/overview) — set up the providers Clerk can broker.

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -107,6 +107,9 @@ For tools that call a provider API, Clerk can [broker the OAuth handshake](/docs
 
 Wrap the three callbacks in a reusable `clerkConnect(provider, options)` factory. This guide uses GitHub as the example, but the same factory works for any [Clerk-brokered OAuth provider](/docs/guides/configure/auth-strategies/social-connections/overview) — swap the provider name and adjust the scopes.
 
+> [!NOTE]
+> GitHub's `repo` scope isn't one of its defaults, so the connection must use **custom credentials** — Clerk's shared development credentials only grant a provider's default scopes. See the [GitHub social connection](/docs/guides/configure/auth-strategies/social-connections/github) guide to register your own OAuth app, and [Configure additional OAuth scopes](/docs/guides/configure/auth-strategies/social-connections/overview#configure-additional-o-auth-scopes).
+
 Start with a helper that reads Clerk's stored token for a given user and provider. It returns `null` if the token is missing or doesn't cover the required scopes, which sends the caller back through the connect flow to grant them.
 
 ```ts {{ filename: 'lib/clerk-connect.ts' }}

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -43,9 +43,7 @@ Factor the guards into helpers so the tool reads as a sequence of small checks. 
       required: readonly string[],
     ): AgentError | null {
       const granted = auth?.attributes.permissions
-      const missing = Array.isArray(granted)
-        ? required.filter(p => !granted.includes(p))
-        : required
+      const missing = Array.isArray(granted) ? required.filter((p) => !granted.includes(p)) : required
       if (missing.length === 0) return null
       return {
         error: true,
@@ -67,10 +65,7 @@ Factor the guards into helpers so the tool reads as a sequence of small checks. 
       execute: async ({ projectId }, ctx) => {
         const auth = ctx.session.auth.current
 
-        const userError = requireUserPrincipal(
-          auth,
-          'Only signed-in users can archive projects.',
-        )
+        const userError = requireUserPrincipal(auth, 'Only signed-in users can archive projects.')
         if (userError) return userError
 
         const permError = requirePermissions(auth, ['org:projects:archive'])
@@ -92,14 +87,8 @@ Same shape for API key scopes:
 const auth = ctx.session.auth.current
 const scopes = auth?.attributes.scopes
 
-if (
-  auth?.principalType === 'machine' &&
-  auth.attributes.tokenType === 'api_key'
-) {
-  if (
-    !Array.isArray(scopes) ||
-    !scopes.includes('projects:write')
-  ) {
+if (auth?.principalType === 'machine' && auth.attributes.tokenType === 'api_key') {
+  if (!Array.isArray(scopes) || !scopes.includes('projects:write')) {
     return {
       error: true,
       message: 'API key is missing the projects:write scope.',
@@ -136,7 +125,7 @@ export async function readProviderToken(
 
   if (requiredScopes.length) {
     const granted = new Set(entry.scopes ?? [])
-    if (!requiredScopes.every(s => granted.has(s))) return null
+    if (!requiredScopes.every((s) => granted.has(s))) return null
   }
 
   return entry.token
@@ -190,7 +179,7 @@ export function clerkConnect(
 
 `startAuthorization` builds the URL Eve sends the user to. Forward `callbackUrl` so the dashboard page can redirect back when consent finishes, and pass any required scopes.
 
-```ts {{ filename: 'lib/clerk-connect.ts' }}
+```ts {{ filename: 'lib/clerk-connect.ts', prettier: false }}
 // Inside defineInteractiveAuthorization({...})
 startAuthorization: async ({ callbackUrl }) => {
   const params = new URLSearchParams({ return: callbackUrl })
@@ -208,7 +197,7 @@ startAuthorization: async ({ callbackUrl }) => {
 
 After the redirect, `completeAuthorization` re-reads the stored token. If consent succeeded, the token is now there; if not, throw to fail the flow.
 
-```ts {{ filename: 'lib/clerk-connect.ts' }}
+```ts {{ filename: 'lib/clerk-connect.ts', prettier: false }}
 // Inside defineInteractiveAuthorization({...})
 completeAuthorization: async ({ principal }) => {
   if (principal.type !== 'user') {
@@ -284,7 +273,7 @@ export default function ConnectProviderPage() {
         oidcPrompt,
         redirectUrl: returnUrl ?? '/',
       })
-      .then(account => {
+      .then((account) => {
         const redirectUrl = account.verification?.externalVerificationRedirectURL
         if (redirectUrl) router.push(redirectUrl.toString())
       })
@@ -296,9 +285,9 @@ export default function ConnectProviderPage() {
 
 #### Fallback for API key callers
 
-API keys can't drive a browser consent flow, but the user *behind* the key may already have connected. Read their stored token directly inside `execute` using the exported `readProviderToken`.
+API keys can't drive a browser consent flow, but the user _behind_ the key may already have connected. Read their stored token directly inside `execute` using the exported `readProviderToken`.
 
-```ts {{ filename: 'agent/tools/list_repos.ts' }}
+```ts {{ filename: 'agent/tools/list_repos.ts', prettier: false }}
 import { readProviderToken } from '@/lib/clerk-connect'
 
 execute: async (_input, ctx) => {

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -13,6 +13,8 @@ Gate individual eve tool calls against the caller's Clerk permissions and scopes
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
+---
+
 The manual path has two parts: permission checks inside a tool, then OAuth brokered through Clerk.
 
 ## Permission checks inside a tool

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -248,42 +248,63 @@ export default defineTool({
 
 #### The dashboard `/connect/[provider]` route
 
-The challenge URL points at a dashboard page that runs Clerk's frontend [`createExternalAccount`](/docs/reference/objects/user#create-external-account) and redirects back to the `return` URL. Making the route dynamic on `[provider]` lets one page handle every provider you pass to `clerkConnect`.
+The challenge URL points at a dashboard page that runs Clerk's frontend connect flow — [`createExternalAccount`](/docs/reference/objects/user#create-external-account), or `reauthorize` when the provider's already connected but missing a scope — and redirects back to the `return` URL. Making the route dynamic on `[provider]` lets one page handle every provider you pass to `clerkConnect`.
 
 ```tsx {{ filename: 'app/connect/[provider]/page.tsx' }}
 'use client'
 
-import { useUser } from '@clerk/nextjs'
-import { useParams, useRouter, useSearchParams } from 'next/navigation'
-import { useEffect } from 'react'
+import { useReverification, useUser } from '@clerk/nextjs'
+import type { OAuthStrategy } from '@clerk/types'
+import { useParams, useSearchParams } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
 
 export default function ConnectProviderPage() {
   const { user, isLoaded } = useUser()
   const { provider } = useParams<{ provider: string }>()
   const params = useSearchParams()
-  const router = useRouter()
+  const [error, setError] = useState<string>()
+  const started = useRef(false)
+
+  // createExternalAccount can require step-up reverification.
+  const createExternalAccount = useReverification(
+    (args: Parameters<NonNullable<typeof user>['createExternalAccount']>[0]) =>
+      user?.createExternalAccount(args),
+  )
 
   useEffect(() => {
-    if (!isLoaded || !user) return
+    if (!isLoaded || !user || started.current) return
+    started.current = true
 
-    const returnUrl = params.get('return')
-    const additionalScopes = params.get('scopes')?.split(' ') ?? []
+    const returnUrl = params.get('return') ?? '/'
+    const additionalScopes = params.get('scopes')?.split(' ').filter(Boolean) ?? []
     const oidcPrompt = params.get('prompt') ?? undefined
+    const strategy = `oauth_${provider}` as OAuthStrategy
+    const existing = user.externalAccounts.find((a) => a.provider === provider)
 
-    user
-      .createExternalAccount({
-        strategy: `oauth_${provider}` as `oauth_${string}`,
-        additionalScopes,
-        oidcPrompt,
-        redirectUrl: returnUrl ?? '/',
-      })
-      .then((account) => {
-        const redirectUrl = account.verification?.externalVerificationRedirectURL
-        if (redirectUrl) router.push(redirectUrl.toString())
-      })
-  }, [isLoaded, user, params, provider, router])
+    void (async () => {
+      try {
+        // If the provider's already connected but without the scope (e.g. the
+        // user signed in with GitHub), reauthorize to add it — a fresh
+        // createExternalAccount would fail or loop.
+        const account =
+          existing && additionalScopes.length
+            ? await existing.reauthorize({ additionalScopes, redirectUrl: returnUrl, oidcPrompt })
+            : await createExternalAccount({ strategy, additionalScopes, redirectUrl: returnUrl, oidcPrompt })
 
-  return <p>Connecting {provider}…</p>
+        const url = account?.verification?.externalVerificationRedirectURL
+        if (url) {
+          // Full-page navigation; router.push is unreliable for cross-origin URLs.
+          window.location.href = url.href
+          return
+        }
+        setError('Clerk did not return a verification URL.')
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    })()
+  }, [isLoaded, user, provider, params, createExternalAccount])
+
+  return <p>{error ? `Connection failed: ${error}` : `Connecting ${provider}…`}</p>
 }
 ```
 

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -234,6 +234,7 @@ import { clerkConnect } from '@/lib/clerk-connect'
 export default defineTool({
   description: "List the caller's GitHub repositories.",
   inputSchema: z.object({}),
+  // `repo` covers public + private repos; use `public_repo` for public only.
   auth: clerkConnect('github', { scopes: ['repo'] }),
   execute: async (_input, ctx) => {
     const { token } = await ctx.getToken()

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -289,7 +289,12 @@ export default function ConnectProviderPage() {
         const account =
           existing && additionalScopes.length
             ? await existing.reauthorize({ additionalScopes, redirectUrl: returnUrl, oidcPrompt })
-            : await createExternalAccount({ strategy, additionalScopes, redirectUrl: returnUrl, oidcPrompt })
+            : await createExternalAccount({
+                strategy,
+                additionalScopes,
+                redirectUrl: returnUrl,
+                oidcPrompt,
+              })
 
         const url = account?.verification?.externalVerificationRedirectURL
         if (url) {

--- a/docs/guides/ai/eve/authorize-tool-calls.mdx
+++ b/docs/guides/ai/eve/authorize-tool-calls.mdx
@@ -1,10 +1,10 @@
 ---
-title: Authorizing tool calls
-description: Authorize individual Eve tool calls — permission gating from the auth context, plus brokered OAuth for tools that need an external provider token.
+title: Authorize tool calls
+description: Authorize individual eve tool calls — permission checks from the auth context, plus brokered OAuth for tools that need an external provider token.
 sdk: nextjs
 ---
 
-This page covers gating tool calls against Clerk permissions and scopes, plus brokering OAuth for tools that need a provider token.
+Gate individual eve tool calls against the caller's Clerk permissions and scopes — and broker OAuth for tools that need a provider token on the caller's behalf.
 
 > [!TIP]
 > Skip the OAuth boilerplate — install the `clerkConnect()` and `clerkOAuthToken()` helpers via shadcn.
@@ -13,11 +13,11 @@ This page covers gating tool calls against Clerk permissions and scopes, plus br
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
-## Build it from scratch
+The manual path has two parts: permission checks inside a tool, then OAuth brokered through Clerk.
 
-### Permission gating inside a tool
+## Permission checks inside a tool
 
-Read the authenticated principal off Eve's session context and, if the caller is a user, check their permissions. See [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth#adding-attributes) for how permissions and scopes get populated.
+Read the authenticated principal off eve's session context and, if the caller is a user, check their permissions. See [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth#add-attributes) for how permissions and scopes get populated.
 
 Factor the guards into helpers so the tool reads as a sequence of small checks. `requireUserPrincipal` returns an agent error if the caller isn't a signed-in user; `requirePermissions` returns one if any of the required permissions are missing.
 
@@ -79,7 +79,7 @@ Factor the guards into helpers so the tool reads as a sequence of small checks. 
   </Tab>
 </Tabs>
 
-Always return a structured error rather than throwing — the model relays the string to the user. Throwing aborts the tool loop and reaches the user only as a generic failure.
+Always return a structured error rather than throwing; the model relays the string to the user. A thrown error aborts the tool loop and reaches the user only as a generic failure.
 
 Same shape for API key scopes:
 
@@ -97,18 +97,18 @@ if (auth?.principalType === 'machine' && auth.attributes.tokenType === 'api_key'
 }
 ```
 
-### OAuth via Clerk brokered connections
+## OAuth via Clerk brokered connections {{ id: 'oauth-via-clerk-brokered-connections' }}
 
-For tools that call a provider API, Clerk can [broker the OAuth handshake](/docs/guides/configure/auth-strategies/social-connections/overview) and store the access token. Eve drives the consent flow when the token's missing through an [`AuthorizationDefinition`](https://eve.dev/docs/connections#self-hosted-interactive-oauth) on the tool. The three callbacks on [`defineInteractiveAuthorization`](https://eve.dev/docs/connections#self-hosted-interactive-oauth):
+For tools that call a provider API, Clerk can [broker the OAuth handshake](/docs/guides/configure/auth-strategies/social-connections/overview) and store the access token. When the token's missing, eve drives the consent flow through an [`AuthorizationDefinition`](https://eve.dev/docs/connections#self-hosted-interactive-oauth) on the tool. The three callbacks on [`defineInteractiveAuthorization`](https://eve.dev/docs/connections#self-hosted-interactive-oauth):
 
 - `getToken({ principal })` — return the stored token, or throw to request authorization.
 - `startAuthorization({ callbackUrl })` — return a challenge URL to send the user through consent.
 - `completeAuthorization({ principal })` — re-read the token after the redirect.
 
-Wrap the three callbacks in a reusable `clerkConnect(provider, options)` factory. This guide uses GitHub as the example, but the same factory works for any [Clerk-brokered OAuth provider](/docs/guides/configure/auth-strategies/social-connections/overview) — swap the provider name and adjust the scopes.
+Wrap the three callbacks in a reusable `clerkConnect(provider, options)` factory. This guide uses GitHub as the example, but the same factory works for any [Clerk-brokered OAuth provider](/docs/guides/configure/auth-strategies/social-connections/overview). Swap the provider name and adjust the scopes.
 
 > [!NOTE]
-> GitHub's `repo` scope isn't one of its defaults, so the connection must use **custom credentials** — Clerk's shared development credentials only grant a provider's default scopes. See the [GitHub social connection](/docs/guides/configure/auth-strategies/social-connections/github) guide to register your own OAuth app, and [Configure additional OAuth scopes](/docs/guides/configure/auth-strategies/social-connections/overview#configure-additional-o-auth-scopes).
+> GitHub's `repo` scope isn't one of its defaults, so the connection must use **custom credentials**. Clerk's shared development credentials only grant a provider's default scopes. See the [GitHub social connection](/docs/guides/configure/auth-strategies/social-connections/github) guide to register your own OAuth app, and [Configure additional OAuth scopes](/docs/guides/configure/auth-strategies/social-connections/overview#configure-additional-o-auth-scopes).
 
 Start with a helper that reads Clerk's stored token for a given user and provider. It returns `null` if the token is missing or doesn't cover the required scopes, which sends the caller back through the connect flow to grant them.
 
@@ -180,7 +180,7 @@ export function clerkConnect(
 }
 ```
 
-`startAuthorization` builds the URL Eve sends the user to. Forward `callbackUrl` so the dashboard page can redirect back when consent finishes, and pass any required scopes.
+`startAuthorization` builds the URL eve sends the user to. Forward `callbackUrl` so the dashboard page can redirect back when consent finishes, and pass any required scopes.
 
 ```ts {{ filename: 'lib/clerk-connect.ts', prettier: false }}
 // Inside defineInteractiveAuthorization({...})
@@ -224,9 +224,9 @@ completeAuthorization: async ({ principal }) => {
 },
 ```
 
-Now any tool can opt into Clerk-brokered OAuth with one line: `auth: clerkConnect('github', { scopes: ['repo'] })`. By the time tool execution reaches `ctx.getToken()`, Eve has already driven the consent flow if it needed to.
+Now any tool can opt into Clerk-brokered OAuth with one line: `auth: clerkConnect('github', { scopes: ['repo'] })`. By the time tool execution reaches `ctx.getToken()`, eve has already driven the consent flow if it needed to.
 
-```ts {{ filename: 'agent/tools/list_repos.ts' }}
+```ts {{ filename: 'agent/tools/list_repos.ts', mark: [9] }}
 import { defineTool } from 'eve/tools'
 import { z } from 'zod'
 import { clerkConnect } from '@/lib/clerk-connect'
@@ -246,11 +246,11 @@ export default defineTool({
 })
 ```
 
-#### The dashboard `/connect/[provider]` route
+### The dashboard `/connect/[provider]` route
 
-The challenge URL points at a dashboard page that runs Clerk's frontend connect flow — [`createExternalAccount`](/docs/reference/objects/user#create-external-account), or `reauthorize` when the provider's already connected but missing a scope — and redirects back to the `return` URL. Making the route dynamic on `[provider]` lets one page handle every provider you pass to `clerkConnect`.
+The challenge URL points at a dashboard page that runs Clerk's frontend connect flow — [`createExternalAccount`](/docs/reference/objects/user#create-external-account), or `reauthorize` when the provider's already connected but missing a scope — and redirects back to the `return` URL. A dynamic `[provider]` route lets one page handle every provider you pass to `clerkConnect`.
 
-```tsx {{ filename: 'app/connect/[provider]/page.tsx' }}
+```tsx {{ filename: 'app/connect/[provider]/page.tsx', mark: [[37, 39]] }}
 'use client'
 
 import { useReverification, useUser } from '@clerk/nextjs'
@@ -313,7 +313,7 @@ export default function ConnectProviderPage() {
 }
 ```
 
-#### Fallback for API key callers
+### Fallback for API key callers
 
 API keys can't drive a browser consent flow, but the user _behind_ the key may already have connected. Read their stored token directly inside `execute` using the exported `readProviderToken`.
 
@@ -341,7 +341,8 @@ execute: async (_input, ctx) => {
 },
 ```
 
-## Next steps
+## Related guides
 
-- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — populate the `permissions` and `scopes` attributes this page reads.
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — populate the `permissions` and `scopes` attributes these checks read.
+- [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) — create the API keys whose scopes these tool checks enforce.
 - [Social connections](/docs/guides/configure/auth-strategies/social-connections/overview) — set up the providers Clerk can broker.

--- a/docs/guides/ai/eve/custom-channel-auth.mdx
+++ b/docs/guides/ai/eve/custom-channel-auth.mdx
@@ -13,6 +13,8 @@ Verify Clerk callers at your eve agent's channel boundary — accept web session
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
+---
+
 Everything below builds the channel `AuthFn` from scratch: session verification first, then multi-token support and attribute mapping.
 
 An eve channel authorizes inbound requests through a list of [`AuthFn` callbacks](https://eve.dev/docs/guides/auth-and-route-protection). Each entry receives the request, returns an eve principal to accept, or returns `null` to skip to the next entry.

--- a/docs/guides/ai/eve/custom-channel-auth.mdx
+++ b/docs/guides/ai/eve/custom-channel-auth.mdx
@@ -1,10 +1,10 @@
 ---
 title: Custom channel auth
-description: Build an Eve channel AuthFn that verifies Clerk callers from scratch — basic session auth, multi-token acceptance, and mapping Clerk auth to eve principal attributes.
+description: Build an eve channel AuthFn that verifies Clerk callers from scratch — session auth, multi-token acceptance, and mapping Clerk auth to eve principal attributes.
 sdk: nextjs
 ---
 
-Verify Clerk callers in your Eve agent's channel. This page breaks down how to secure your eve auth channel with Clerk and accept requests from web sessions, API keys, and other machine tokens.
+Verify Clerk callers at your eve agent's channel boundary — accept web sessions, API keys, and machine tokens, and map each to an eve principal your tools and instructions can read.
 
 > [!TIP]
 > Skip the manual setup — install the configurable `clerkAuth()` helper via shadcn.
@@ -13,9 +13,9 @@ Verify Clerk callers in your Eve agent's channel. This page breaks down how to s
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
-## Build it from scratch
+Everything below builds the channel `AuthFn` from scratch: session verification first, then multi-token support and attribute mapping.
 
-Eve channels authorize inbound requests through a list of [`AuthFn` callbacks](https://eve.dev/docs/guides/auth-and-route-protection). Each entry receives the request, returns an eve principal to accept, or returns `null` to skip to the next entry.
+An eve channel authorizes inbound requests through a list of [`AuthFn` callbacks](https://eve.dev/docs/guides/auth-and-route-protection). Each entry receives the request, returns an eve principal to accept, or returns `null` to skip to the next entry.
 
 ```ts
 import type { AuthFn } from 'eve/channels/auth'
@@ -25,11 +25,11 @@ const myAuth: AuthFn<Request> = async (request) => {
 }
 ```
 
-### Basic: verify a Clerk session
+## Verify a Clerk session
 
 Hand the `Request` to Clerk's [`authenticateRequest()`](/docs/reference/backend/authenticate-request) and map the verified state to an eve principal.
 
-```ts {{ filename: 'agent/channels/eve.ts' }}
+```ts {{ filename: 'agent/channels/eve.ts', mark: [12] }}
 import { createClerkClient } from '@clerk/backend'
 import type { AuthFn } from 'eve/channels/auth'
 import { eveChannel } from 'eve/channels/eve'
@@ -64,7 +64,7 @@ export default eveChannel({
 
 The returned object is what every downstream piece (instructions, tools, subagents) reads as `ctx.session.auth.current`.
 
-### Reject vs. fall through
+## Reject vs. fall through
 
 Returning `null` skips this authenticator and passes the request to the next entry in the channel's auth chain. If no entry accepts, the request is rejected. Throw [`UnauthenticatedError`](https://eve.dev/docs/guides/auth-and-route-protection) instead to short-circuit the chain with a `401` — useful when Clerk is a required authentication strategy.
 
@@ -79,11 +79,11 @@ if (!state?.isAuthenticated) {
 }
 ```
 
-### Multi-token: accept session, API key, M2M, and OAuth
+## Accept multiple token types
 
 Pass an array to [`acceptsToken`](/docs/reference/backend/authenticate-request#authenticate-request-options) to verify more than one Clerk token type in the same call. Switch on `auth.tokenType` to branch on what authenticated.
 
-```ts {{ filename: 'agent/channels/eve.ts' }}
+```ts {{ filename: 'agent/channels/eve.ts', mark: [4, 5] }}
 const clerkAuth: AuthFn<Request> = async (request) => {
   const state = await clerk
     .authenticateRequest(request, {
@@ -117,11 +117,11 @@ const clerkAuth: AuthFn<Request> = async (request) => {
 }
 ```
 
-`machineSecretKey` is required when accepting `m2m_token` — Clerk uses it to verify the inbound token. See [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) for setup.
+`machineSecretKey` is required when accepting `m2m_token`. Clerk uses it to verify the inbound token. See [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) for setup.
 
-### Adding attributes
+## Add attributes
 
-[Attributes](https://eve.dev/docs/guides/auth-and-route-protection) is a free-form object made accessible as shared auth context in instructions, tools, and subagents. Customize the context you make available by extracting from the Clerk auth object.
+[Attributes](https://eve.dev/docs/guides/auth-and-route-protection) is a free-form object exposed as shared auth context in instructions, tools, and subagents. Customize it by pulling fields off the Clerk auth object.
 
 Session token:
 
@@ -142,7 +142,7 @@ const name = auth.sessionClaims?.name
 if (typeof name === 'string') attributes.name = name
 ```
 
-Machine variants — all share `scopes`, with additional fields specific to each token type:
+Machine variants all share `scopes`, with additional fields specific to each token type:
 
 ```ts
 const attributes: Record<string, string | readonly string[]> = {
@@ -171,9 +171,9 @@ Summary by token type:
 | `m2m_token` | `machine` | `scopes` |
 | `oauth_token` | `machine` | `scopes`, `userId`, `clientId` |
 
-See [Enriching instructions](/docs/guides/ai/eve/enriching-instructions) and [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) for how to read these downstream.
+See [Enrich instructions](/docs/guides/ai/eve/enriching-instructions) and [Authorize tool calls](/docs/guides/ai/eve/authorize-tool-calls) for how to read these downstream.
 
-### Composing with other authenticators
+## Compose with other authenticators
 
 Add other entries to the `auth` chain. Each runs in order; the first non-null wins.
 
@@ -186,10 +186,10 @@ export default eveChannel({
 ```
 
 > [!CAUTION]
-> Omitting [`localDev()`](https://eve.dev/docs/guides/auth-and-route-protection#localdev) means unauthenticated requests get a real `401` on localhost. Useful for testing real auth flows; just remember the agent won't be reachable from your browser without signing in.
+> Omitting [`localDev()`](https://eve.dev/docs/guides/auth-and-route-protection#localdev) means unauthenticated requests get a real `401` on localhost. Useful for testing real auth flows. Remember the agent won't be reachable from your browser without signing in.
 
-## Next steps
+## Related guides
 
 - [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) — API key auth and agent-to-agent M2M.
-- [Enriching instructions](/docs/guides/ai/eve/enriching-instructions) — read the principal inside dynamic instructions.
-- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate tool invocations against permissions on the principal.
+- [Enrich instructions](/docs/guides/ai/eve/enriching-instructions) — read the principal inside dynamic instructions.
+- [Authorize tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate tool invocations against permissions on the principal.

--- a/docs/guides/ai/eve/custom-channel-auth.mdx
+++ b/docs/guides/ai/eve/custom-channel-auth.mdx
@@ -20,7 +20,7 @@ Eve channels authorize inbound requests through a list of [`AuthFn` callbacks](h
 ```ts
 import type { AuthFn } from 'eve/channels/auth'
 
-const myAuth: AuthFn<Request> = async request => {
+const myAuth: AuthFn<Request> = async (request) => {
   // Return a SessionAuthContext to accept, or `null` to skip.
 }
 ```
@@ -39,7 +39,7 @@ const clerk = createClerkClient({
   publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
 })
 
-const clerkAuth: AuthFn<Request> = async request => {
+const clerkAuth: AuthFn<Request> = async (request) => {
   const state = await clerk
     .authenticateRequest(request, { acceptsToken: 'session_token' })
     .catch(() => null)
@@ -84,7 +84,7 @@ if (!state?.isAuthenticated) {
 Pass an array to [`acceptsToken`](/docs/reference/backend/authenticate-request#authenticate-request-options) to verify more than one Clerk token type in the same call. Switch on `auth.tokenType` to branch on what authenticated.
 
 ```ts {{ filename: 'agent/channels/eve.ts' }}
-const clerkAuth: AuthFn<Request> = async request => {
+const clerkAuth: AuthFn<Request> = async (request) => {
   const state = await clerk
     .authenticateRequest(request, {
       acceptsToken: ['session_token', 'api_key', 'm2m_token', 'oauth_token'],
@@ -165,9 +165,9 @@ if (auth.tokenType === 'oauth_token') {
 Summary by token type:
 
 | Token type | `principalType` | Typical attributes |
-| --- | --- | --- |
+| - | - | - |
 | `session_token` | `user` | `orgId`, `role`, `permissions`, `name` |
-| `api_key` | `machine` | `scopes`, `userId` *or* `orgId` |
+| `api_key` | `machine` | `scopes`, `userId` _or_ `orgId` |
 | `m2m_token` | `machine` | `scopes` |
 | `oauth_token` | `machine` | `scopes`, `userId`, `clientId` |
 

--- a/docs/guides/ai/eve/custom-channel-auth.mdx
+++ b/docs/guides/ai/eve/custom-channel-auth.mdx
@@ -1,0 +1,195 @@
+---
+title: Custom channel auth
+description: Build an Eve channel AuthFn that verifies Clerk callers from scratch — basic session auth, multi-token acceptance, and mapping Clerk auth to eve principal attributes.
+sdk: nextjs
+---
+
+Verify Clerk callers in your Eve agent's channel. This page breaks down how to secure your eve auth channel with Clerk and accept requests from web sessions, API keys, and other machine tokens.
+
+> [!TIP]
+> Skip the manual setup — install the configurable `clerkAuth()` helper via shadcn.
+
+```bash {{ filename: 'terminal', prompt: '$' }}
+bunx --bun shadcn@latest add clerk/eve-agents/auth
+```
+
+## Build it from scratch
+
+Eve channels authorize inbound requests through a list of [`AuthFn` callbacks](https://eve.dev/docs/guides/auth-and-route-protection). Each entry receives the request, returns an eve principal to accept, or returns `null` to skip to the next entry.
+
+```ts
+import type { AuthFn } from 'eve/channels/auth'
+
+const myAuth: AuthFn<Request> = async request => {
+  // Return a SessionAuthContext to accept, or `null` to skip.
+}
+```
+
+### Basic: verify a Clerk session
+
+Hand the `Request` to Clerk's [`authenticateRequest()`](/docs/reference/backend/authenticate-request) and map the verified state to an eve principal.
+
+```ts {{ filename: 'agent/channels/eve.ts' }}
+import { createClerkClient } from '@clerk/backend'
+import type { AuthFn } from 'eve/channels/auth'
+import { eveChannel } from 'eve/channels/eve'
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+})
+
+const clerkAuth: AuthFn<Request> = async request => {
+  const state = await clerk
+    .authenticateRequest(request, { acceptsToken: 'session_token' })
+    .catch(() => null)
+
+  if (!state?.isAuthenticated) return null
+
+  const auth = state.toAuth()
+
+  return {
+    authenticator: 'clerk',
+    principalType: 'user',
+    principalId: auth.userId,
+    subject: auth.userId,
+    attributes: { tokenType: auth.tokenType },
+  }
+}
+
+export default eveChannel({
+  auth: [clerkAuth],
+})
+```
+
+The returned object is what every downstream piece (instructions, tools, subagents) reads as `ctx.session.auth.current`.
+
+### Reject vs. fall through
+
+Returning `null` skips this authenticator and passes the request to the next entry in the channel's auth chain. If no entry accepts, the request is rejected. Throw [`UnauthenticatedError`](https://eve.dev/docs/guides/auth-and-route-protection) instead to short-circuit the chain with a `401` — useful when Clerk is a required authentication strategy.
+
+```ts
+import { UnauthenticatedError } from 'eve/channels/auth'
+
+if (!state?.isAuthenticated) {
+  throw new UnauthenticatedError({
+    code: 'authentication_required',
+    message: `Clerk auth failed (${state?.reason ?? 'unknown'})`,
+  })
+}
+```
+
+### Multi-token: accept session, API key, M2M, and OAuth
+
+Pass an array to [`acceptsToken`](/docs/reference/backend/authenticate-request#authenticate-request-options) to verify more than one Clerk token type in the same call. Switch on `auth.tokenType` to branch on what authenticated.
+
+```ts {{ filename: 'agent/channels/eve.ts' }}
+const clerkAuth: AuthFn<Request> = async request => {
+  const state = await clerk
+    .authenticateRequest(request, {
+      acceptsToken: ['session_token', 'api_key', 'm2m_token', 'oauth_token'],
+      machineSecretKey: process.env.CLERK_MACHINE_SECRET_KEY,
+    })
+    .catch(() => null)
+
+  if (!state?.isAuthenticated) return null
+
+  const auth = state.toAuth()
+
+  if (auth.tokenType === 'session_token') {
+    return {
+      authenticator: 'clerk',
+      principalType: 'user',
+      principalId: auth.userId,
+      subject: auth.userId,
+      attributes: { tokenType: auth.tokenType },
+    }
+  }
+
+  // API key, M2M, OAuth — Clerk groups these as machine principals.
+  return {
+    authenticator: 'clerk',
+    principalType: 'machine',
+    principalId: auth.subject,
+    subject: auth.subject,
+    attributes: { tokenType: auth.tokenType },
+  }
+}
+```
+
+`machineSecretKey` is required when accepting `m2m_token` — Clerk uses it to verify the inbound token. See [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) for setup.
+
+### Adding attributes
+
+[Attributes](https://eve.dev/docs/guides/auth-and-route-protection) is a free-form object made accessible as shared auth context in instructions, tools, and subagents. Customize the context you make available by extracting from the Clerk auth object.
+
+Session token:
+
+```ts
+const attributes: Record<string, string | readonly string[]> = {
+  tokenType: auth.tokenType,
+}
+
+if (auth.orgId) attributes.orgId = auth.orgId
+if (auth.orgRole) attributes.role = auth.orgRole
+if (auth.orgPermissions?.length) attributes.permissions = auth.orgPermissions
+```
+
+You can pull anything off `auth.sessionClaims` to enrich attributes too — useful for [custom claims](/docs/guides/sessions/customize-session-tokens) you've added to the session token.
+
+```ts
+const name = auth.sessionClaims?.name
+if (typeof name === 'string') attributes.name = name
+```
+
+Machine variants — all share `scopes`, with additional fields specific to each token type:
+
+```ts
+const attributes: Record<string, string | readonly string[]> = {
+  tokenType: auth.tokenType,
+}
+if (auth.scopes?.length) attributes.scopes = auth.scopes
+
+if (auth.tokenType === 'api_key') {
+  // API keys are scoped to either a user or an org, never both.
+  if (auth.userId) attributes.userId = auth.userId
+  if (auth.orgId) attributes.orgId = auth.orgId
+}
+
+if (auth.tokenType === 'oauth_token') {
+  attributes.userId = auth.userId
+  attributes.clientId = auth.clientId
+}
+```
+
+Summary by token type:
+
+| Token type | `principalType` | Typical attributes |
+| --- | --- | --- |
+| `session_token` | `user` | `orgId`, `role`, `permissions`, `name` |
+| `api_key` | `machine` | `scopes`, `userId` *or* `orgId` |
+| `m2m_token` | `machine` | `scopes` |
+| `oauth_token` | `machine` | `scopes`, `userId`, `clientId` |
+
+See [Enriching instructions](/docs/guides/ai/eve/enriching-instructions) and [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) for how to read these downstream.
+
+### Composing with other authenticators
+
+Add other entries to the `auth` chain. Each runs in order; the first non-null wins.
+
+```ts
+import { vercelOidc } from 'eve/channels/auth'
+
+export default eveChannel({
+  auth: [clerkAuth, vercelOidc()],
+})
+```
+
+> [!CAUTION]
+> Omitting [`localDev()`](https://eve.dev/docs/guides/auth-and-route-protection#localdev) means unauthenticated requests get a real `401` on localhost. Useful for testing real auth flows; just remember the agent won't be reachable from your browser without signing in.
+
+## Next steps
+
+- [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) — API key auth and agent-to-agent M2M.
+- [Enriching instructions](/docs/guides/ai/eve/enriching-instructions) — read the principal inside dynamic instructions.
+- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate tool invocations against permissions on the principal.

--- a/docs/guides/ai/eve/enriching-instructions.mdx
+++ b/docs/guides/ai/eve/enriching-instructions.mdx
@@ -13,6 +13,8 @@ Rebuild an eve agent's system prompt per session from the authenticated Clerk ca
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
+---
+
 The rest of this guide builds the instructions from scratch: a minimal version first, then one that emits every attribute.
 
 An eve agent's [dynamic instructions](https://eve.dev/docs/guides/dynamic-capabilities#dynamic-instructions) rebuild the system prompt on every `session.started` event. Read the Clerk principal off `ctx.session.auth.current` and the prompt becomes per-caller.

--- a/docs/guides/ai/eve/enriching-instructions.mdx
+++ b/docs/guides/ai/eve/enriching-instructions.mdx
@@ -1,10 +1,10 @@
 ---
-title: Enriching instructions
-description: Build Eve dynamic instructions that personalize the system prompt per session from the authenticated Clerk caller, without any helper packages.
+title: Enrich instructions
+description: Build eve dynamic instructions that personalize the system prompt per session from the authenticated Clerk caller, without any helper packages.
 sdk: nextjs
 ---
 
-Personalize an Eve agent's system prompt per session from the authenticated Clerk caller. This page walks through two patterns: a minimal instructions file and emitting every attribute.
+Rebuild an eve agent's system prompt per session from the authenticated Clerk caller — from a one-line greeting to the caller's full auth context.
 
 > [!TIP]
 > Skip the manual setup — install the `clerkInstructions()` helper via shadcn.
@@ -13,13 +13,13 @@ Personalize an Eve agent's system prompt per session from the authenticated Cler
 bunx --bun shadcn@latest add clerk/eve-agents/auth
 ```
 
-## Build it from scratch
+The rest of this guide builds the instructions from scratch: a minimal version first, then one that emits every attribute.
 
-Eve's [dynamic instructions](https://eve.dev/docs/guides/dynamic-capabilities#dynamic-instructions) rebuild the system prompt on every `session.started` event. Read the Clerk principal off `ctx.session.auth.current` and the prompt becomes per-caller.
+An eve agent's [dynamic instructions](https://eve.dev/docs/guides/dynamic-capabilities#dynamic-instructions) rebuild the system prompt on every `session.started` event. Read the Clerk principal off `ctx.session.auth.current` and the prompt becomes per-caller.
 
-### A minimal dynamic instructions file
+## A minimal dynamic instructions file
 
-```ts {{ filename: 'agent/instructions.ts' }}
+```ts {{ filename: 'agent/instructions.ts', mark: [6] }}
 import { defineDynamic, defineInstructions } from 'eve/instructions'
 
 export default defineDynamic({
@@ -43,7 +43,7 @@ export default defineDynamic({
 
 `ctx.session.auth.current` is `null` when no caller authenticated, so guard with `auth?.` before reading attributes.
 
-### Inlining every attribute
+## Inline every attribute
 
 To reflect every attribute (org id, role, permissions, etc.), import a `formatAuthAttributes` helper into the instructions file and pass it the current auth context. The helper itself lives in `agent/lib/utils.ts` and emits one `key: value` line per non-empty entry.
 
@@ -110,11 +110,11 @@ name: Nicolas
 
 Unauthenticated requests get an empty `userInfo`, so the section is filtered out.
 
-### Per-turn context from the browser
+## Per-turn context from the browser
 
-Dynamic instructions are generated once per session. For per-turn context, pass user info to eve's [`clientContext`](https://eve.dev/docs/guides/frontend/overview#attach-page-context-per-turn).
+Dynamic instructions run once per session. For per-turn context, pass user info to eve's [`clientContext`](https://eve.dev/docs/guides/frontend/overview#attach-page-context-per-turn) on each send.
 
-```tsx {{ filename: 'components/chat/chat.tsx' }}
+```tsx {{ filename: 'components/chat/chat.tsx', mark: [[11, 14]] }}
 import { useAuth, useUser } from '@clerk/nextjs'
 import { useEveAgent } from 'eve/react'
 
@@ -135,7 +135,7 @@ export function Chat() {
 }
 ```
 
-## Next steps
+## Related guides
 
 - [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — produce the principal these instructions read.
-- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate the tools the personalized agent can invoke.
+- [Authorize tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate the tools the personalized agent can invoke.

--- a/docs/guides/ai/eve/enriching-instructions.mdx
+++ b/docs/guides/ai/eve/enriching-instructions.mdx
@@ -31,7 +31,7 @@ export default defineDynamic({
 
       if (auth?.principalType === 'user' && auth.attributes.name) {
         sections.push(
-          `You are speaking with ${auth.attributes.name}. Address them by name when it feels natural.`
+          `You are speaking with ${auth.attributes.name}. Address them by name when it feels natural.`,
         )
       }
 
@@ -123,7 +123,7 @@ export function Chat() {
   const { orgId } = useAuth()
 
   const agent = useEveAgent({
-    prepareSend: input => ({
+    prepareSend: (input) => ({
       ...input,
       clientContext: {
         user: user?.fullName ?? null,

--- a/docs/guides/ai/eve/enriching-instructions.mdx
+++ b/docs/guides/ai/eve/enriching-instructions.mdx
@@ -1,0 +1,141 @@
+---
+title: Enriching instructions
+description: Build Eve dynamic instructions that personalize the system prompt per session from the authenticated Clerk caller, without any helper packages.
+sdk: nextjs
+---
+
+Personalize an Eve agent's system prompt per session from the authenticated Clerk caller. This page walks through two patterns: a minimal instructions file and emitting every attribute.
+
+> [!TIP]
+> Skip the manual setup — install the `clerkInstructions()` helper via shadcn.
+
+```bash {{ filename: 'terminal', prompt: '$' }}
+bunx --bun shadcn@latest add clerk/eve-agents/auth
+```
+
+## Build it from scratch
+
+Eve's [dynamic instructions](https://eve.dev/docs/guides/dynamic-capabilities#dynamic-instructions) rebuild the system prompt on every `session.started` event. Read the Clerk principal off `ctx.session.auth.current` and the prompt becomes per-caller.
+
+### A minimal dynamic instructions file
+
+```ts {{ filename: 'agent/instructions.ts' }}
+import { defineDynamic, defineInstructions } from 'eve/instructions'
+
+export default defineDynamic({
+  events: {
+    'session.started': (_event, ctx) => {
+      const auth = ctx.session.auth.current
+
+      const sections = ['You are a helpful assistant.']
+
+      if (auth?.principalType === 'user' && auth.attributes.name) {
+        sections.push(
+          `You are speaking with ${auth.attributes.name}. Address them by name when it feels natural.`
+        )
+      }
+
+      return defineInstructions({ markdown: sections.join('\n\n') })
+    },
+  },
+})
+```
+
+`ctx.session.auth.current` is `null` when no caller authenticated, so guard with `auth?.` before reading attributes.
+
+### Inlining every attribute
+
+To reflect every attribute (org id, role, permissions, etc.), import a `formatAuthAttributes` helper into the instructions file and pass it the current auth context. The helper itself lives in `agent/lib/utils.ts` and emits one `key: value` line per non-empty entry.
+
+<Tabs items={["agent/instructions.ts", "agent/lib/utils.ts"]}>
+  <Tab>
+    ```ts {{ filename: 'agent/instructions.ts' }}
+    import { defineDynamic, defineInstructions } from 'eve/instructions'
+    import { formatAuthAttributes } from './lib/utils'
+
+    export default defineDynamic({
+      events: {
+        'session.started': (_event, ctx) => {
+          const userInfo = formatAuthAttributes(ctx.session.auth.current)
+
+          const sections = [
+            'You are a helpful assistant.',
+            userInfo &&
+              `Use the following info about the caller to personalize your response:\n${userInfo}`,
+          ].filter(Boolean) as string[]
+
+          return defineInstructions({ markdown: sections.join('\n\n') })
+        },
+      },
+    })
+    ```
+  </Tab>
+
+  <Tab>
+    ```ts {{ filename: 'agent/lib/utils.ts' }}
+    import type { SessionAuthContext } from 'eve/context'
+
+    export function formatAuthAttributes(auth: SessionAuthContext | null): string {
+      if (!auth) return ''
+
+      const lines: string[] = []
+      for (const [key, value] of Object.entries(auth.attributes)) {
+        const stringValue =
+          typeof value === 'string'
+            ? value
+            : Array.isArray(value) && value.length > 0
+              ? value.join(', ')
+              : ''
+        if (stringValue) lines.push(`${key}: ${stringValue}`)
+      }
+
+      return lines.join('\n')
+    }
+    ```
+  </Tab>
+</Tabs>
+
+For a signed-in user with an org membership the prompt picks up:
+
+```text
+You are a helpful assistant.
+
+Use the following info about the caller to personalize your response:
+tokenType: session_token
+orgId: org_123
+role: org:admin
+permissions: org:projects:archive, org:projects:read
+name: Nicolas
+```
+
+Unauthenticated requests get an empty `userInfo`, so the section is filtered out.
+
+### Per-turn context from the browser
+
+Dynamic instructions are generated once per session. For per-turn context, pass user info to eve's [`clientContext`](https://eve.dev/docs/guides/frontend/overview#attach-page-context-per-turn).
+
+```tsx {{ filename: 'components/chat/chat.tsx' }}
+import { useAuth, useUser } from '@clerk/nextjs'
+import { useEveAgent } from 'eve/client/react'
+
+export function Chat() {
+  const { user } = useUser()
+  const { orgId } = useAuth()
+
+  const agent = useEveAgent({
+    prepareSend: input => ({
+      ...input,
+      clientContext: {
+        user: user?.fullName ?? null,
+        orgId: orgId ?? null,
+      },
+    }),
+  })
+  // ...
+}
+```
+
+## Next steps
+
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — produce the principal these instructions read.
+- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — gate the tools the personalized agent can invoke.

--- a/docs/guides/ai/eve/enriching-instructions.mdx
+++ b/docs/guides/ai/eve/enriching-instructions.mdx
@@ -116,7 +116,7 @@ Dynamic instructions are generated once per session. For per-turn context, pass 
 
 ```tsx {{ filename: 'components/chat/chat.tsx' }}
 import { useAuth, useUser } from '@clerk/nextjs'
-import { useEveAgent } from 'eve/client/react'
+import { useEveAgent } from 'eve/react'
 
 export function Chat() {
   const { user } = useUser()

--- a/docs/guides/ai/eve/getting-started.mdx
+++ b/docs/guides/ai/eve/getting-started.mdx
@@ -1,13 +1,13 @@
 ---
-title: Get started with Clerk and Eve
-description: Overview of the Clerk + Eve integration. Install ready-to-go helpers via shadcn, or try the demo to see every pattern in one place.
+title: Get started with Clerk and eve
+description: Overview of the Clerk + eve integration. Install ready-to-go helpers via shadcn, or try the demo to see every pattern in one place.
 sdk: nextjs
 ---
 
 <TutorialHero
   exampleRepo={[
     {
-      title: "Clerk + Eve agents starter",
+      title: "Clerk + eve agents starter",
       link: "https://github.com/clerk/eve-agents/tree/main"
     }
   ]}
@@ -25,16 +25,16 @@ sdk: nextjs
   ]}
 />
 
-[Eve](https://eve.dev) is Vercel's filesystem-first framework for durable AI agents. Identity, channels, instructions, tools, and subagents all live in conventional files, so projects stay easy to inspect, extend, and operate.
+Built by Vercel, [eve](https://eve.dev) is a filesystem-first framework for durable AI agents. Identity, channels, instructions, tools, and subagents all live in conventional files you can read, diff, and version like any other code.
 
-This guide group covers four common patterns for pairing Clerk with Eve:
+Clerk and eve fit together through four common patterns:
 
 - [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — accept any Clerk token type at the channel boundary and map it to an eve principal.
 - [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) — API key callers and machine-to-machine calls between agents.
-- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — permission checks inside `execute`, plus brokered OAuth for tools that need provider tokens.
-- [Enriching instructions](/docs/guides/ai/eve/enriching-instructions) — rebuild the system prompt per session from the authenticated caller.
+- [Authorize tool calls](/docs/guides/ai/eve/authorize-tool-calls) — permission checks inside `execute`, plus brokered OAuth for tools that need provider tokens.
+- [Enrich instructions](/docs/guides/ai/eve/enriching-instructions) — rebuild the system prompt per session from the authenticated caller.
 
-Each page shows the underlying pattern from scratch, then points to a shadcn-installable helper if you'd rather skip the boilerplate.
+Each guide starts with a shadcn-installable helper, then builds the pattern from scratch if you'd rather wire it up yourself.
 
 ## Install the helpers via shadcn
 
@@ -70,11 +70,6 @@ git clone https://github.com/clerk/eve-agents.git
 
 Boot the dashboard, sign in, and switch between **Session**, **API key**, and **Unauthenticated** flows in the UI to watch each path behave differently. Ask the agent to list your GitHub repositories to trigger the OAuth connect flow; ask it to archive a project to watch M2M delegation in action.
 
-## Next
+## Detailed walkthroughs
 
-Pick a pattern:
-
-- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth)
-- [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m)
-- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls)
-- [Enriching instructions](/docs/guides/ai/eve/enriching-instructions)
+Start with [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — it produces the eve principal every other pattern reads. From there, layer on [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) for programmatic and agent-to-agent callers, [Authorize tool calls](/docs/guides/ai/eve/authorize-tool-calls) to gate tools and broker provider OAuth, and [Enrich instructions](/docs/guides/ai/eve/enriching-instructions) to personalize the system prompt per caller.

--- a/docs/guides/ai/eve/getting-started.mdx
+++ b/docs/guides/ai/eve/getting-started.mdx
@@ -63,7 +63,7 @@ git clone https://github.com/clerk/eve-agents.git
 ```
 
 | Workspace | What it shows |
-| --- | --- |
+| - | - |
 | `apps/dashboard` | Chat UI with a colocated main agent. |
 | `apps/project-agent` | Remote subagent reachable only via M2M. |
 | `packages/clerk-eve-auth` | Clerk helpers shipped through the shadcn registry. |

--- a/docs/guides/ai/eve/getting-started.mdx
+++ b/docs/guides/ai/eve/getting-started.mdx
@@ -1,0 +1,80 @@
+---
+title: Get started with Clerk and Eve
+description: Overview of the Clerk + Eve integration. Install ready-to-go helpers via shadcn, or try the demo to see every pattern in one place.
+sdk: nextjs
+---
+
+<TutorialHero
+  exampleRepo={[
+    {
+      title: "Clerk + Eve agents starter",
+      link: "https://github.com/clerk/eve-agents/tree/main"
+    }
+  ]}
+  beforeYouStart={[
+    {
+      title: "A Clerk application is required",
+      link: "/docs/getting-started/quickstart/setup-clerk",
+      icon: "clerk",
+    },
+    {
+      title: "Integrate Clerk into your Next.js application",
+      link: "/docs/nextjs/getting-started/quickstart",
+      icon: "nextjs",
+    },
+  ]}
+/>
+
+[Eve](https://eve.dev) is Vercel's filesystem-first framework for durable AI agents. Identity, channels, instructions, tools, and subagents all live in conventional files, so projects stay easy to inspect, extend, and operate.
+
+This guide group covers four common patterns for pairing Clerk with Eve:
+
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth) — accept any Clerk token type at the channel boundary and map it to an eve principal.
+- [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m) — API key callers and machine-to-machine calls between agents.
+- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls) — permission checks inside `execute`, plus brokered OAuth for tools that need provider tokens.
+- [Enriching instructions](/docs/guides/ai/eve/enriching-instructions) — rebuild the system prompt per session from the authenticated caller.
+
+Each page shows the underlying pattern from scratch, then points to a shadcn-installable helper if you'd rather skip the boilerplate.
+
+## Install the helpers via shadcn
+
+The [`clerk/eve-agents`](https://github.com/clerk/eve-agents) repo doubles as a [shadcn GitHub registry](https://ui.shadcn.com/docs/registry/github) that exposes `clerkAuth()`, `clerkInstructions()`, `clerkM2MToken()`, `clerkConnect()`, and `clerkOAuthToken()` as a single drop-in.
+
+```bash {{ filename: 'terminal', prompt: '$' }}
+bunx --bun shadcn@latest add clerk/eve-agents/auth
+```
+
+The helpers land at `lib/clerk-auth/`:
+
+```text
+lib/clerk-auth/
+├── index.ts        # clerkAuth and related types
+├── instructions.ts # clerkInstructions
+├── m2m.ts          # clerkM2MToken
+└── connect.ts      # clerkConnect, clerkOAuthToken
+```
+
+## Try the demo
+
+Clone [`clerk/eve-agents`](https://github.com/clerk/eve-agents) for a working monorepo that exercises every pattern in one place:
+
+```bash {{ filename: 'terminal', prompt: '$' }}
+git clone https://github.com/clerk/eve-agents.git
+```
+
+| Workspace | What it shows |
+| --- | --- |
+| `apps/dashboard` | Chat UI with a colocated main agent. |
+| `apps/project-agent` | Remote subagent reachable only via M2M. |
+| `packages/clerk-eve-auth` | Clerk helpers shipped through the shadcn registry. |
+
+Boot the dashboard, sign in, and switch between **Session**, **API key**, and **Unauthenticated** flows in the UI to watch each path behave differently. Ask the agent to list your GitHub repositories to trigger the OAuth connect flow; ask it to archive a project to watch M2M delegation in action.
+
+## Next
+
+Pick a pattern:
+
+- [Custom channel auth](/docs/guides/ai/eve/custom-channel-auth)
+- [API keys & M2M](/docs/guides/ai/eve/api-keys-and-m2m)
+- [Authorizing tool calls](/docs/guides/ai/eve/authorize-tool-calls)
+- [Enriching instructions](/docs/guides/ai/eve/enriching-instructions)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1219,7 +1219,7 @@
                     "href": "/docs/guides/ai/prompts"
                   },
                   {
-                    "title": "Eve",
+                    "title": "eve",
                     "sdk": ["nextjs"],
                     "items": [
                       [

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1219,6 +1219,34 @@
                     "href": "/docs/guides/ai/prompts"
                   },
                   {
+                    "title": "Eve",
+                    "sdk": ["nextjs"],
+                    "items": [
+                      [
+                        {
+                          "title": "Getting started",
+                          "href": "/docs/guides/ai/eve/getting-started"
+                        },
+                        {
+                          "title": "Custom channel auth",
+                          "href": "/docs/guides/ai/eve/custom-channel-auth"
+                        },
+                        {
+                          "title": "API keys & M2M",
+                          "href": "/docs/guides/ai/eve/api-keys-and-m2m"
+                        },
+                        {
+                          "title": "Authorizing tool calls",
+                          "href": "/docs/guides/ai/eve/authorize-tool-calls"
+                        },
+                        {
+                          "title": "Enriching instructions",
+                          "href": "/docs/guides/ai/eve/enriching-instructions"
+                        }
+                      ]
+                    ]
+                  },
+                  {
                     "title": "MCP development",
                     "items": [
                       [


### PR DESCRIPTION
## Summary

New `Eve` guide sub-group under `docs/guides/ai/`, scoped to Next.js, covering Clerk + Eve patterns:

- **Getting started** — install the shadcn helpers, link to the [`clerk/eve-agents`](https://github.com/clerk/eve-agents) companion repo, and a workspace map for the demo monorepo.
- **Custom channel auth** — build an Eve `AuthFn` from scratch that accepts session tokens, API keys, M2M tokens, and OAuth tokens; map Clerk auth onto eve principal attributes; compose with other authenticators.
- **API keys & M2M** — create API keys and machines via Clerk CLI / Backend API, verify them inbound, and wire agent-to-agent M2M with scoped machines and a `bearer()` resolver.
- **Authorizing tool calls** — gate tool calls by permission/scope using factored helpers, plus a reusable `clerkConnect(provider, options)` factory for Clerk-brokered OAuth and a fallback path for API key callers.
- **Enriching instructions** — read the Clerk principal inside `defineDynamic` to personalize the system prompt per session, plus `clientContext` for per-turn data from the browser.

Sidebar entries added to `manifest.json`. Each pattern page leads with a shadcn callout that points at the canonical helper available to install directly; the body of page shows the from-scratch pattern that the installable helpers abstract.

## Preview

https://clerk.com/docs/pr/nicolas-guides-ai-eve/guides/ai/eve/getting-started

Companion repo (demo monorepo + shadcn registry)
https://github.com/clerk/eve-agents

## Test plan

- [x] `pnpm run build:tsx` clean
- [x] `pnpm run lint` clean
- [x] Snippet validation in local playground app
- [ ] Local preview review