### PR TITLE
Generate Backend docs - Redirect URLs, Email Addresses, and Phone Numbers APIs

### DIFF
--- a/docs/reference/backend/email-addresses/create-email-address.mdx
+++ b/docs/reference/backend/email-addresses/create-email-address.mdx
@@ -3,41 +3,7 @@ title: '`createEmailAddress()`'
 description: Use the createEmailAddress() method to create an email address for the specified user.
 ---
 
-Creates an [`EmailAddress`](/docs/reference/types/email-address) for the specified user.
-
-```ts
-function createEmailAddress(params: CreateEmailAddressParams): Promise<EmailAddress>
-```
-
-## `CreateEmailAddressParams`
-
-<Properties>
-  - `userId`
-  - `string`
-
-  The ID of the user to create the email address for.
-
-  ---
-
-  - `emailAddress`
-  - `string`
-
-  The email address to assign to the specified user.
-
-  ---
-
-  - `primary?`
-  - `boolean`
-
-  Whether or not to set the email address as the user's primary email address. Defaults to `false`, unless it is the first email address.
-
-  ---
-
-  - `verified?`
-  - `boolean`
-
-  Whether or not the email address is verified.
-</Properties>
+<Typedoc src="backend/email-address-api/methods/create-email-address" />
 
 ## Usage
 

--- a/docs/reference/backend/email-addresses/delete-email-address.mdx
+++ b/docs/reference/backend/email-addresses/delete-email-address.mdx
@@ -3,20 +3,7 @@ title: '`deleteEmailAddress()`'
 description: Use the deleteEmailAddress() method to delete an email address.
 ---
 
-Deletes an [`EmailAddress`](/docs/reference/types/email-address).
-
-```ts
-function deleteEmailAddress(emailAddressId: string): Promise<EmailAddress>
-```
-
-## Parameters
-
-<Properties>
-  - `emailAddressId`
-  - `string`
-
-  The ID of the email address to delete.
-</Properties>
+<Typedoc src="backend/email-address-api/methods/delete-email-address" />
 
 ## Usage
 

--- a/docs/reference/backend/email-addresses/get-email-address.mdx
+++ b/docs/reference/backend/email-addresses/get-email-address.mdx
@@ -1,22 +1,9 @@
 ---
 title: '`getEmailAddress()`'
-description: Use the getEmailAddress() method to retrieve a single email address by its ID.
+description: Use the getEmailAddress() method to get an email address by its ID.
 ---
 
-Retrieves a single [`EmailAddress`](/docs/reference/types/email-address).
-
-```ts
-function getEmailAddress(emailAddressId: string): Promise<EmailAddress>
-```
-
-## Parameters
-
-<Properties>
-  - `emailAddressId`
-  - `string`
-
-  The ID of the email address to retrieve.
-</Properties>
+<Typedoc src="backend/email-address-api/methods/get-email-address" />
 
 ## Usage
 

--- a/docs/reference/backend/email-addresses/update-email-address.mdx
+++ b/docs/reference/backend/email-addresses/update-email-address.mdx
@@ -3,30 +3,7 @@ title: '`updateEmailAddress()`'
 description: Use the updateEmailAddress() method to update an email address.
 ---
 
-Updates an [`EmailAddress`](/docs/reference/types/email-address).
-
-```ts
-function updateEmailAddress(
-  emailAddressId: string,
-  params: UpdateEmailAddressParams,
-): Promise<EmailAddress>
-```
-
-## `UpdateEmailAddressParams`
-
-<Properties>
-  - `primary?`
-  - `boolean`
-
-  Whether or not to set the email address as the user's primary email address.
-
-  ---
-
-  - `verified?`
-  - `boolean`
-
-  Whether or not the email address is verified.
-</Properties>
+<Typedoc src="backend/email-address-api/methods/update-email-address" />
 
 ## Usage
 

--- a/docs/reference/backend/phone-numbers/create-phone-number.mdx
+++ b/docs/reference/backend/phone-numbers/create-phone-number.mdx
@@ -3,48 +3,7 @@ title: '`createPhoneNumber()`'
 description: Use the createPhoneNumber() method to create a phone number for the specified user.
 ---
 
-Creates a [`PhoneNumber`](/docs/reference/types/phone-number) for the specified user.
-
-```ts
-function createPhoneNumber(params: CreatePhoneNumberParams): Promise<PhoneNumber>
-```
-
-## `CreatePhoneNumberParams`
-
-<Properties>
-  - `userId`
-  - `string`
-
-  The ID of the user to create the phone number for.
-
-  ---
-
-  - `phoneNumber`
-  - `string`
-
-  The phone number to assign to the specified user. Must adhere to the [E.164 format](https://en.wikipedia.org/wiki/E.164) standard for phone number format.
-
-  ---
-
-  - `primary?`
-  - `boolean`
-
-  Whether or not to set the phone number as the user's primary phone number. Defaults to `false`, unless it is the first phone number.
-
-  ---
-
-  - `verified?`
-  - `boolean`
-
-  Whether or not the phone number is verified.
-
-  ---
-
-  - `reservedForSecondFactor`
-  - `boolean`
-
-  Whether or not the phone number is reserved for [multi-factor authentication](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication). The phone number must also be verified. If there are no other reserved [second factors](!second-factor-verification), the phone number will be set as the default second factor.
-</Properties>
+<Typedoc src="backend/phone-number-api/methods/create-phone-number" />
 
 ## Usage
 

--- a/docs/reference/backend/phone-numbers/delete-phone-number.mdx
+++ b/docs/reference/backend/phone-numbers/delete-phone-number.mdx
@@ -3,20 +3,7 @@ title: '`deletePhoneNumber()`'
 description: Use the deletePhoneNumber() method to delete a phone number.
 ---
 
-Deletes a [`PhoneNumber`](/docs/reference/types/phone-number).
-
-```ts
-function deletePhoneNumber(phoneNumberId: string): Promise<PhoneNumber>
-```
-
-## Parameters
-
-<Properties>
-  - `phoneNumberId`
-  - `string`
-
-  The ID of the phone number to delete.
-</Properties>
+<Typedoc src="backend/phone-number-api/methods/delete-phone-number" />
 
 ## Usage
 

--- a/docs/reference/backend/phone-numbers/get-phone-number.mdx
+++ b/docs/reference/backend/phone-numbers/get-phone-number.mdx
@@ -1,22 +1,9 @@
 ---
 title: '`getPhoneNumber()`'
-description: Use the getPhoneNumber() method to retrieve a single phone number by its ID.
+description: Use the getPhoneNumber() method to get a phone number by its ID.
 ---
 
-Retrieves a single [`PhoneNumber`](/docs/reference/types/phone-number).
-
-```ts
-function getPhoneNumber(phoneNumberId: string): Promise<PhoneNumber>
-```
-
-## Parameters
-
-<Properties>
-  - `phoneNumberId`
-  - `string`
-
-  The ID of the phone number to retrieve.
-</Properties>
+<Typedoc src="backend/phone-number-api/methods/get-phone-number" />
 
 ## Usage
 

--- a/docs/reference/backend/phone-numbers/update-phone-number.mdx
+++ b/docs/reference/backend/phone-numbers/update-phone-number.mdx
@@ -3,37 +3,7 @@ title: '`updatePhoneNumber()`'
 description: Use the updatePhoneNumber() method to update a phone number.
 ---
 
-Updates a [`PhoneNumber`](/docs/reference/types/phone-number).
-
-```ts
-function updatePhoneNumber(
-  phoneNumberId: string,
-  params: UpdatePhoneNumberParams,
-): Promise<PhoneNumber>
-```
-
-## `UpdatePhoneNumberParams`
-
-<Properties>
-  - `primary?`
-  - `boolean`
-
-  Whether or not to set the phone number as the user's primary phone number.
-
-  ---
-
-  - `verified?`
-  - `boolean`
-
-  Whether or not the phone number is verified.
-
-  ---
-
-  - `reservedForSecondFactor`
-  - `boolean`
-
-  Whether or not the phone number is reserved for [multi-factor authentication](/docs/guides/configure/auth-strategies/sign-up-sign-in-options#multi-factor-authentication). The phone number must also be verified. If there are no other reserved [second factors](!second-factor-verification), the phone number will be set as the default second factor.
-</Properties>
+<Typedoc src="backend/phone-number-api/methods/update-phone-number" />
 
 ## Usage
 

--- a/docs/reference/backend/redirect-urls/create-redirect-url.mdx
+++ b/docs/reference/backend/redirect-urls/create-redirect-url.mdx
@@ -3,20 +3,7 @@ title: '`createRedirectUrl()`'
 description: Use the createRedirectUrl() method to create a redirect URL.
 ---
 
-Creates a [`RedirectUrl`](/docs/reference/backend/types/backend-redirect-url).
-
-```ts
-function createRedirectUrl(params: CreateRedirectUrlParams): Promise<RedirectUrl>
-```
-
-## `CreateRedirectUrlParams`
-
-<Properties>
-  - `url`
-  - `string`
-
-  The full url value prefixed with `https://` or a custom scheme. For example, `https://my-app.com/oauth-callback` or `my-app://oauth-callback`
-</Properties>
+<Typedoc src="backend/redirect-url-api/methods/create-redirect-url" />
 
 ## Usage
 

--- a/docs/reference/backend/redirect-urls/delete-redirect-url.mdx
+++ b/docs/reference/backend/redirect-urls/delete-redirect-url.mdx
@@ -3,20 +3,7 @@ title: '`deleteRedirectUrl()`'
 description: Use the deleteRedirectUrl() method to delete a redirect URL.
 ---
 
-Deletes a [`RedirectUrl`](/docs/reference/backend/types/backend-redirect-url).
-
-```ts
-function deleteRedirectUrl(redirectUrlId: string): Promise<RedirectUrl>
-```
-
-## Parameters
-
-<Properties>
-  - `redirectUrlId`
-  - `string`
-
-  The ID of the redirect URL to delete.
-</Properties>
+<Typedoc src="backend/redirect-url-api/methods/delete-redirect-url" />
 
 ## Usage
 

--- a/docs/reference/backend/redirect-urls/get-redirect-url-list.mdx
+++ b/docs/reference/backend/redirect-urls/get-redirect-url-list.mdx
@@ -1,13 +1,9 @@
 ---
 title: '`getRedirectUrlList()`'
-description: Use the getRedirectUrlList() method to retrieve a list of white-listed redirect URLs.
+description: Use the getRedirectUrlList() method to get a list of whitelisted redirect URLs for your instance.
 ---
 
-Retrieves a list of all white-listed redirect URLs. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`RedirectUrl`](/docs/reference/backend/types/backend-redirect-url) objects, and a `totalCount` property that indicates the total number of redirect URLs for the application.
-
-```tsx
-function getRedirectUrlList(): () => Promise<PaginatedResourceResponse<RedirectUrl[]>>
-```
+<Typedoc src="backend/redirect-url-api/methods/get-redirect-url-list" />
 
 ## Usage
 

--- a/docs/reference/backend/redirect-urls/get-redirect-url.mdx
+++ b/docs/reference/backend/redirect-urls/get-redirect-url.mdx
@@ -1,22 +1,9 @@
 ---
 title: '`getRedirectUrl()`'
-description: Use the getRedirectUrl() method to retrieve a single redirect URL by its ID.
+description: Use the getRedirectUrl() method to get a redirect URL by its ID.
 ---
 
-Retrieves a single [`RedirectUrl`](/docs/reference/backend/types/backend-redirect-url).
-
-```ts
-function getRedirectUrl(redirectUrlId: string): Promise<RedirectUrl>
-```
-
-## Parameters
-
-<Properties>
-  - `redirectUrlId`
-  - `string`
-
-  The ID of the redirect URL to retrieve.
-</Properties>
+<Typedoc src="backend/redirect-url-api/methods/get-redirect-url" />
 
 ## Usage
 


### PR DESCRIPTION
### What does this solve? What changed?

Replaces the hand-written Backend reference pages for Redirect URLs, Email Addresses, and Phone Numbers with `<Typedoc />` includes, so the reference stays in sync with the SDK going forward.

- Redirect URLs: `create-redirect-url`, `delete-redirect-url`, `get-redirect-url`, `get-redirect-url-list`
- Email Addresses: `create-email-address`, `delete-email-address`, `get-email-address`, `update-email-address`
- Phone Numbers: `create-phone-number`, `delete-phone-number`, `get-phone-number`, `update-phone-number`

Stacked on #3445 (`aa/DOCS-10984`).

### Deadline

- No rush

