### PR TITLE
Generate Backend docs - SAML, Enterprise Connections, Sign-in Tokens, and Agent Tasks APIs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2776,6 +2776,33 @@
                           "href": "/docs/reference/backend/overview"
                         },
                         {
+                          "title": "Enterprise Connections",
+                          "items": [
+                            [
+                              {
+                                "title": "`createEnterpriseConnection()`",
+                                "href": "/docs/reference/backend/enterprise-connections/create-enterprise-connection"
+                              },
+                              {
+                                "title": "`deleteEnterpriseConnection()`",
+                                "href": "/docs/reference/backend/enterprise-connections/delete-enterprise-connection"
+                              },
+                              {
+                                "title": "`getEnterpriseConnection()`",
+                                "href": "/docs/reference/backend/enterprise-connections/get-enterprise-connection"
+                              },
+                              {
+                                "title": "`getEnterpriseConnectionList()`",
+                                "href": "/docs/reference/backend/enterprise-connections/get-enterprise-connection-list"
+                              },
+                              {
+                                "title": "`updateEnterpriseConnection()`",
+                                "href": "/docs/reference/backend/enterprise-connections/update-enterprise-connection"
+                              }
+                            ]
+                          ]
+                        },
+                        {
                           "title": "User",
                           "items": [
                             [
@@ -3496,6 +3523,10 @@
                                 "href": "/docs/reference/backend/types/auth-object"
                               },
                               {
+                                "title": "`AgentTask` object",
+                                "href": "/docs/reference/backend/types/backend-agent-task"
+                              },
+                              {
                                 "title": "`AllowlistIdentifier` object",
                                 "href": "/docs/reference/backend/types/backend-allowlist-identifier"
                               },
@@ -3606,6 +3637,10 @@
                               {
                                 "title": "`SessionActivity` object",
                                 "href": "/docs/reference/backend/types/backend-session-activity"
+                              },
+                              {
+                                "title": "`SignInToken` object",
+                                "href": "/docs/reference/backend/types/backend-sign-in-token"
                               },
                               {
                                 "title": "`RedirectURL` object",

--- a/docs/reference/backend/agent-tasks/create.mdx
+++ b/docs/reference/backend/agent-tasks/create.mdx
@@ -5,55 +5,7 @@ description: Use the create() method to create an Agent Task.
 
 <Include src="_partials/agent-tasks-beta-callout" />
 
-Creates an [`AgentTask`](/docs/reference/types/agent-task) that generates a URL which, when visited, creates a session for the specified user. This is useful for automated testing or agent-driven flows where full authentication isn't practical.
-
-```ts
-function create(params: CreateAgentTaskParams): Promise<AgentTask>
-```
-
-## `CreateAgentTaskParams`
-
-<Properties>
-  - `onBehalfOf`
-  - `{ userId: string } | { identifier: string }`
-
-  The user to create the Agent Task for. Provide either a `userId` or an `identifier` (e.g., an email address, phone number, or username).
-
-  ---
-
-  - `permissions`
-  - `string`
-
-  The permissions the Agent Task will have. Currently, `'*'` is the only supported value, which grants all permissions.
-
-  ---
-
-  - `agentName`
-  - `string`
-
-  The name of the agent creating the task.
-
-  ---
-
-  - `taskDescription`
-  - `string`
-
-  A description of the Agent Task.
-
-  ---
-
-  - `redirectUrl`
-  - `string`
-
-  The URL to redirect to after the Agent Task is consumed.
-
-  ---
-
-  - `sessionMaxDurationInSeconds?`
-  - `number`
-
-  The maximum duration in seconds for the session created by the Agent Task. Defaults to 30 minutes (1800 seconds).
-</Properties>
+<Typedoc src="backend/agent-task-api/methods/create" />
 
 ## Usage
 

--- a/docs/reference/backend/agent-tasks/revoke.mdx
+++ b/docs/reference/backend/agent-tasks/revoke.mdx
@@ -5,20 +5,7 @@ description: Use the revoke() method to revoke an Agent Task.
 
 <Include src="_partials/agent-tasks-beta-callout" />
 
-Revokes an existing [`AgentTask`](/docs/reference/types/agent-task), preventing it from being used to create a session.
-
-```ts
-function revoke(agentTaskId: string): Promise<Omit<AgentTask, 'url'>>
-```
-
-## Parameters
-
-<Properties>
-  - `agentTaskId`
-  - `string`
-
-  The ID of the Agent Task to revoke.
-</Properties>
+<Typedoc src="backend/agent-task-api/methods/revoke" />
 
 ## Usage
 

--- a/docs/reference/backend/enterprise-connections/create-enterprise-connection.mdx
+++ b/docs/reference/backend/enterprise-connections/create-enterprise-connection.mdx
@@ -1,0 +1,30 @@
+---
+title: '`createEnterpriseConnection()`'
+description: Use the createEnterpriseConnection() method to create an enterprise connection.
+---
+
+<Typedoc src="backend/enterprise-connection-api/methods/create-enterprise-connection" />
+
+## Usage
+
+<Include src="_partials/backend/usage" />
+
+```tsx
+const response = await clerkClient.enterpriseConnections.createEnterpriseConnection({
+  name: 'Google',
+  organizationId: 'org_123',
+  oidc: {
+    authUrl: 'https://example.com/auth',
+    clientId: '1234567890',
+    clientSecret: '1234567890',
+    discoveryUrl: 'https://example.com/discovery',
+    requiresPkce: false,
+    tokenUrl: 'https://example.com/token',
+    userInfoUrl: 'https://example.com/userinfo',
+  },
+})
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `POST/enterprise_connections`. See the [BAPI reference](/docs/reference/backend-api/tag/enterprise-connections/POST/enterprise_connections){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/enterprise-connections/delete-enterprise-connection.mdx
+++ b/docs/reference/backend/enterprise-connections/delete-enterprise-connection.mdx
@@ -1,0 +1,18 @@
+---
+title: '`deleteEnterpriseConnection()`'
+description: Use the deleteEnterpriseConnection() method to delete an enterprise connection.
+---
+
+<Typedoc src="backend/enterprise-connection-api/methods/delete-enterprise-connection" />
+
+## Usage
+
+<Include src="_partials/backend/usage" />
+
+```tsx
+const response = await clerkClient.enterpriseConnections.deleteEnterpriseConnection('ec_123')
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `DELETE/enterprise_connections/{enterprise_connection_id}`. See the [BAPI reference](/docs/reference/backend-api/tag/enterprise-connections/DELETE/enterprise_connections/%7Benterprise_connection_id%7D){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/enterprise-connections/get-enterprise-connection-list.mdx
+++ b/docs/reference/backend/enterprise-connections/get-enterprise-connection-list.mdx
@@ -1,0 +1,18 @@
+---
+title: '`getEnterpriseConnectionList()`'
+description: Use the getEnterpriseConnectionList() method to get a list of enterprise connections.
+---
+
+<Typedoc src="backend/enterprise-connection-api/methods/get-enterprise-connection-list" />
+
+## Usage
+
+<Include src="_partials/backend/usage" />
+
+```tsx
+const response = await clerkClient.enterpriseConnections.getEnterpriseConnectionList()
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `GET/enterprise_connections`. See the [BAPI reference](/docs/reference/backend-api/tag/enterprise-connections/GET/enterprise_connections){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/enterprise-connections/get-enterprise-connection.mdx
+++ b/docs/reference/backend/enterprise-connections/get-enterprise-connection.mdx
@@ -1,0 +1,18 @@
+---
+title: '`getEnterpriseConnection()`'
+description: Use the getEnterpriseConnection() method to get an enterprise connection.
+---
+
+<Typedoc src="backend/enterprise-connection-api/methods/get-enterprise-connection" />
+
+## Usage
+
+<Include src="_partials/backend/usage" />
+
+```tsx
+const response = await clerkClient.enterpriseConnections.getEnterpriseConnection('ec_123')
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `GET/enterprise_connections/{enterprise_connection_id}`. See the [BAPI reference](/docs/reference/backend-api/tag/enterprise-connections/GET/enterprise_connections/%7Benterprise_connection_id%7D){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/enterprise-connections/update-enterprise-connection.mdx
+++ b/docs/reference/backend/enterprise-connections/update-enterprise-connection.mdx
@@ -1,0 +1,30 @@
+---
+title: '`updateEnterpriseConnection()`'
+description: Use the updateEnterpriseConnection() method to update an enterprise connection.
+---
+
+<Typedoc src="backend/enterprise-connection-api/methods/update-enterprise-connection" />
+
+## Usage
+
+<Include src="_partials/backend/usage" />
+
+```tsx
+const response = await clerkClient.enterpriseConnections.updateEnterpriseConnection('ec_123', {
+  name: 'Google',
+  provider: 'oidc_google',
+  oidc: {
+    authUrl: 'https://example.com/auth',
+    clientId: '1234567890',
+    clientSecret: '1234567890',
+    discoveryUrl: 'https://example.com/discovery',
+    requiresPkce: false,
+    tokenUrl: 'https://example.com/token',
+    userInfoUrl: 'https://example.com/userinfo',
+  },
+})
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `PATCH/enterprise_connections/{enterprise_connection_id}`. See the [BAPI reference](/docs/reference/backend-api/tag/enterprise-connections/PATCH/enterprise_connections/%7Benterprise_connection_id%7D){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/saml-connections/create-saml-connection.mdx
+++ b/docs/reference/backend/saml-connections/create-saml-connection.mdx
@@ -1,7 +1,10 @@
 ---
-title: '`createSamlConnection()`'
+title: '`createSamlConnection()` (deprecated)'
 description: Use the createSamlConnection() method to create a SAML connection.
 ---
+
+> [!WARNING]
+> This method is deprecated. Use [`createEnterpriseConnection()`](/docs/reference/backend/enterprise-connections/create-enterprise-connection) instead.
 
 Creates a new [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection).
 

--- a/docs/reference/backend/saml-connections/delete-saml-connection.mdx
+++ b/docs/reference/backend/saml-connections/delete-saml-connection.mdx
@@ -1,7 +1,10 @@
 ---
-title: '`deleteSamlConnection()`'
+title: '`deleteSamlConnection()` (deprecated)'
 description: Use the deleteSamlConnection() method to delete a SAML connection.
 ---
+
+> [!WARNING]
+> This method is deprecated. Use [`deleteEnterpriseConnection()`](/docs/reference/backend/enterprise-connections/delete-enterprise-connection) instead.
 
 Deletes a [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) by its ID. Returns a [`DeletedObjectResource`](/docs/reference/types/deleted-object-resource) object.
 

--- a/docs/reference/backend/saml-connections/get-saml-connection-list.mdx
+++ b/docs/reference/backend/saml-connections/get-saml-connection-list.mdx
@@ -1,7 +1,10 @@
 ---
-title: '`getSamlConnectionList()`'
+title: '`getSamlConnectionList()` (deprecated)'
 description: Use the getSamlConnectionList() method to retrieve the list of SAML connections for an instance.
 ---
+
+> [!WARNING]
+> This method is deprecated. Use [`getEnterpriseConnectionList()`](/docs/reference/backend/enterprise-connections/get-enterprise-connection-list) instead.
 
 Retrieves the list of SAML connections for an instance. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) objects, and a `totalCount` property that indicates the total number of SAML connections for the instance.
 

--- a/docs/reference/backend/saml-connections/get-saml-connection-list.mdx
+++ b/docs/reference/backend/saml-connections/get-saml-connection-list.mdx
@@ -1,12 +1,12 @@
 ---
 title: '`getSamlConnectionList()` (deprecated)'
-description: Use the getSamlConnectionList() method to retrieve the list of SAML connections for an instance.
+description: Use the getSamlConnectionList() method to get the list of SAML connections for an instance.
 ---
 
 > [!WARNING]
 > This method is deprecated. Use [`getEnterpriseConnectionList()`](/docs/reference/backend/enterprise-connections/get-enterprise-connection-list) instead.
 
-Retrieves the list of SAML connections for an instance. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) objects, and a `totalCount` property that indicates the total number of SAML connections for the instance.
+Gets the list of SAML connections for an instance. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) objects, and a `totalCount` property that indicates the total number of SAML connections for the instance.
 
 ```ts
 function getSamlConnectionList(params: SamlConnectionListParams = {}): Promise<SamlConnection[]>
@@ -30,9 +30,9 @@ function getSamlConnectionList(params: SamlConnectionListParams = {}): Promise<S
 
 ## Usage
 
-### Basic
-
 <Include src="_partials/backend/usage" />
+
+### Basic
 
 ```tsx
 const response = await clerkClient.samlConnections.getSamlConnectionList()
@@ -40,7 +40,7 @@ const response = await clerkClient.samlConnections.getSamlConnectionList()
 
 ### Limit the number of results
 
-Retrieves Organization list that is filtered by the number of results.
+Gets the list of SAML connections, limited to the specified number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.samlConnections.getSamlConnectionList({
@@ -51,7 +51,7 @@ const { data, totalCount } = await clerkClient.samlConnections.getSamlConnection
 
 ### Skip results
 
-Retrieves Organization list that is filtered by the number of results to skip.
+Gets the list of SAML connections, skipping the specified number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.samlConnections.getSamlConnectionList({

--- a/docs/reference/backend/saml-connections/get-saml-connection.mdx
+++ b/docs/reference/backend/saml-connections/get-saml-connection.mdx
@@ -1,7 +1,10 @@
 ---
-title: '`getSamlConnection()`'
+title: '`getSamlConnection()` (deprecated)'
 description: Use the getSamlConnection() method to retrieve a SAML connection.
 ---
+
+> [!WARNING]
+> This method is deprecated. Use [`getEnterpriseConnection()`](/docs/reference/backend/enterprise-connections/get-enterprise-connection) instead.
 
 Retrieves a [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) by its ID.
 

--- a/docs/reference/backend/saml-connections/get-saml-connection.mdx
+++ b/docs/reference/backend/saml-connections/get-saml-connection.mdx
@@ -1,12 +1,12 @@
 ---
 title: '`getSamlConnection()` (deprecated)'
-description: Use the getSamlConnection() method to retrieve a SAML connection.
+description: Use the getSamlConnection() method to get a SAML connection.
 ---
 
 > [!WARNING]
 > This method is deprecated. Use [`getEnterpriseConnection()`](/docs/reference/backend/enterprise-connections/get-enterprise-connection) instead.
 
-Retrieves a [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) by its ID.
+Gets the given [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection).
 
 ```ts
 function getSamlConnection(samlConnectionId: string): Promise<SamlConnection>

--- a/docs/reference/backend/saml-connections/update-saml-connection.mdx
+++ b/docs/reference/backend/saml-connections/update-saml-connection.mdx
@@ -1,7 +1,10 @@
 ---
-title: '`updateSamlConnection()`'
+title: '`updateSamlConnection()` (deprecated)'
 description: Use the updateSamlConnection() method to update a SAML connection.
 ---
+
+> [!WARNING]
+> This method is deprecated. Use [`updateEnterpriseConnection()`](/docs/reference/backend/enterprise-connections/update-enterprise-connection) instead.
 
 Updates a [`SamlConnection`](/docs/reference/backend/types/backend-saml-connection) by its ID.
 

--- a/docs/reference/backend/sign-in-tokens/create-sign-in-token.mdx
+++ b/docs/reference/backend/sign-in-tokens/create-sign-in-token.mdx
@@ -3,27 +3,7 @@ title: '`createSignInToken()`'
 description: Use the createSignInToken() method to create a new sign-in token for a given user.
 ---
 
-Creates a new sign-in token and associates it with the given user. By default, sign-in tokens expire in 30 days. You can optionally supply a different duration in seconds using the `expires_in_seconds` property.
-
-```ts
-function createSignInToken(params: CreateSignInTokensParams): Promise<SignInToken>
-```
-
-## `CreateSignInTokenParams`
-
-<Properties>
-  - `userId`
-  - `string`
-
-  The ID of the user who can use the newly created sign-in token.
-
-  ---
-
-  - `expiresInSeconds`
-  - `string`
-
-  Specifies the life duration of the sign in token in seconds. Defaults to `2592000` (30 days)
-</Properties>
+<Typedoc src="backend/sign-in-token-api/methods/create-sign-in-token" />
 
 ## Usage
 

--- a/docs/reference/backend/sign-in-tokens/revoke-sign-in-token.mdx
+++ b/docs/reference/backend/sign-in-tokens/revoke-sign-in-token.mdx
@@ -3,20 +3,7 @@ title: '`revokeSignInToken()`'
 description: Use the revokeSignInToken() method to revoke a pending sign-in token.
 ---
 
-Revokes a pending sign-in token.
-
-```ts
-function revokeSignInToken(signInTokenId: string): Promise<SignInToken>
-```
-
-## Parameters
-
-<Properties>
-  - `signInTokenId`
-  - `string`
-
-  The ID of the sign-in token to revoke.
-</Properties>
+<Typedoc src="backend/sign-in-token-api/methods/revoke-sign-in-token" />
 
 ## Usage
 

--- a/docs/reference/backend/types/backend-agent-task.mdx
+++ b/docs/reference/backend/types/backend-agent-task.mdx
@@ -1,0 +1,6 @@
+---
+title: The Backend `AgentTask` object
+description: The Backend AgentTask object represents an Agent Task.
+---
+
+<Typedoc src="backend/agent-task" />

--- a/docs/reference/backend/types/backend-sign-in-token.mdx
+++ b/docs/reference/backend/types/backend-sign-in-token.mdx
@@ -1,0 +1,6 @@
+---
+title: The Backend `SignInToken` object
+description: The Backend SignInToken object holds information about a sign-in token.
+---
+
+<Typedoc src="backend/sign-in-token" />


### PR DESCRIPTION
### What does this solve? What changed?

Sources additional Backend SDK reference pages from generated Typedoc and adds the new Enterprise Connections API. Continues the Backend docs migration tracked in #3445.

- Replace hand-written content with `<Typedoc />` for `createSignInToken()`, `revokeSignInToken()`, `agentTasks.create()`, and `agentTasks.revoke()`
- Add reference pages for `enterpriseConnections.create/delete/get/getList/update`, plus manifest entries
- Mark the SAML Connections methods as deprecated and point readers to the Enterprise Connections equivalents
- Add object reference pages for `SignInToken` and `AgentTask`

### Deadline

No rush.

### Other resources

- Base PR: #3445
