### PR TITLE
Generate Backend docs - API Keys, M2M Tokens, and OAuth Applications APIs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3454,6 +3454,11 @@
                                 "href": "/docs/reference/backend/api-keys/get"
                               },
                               {
+                                "title": "`getSecret()`",
+                                "wrap": false,
+                                "href": "/docs/reference/backend/api-keys/get-secret"
+                              },
+                              {
                                 "title": "`create()`",
                                 "wrap": false,
                                 "href": "/docs/reference/backend/api-keys/create"
@@ -3613,6 +3618,10 @@
                               {
                                 "title": "`Invitation` object",
                                 "href": "/docs/reference/backend/types/backend-invitation"
+                              },
+                              {
+                                "title": "`M2MToken` object",
+                                "href": "/docs/reference/backend/types/backend-m2m-token"
                               },
                               {
                                 "title": "`OAuthApplication` object",

--- a/docs/reference/backend/api-keys/create.mdx
+++ b/docs/reference/backend/api-keys/create.mdx
@@ -3,62 +3,7 @@ title: '`create()`'
 description: Use the create() method to create an API key.
 ---
 
-Creates a new [API key](/docs/guides/development/machine-auth/api-keys). Returns the created [`APIKey`](/docs/reference/backend/types/backend-api-key) object.
-
-```ts
-function create(params: CreateAPIKeyParams): Promise<APIKeyResource>
-```
-
-## `CreateAPIKeyParams`
-
-<Properties>
-  - `name`
-  - `string`
-
-  A descriptive name for the API key (e.g., "Production API Key", "Development Key").
-
-  ---
-
-  - `subject`
-  - `string`
-
-  The user ID (`user_xxx`) or Organization ID (`org_xxx`) to associate the API key with.
-
-  ---
-
-  - `description?`
-  - `string | null`
-
-  A longer description of what the API key is used for.
-
-  ---
-
-  - `scopes?`
-  - `string[]`
-
-  An array of scope strings that define what the API key can access.
-
-  ---
-
-  - `claims?`
-  - `Record<string, unknown> | null`
-
-  Additional custom claims to store additional information about the API key.
-
-  ---
-
-  - `createdBy?`
-  - `string | null`
-
-  The user ID of the user creating the API key (for audit purposes).
-
-  ---
-
-  - `secondsUntilExpiration?`
-  - `number | null`
-
-  Number of seconds until the API key expires. Defaults to `null` (API key does not expire).
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/create" />
 
 ## Usage
 

--- a/docs/reference/backend/api-keys/create.mdx
+++ b/docs/reference/backend/api-keys/create.mdx
@@ -34,9 +34,6 @@ const apiKey = await clerkClient.apiKeys.create({
 })
 ```
 
-> [!WARNING]
-> The API key secret is only available in the response from `create()` and cannot be retrieved again. Make sure to store the secret securely immediately after creation.
-
 ## Backend API (BAPI) endpoint
 
 This method in the SDK is a wrapper around the BAPI endpoint `POST/api_keys`. See the [BAPI reference](/docs/reference/backend-api/tag/api-keys/POST/api_keys){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/api-keys/delete.mdx
+++ b/docs/reference/backend/api-keys/delete.mdx
@@ -3,20 +3,7 @@ title: '`delete()`'
 description: Use the delete() method to delete an API key.
 ---
 
-Deletes an [API key](/docs/guides/development/machine-auth/api-keys) by its ID. Returns a [`DeletedObjectResource`](/docs/reference/types/deleted-object-resource) object.
-
-```ts {{ prettier: false }}
-function delete(apiKeyId: string): Promise<DeletedObjectResource>
-```
-
-## Parameters
-
-<Properties>
-  - `apiKeyId`
-  - `string`
-
-  The ID of the API key to delete.
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/delete" />
 
 ## Usage
 

--- a/docs/reference/backend/api-keys/get-secret.mdx
+++ b/docs/reference/backend/api-keys/get-secret.mdx
@@ -1,0 +1,18 @@
+---
+title: '`getSecret()`'
+description: Use the getSecret() method to get the secret of an API key.
+---
+
+<Typedoc src="backend/api-keys-api/methods/get-secret" />
+
+## Usage
+
+<Include src="_partials/backend/usage" />
+
+```tsx
+const response = await clerkClient.apiKeys.getSecret('apikey_123')
+```
+
+## Backend API (BAPI) endpoint
+
+This method in the SDK is a wrapper around the BAPI endpoint `GET/api_keys/{apiKeyId}/secret`. See the [BAPI reference](/docs/reference/backend-api/tag/api-keys/GET/api_keys/%7BapiKeyID%7D/secret){{ target: '_blank' }} for more information.

--- a/docs/reference/backend/api-keys/get.mdx
+++ b/docs/reference/backend/api-keys/get.mdx
@@ -1,22 +1,9 @@
 ---
 title: '`get()`'
-description: Use the get() method to retrieve an API key.
+description: Use the get() method to get an API key.
 ---
 
-Retrieves a specific [API key](/docs/guides/development/machine-auth/api-keys) by its ID. Returns an [`APIKey`](/docs/reference/backend/types/backend-api-key) object.
-
-```ts
-function get(apiKeyId: string): Promise<APIKeyResource>
-```
-
-## Parameters
-
-<Properties>
-  - `apiKeyId`
-  - `string`
-
-  The ID of the API key to retrieve.
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/get" />
 
 ## Usage
 

--- a/docs/reference/backend/api-keys/list.mdx
+++ b/docs/reference/backend/api-keys/list.mdx
@@ -1,45 +1,9 @@
 ---
 title: '`list()`'
-description: Use the list() method to list API keys.
+description: Use the list() method to get a list of API keys for the given user or Organization.
 ---
 
-Retrieves a list of API keys for a given user or organization. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`APIKey`](/docs/reference/backend/types/backend-api-key) objects, and a `totalCount` property that indicates the total number of API keys in the system.
-
-```ts
-function list(
-  queryParams: GetAPIKeyListParams,
-): Promise<PaginatedResourceResponse<APIKeyResource[]>>
-```
-
-## `GetAPIKeyListParams`
-
-<Properties>
-  - `subject`
-  - `string`
-
-  The user or Organization ID to query API keys by.
-
-  ---
-
-  - `includeInvalid?`
-  - `boolean`
-
-  Whether to include invalid API keys (revoked or expired). Defaults to `false`.
-
-  ---
-
-  - `limit?`
-  - `number`
-
-  The maximum number of API keys to return. Defaults to `10`.
-
-  ---
-
-  - `offset?`
-  - `number`
-
-  The number of API keys to skip before returning results. Defaults to `0`.
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/list" />
 
 ## Usage
 

--- a/docs/reference/backend/api-keys/list.mdx
+++ b/docs/reference/backend/api-keys/list.mdx
@@ -9,7 +9,7 @@ description: Use the list() method to get a list of API keys for the given user 
 
 <Include src="_partials/backend/usage" />
 
-### List API keys for a user
+### Gets a list of API keys for a user
 
 ```tsx
 const userId = 'user_123'
@@ -19,7 +19,7 @@ const apiKeys = await clerkClient.apiKeys.list({
 })
 ```
 
-### List API keys for a user, including invalid ones
+### Gets a list of API keys for a user, including invalid ones
 
 ```tsx
 const userId = 'user_123'
@@ -30,7 +30,7 @@ const apiKeys = await clerkClient.apiKeys.list({
 })
 ```
 
-### List API keys for a user with pagination
+### Gets a list of API keys for a user with pagination
 
 ```tsx
 const userId = 'user_123'

--- a/docs/reference/backend/api-keys/revoke.mdx
+++ b/docs/reference/backend/api-keys/revoke.mdx
@@ -3,27 +3,7 @@ title: '`revoke()`'
 description: Use the revoke() method to revoke an API key.
 ---
 
-Revokes an [API key](/docs/guides/development/machine-auth/api-keys) by its ID. This will immediately invalidate the API key and prevent it from being used to authenticate any future requests. Returns an [`APIKey`](/docs/reference/backend/types/backend-api-key) object.
-
-```ts
-function revoke(params: RevokeAPIKeyParams): Promise<APIKeyResource>
-```
-
-## `RevokeAPIKeyParams`
-
-<Properties>
-  - `apiKeyId`
-  - `string`
-
-  The ID of the API key to revoke.
-
-  ---
-
-  - `revocationReason?`
-  - `string | null`
-
-  Optional reason for revocation. Useful for your records.
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/revoke" />
 
 ## Usage
 

--- a/docs/reference/backend/api-keys/update.mdx
+++ b/docs/reference/backend/api-keys/update.mdx
@@ -3,55 +3,7 @@ title: '`update()`'
 description: Use the update() method to update an API key.
 ---
 
-Updates an [API key](/docs/guides/development/machine-auth/api-keys) by its ID. Returns an [`APIKey`](/docs/reference/backend/types/backend-api-key) object.
-
-```ts
-function update(params: UpdateAPIKeyParams): Promise<APIKeyResource>
-```
-
-## `UpdateAPIKeyParams`
-
-<Properties>
-  - `apiKeyID`
-  - `string`
-
-  The ID of the API key to update.
-
-  ---
-
-  - `subject`
-  - `string`
-
-  The user ID (`user_xxx`) or Organization ID (`org_xxx`) to associate the API key with.
-
-  ---
-
-  - `description?`
-  - `string | null`
-
-  A longer description of what the API key is used for.
-
-  ---
-
-  - `scopes?`
-  - `string[]`
-
-  An array of scope strings that define what the API key can access.
-
-  ---
-
-  - `claims?`
-  - `Record<string, unknown> | null`
-
-  Additional custom claims to store additional information about the API key.
-
-  ---
-
-  - `secondsUntilExpiration?`
-  - `number | null`
-
-  Number of seconds until the API key expires. Defaults to `null` (API key does not expire).
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/update" />
 
 ## Usage
 

--- a/docs/reference/backend/api-keys/verify.mdx
+++ b/docs/reference/backend/api-keys/verify.mdx
@@ -3,26 +3,10 @@ title: '`verify()`'
 description: Use the verify() method to verify an API key secret.
 ---
 
-Verifies an [API key](/docs/guides/development/machine-auth/api-keys) secret. Returns an [`APIKey`](/docs/reference/backend/types/backend-api-key) object.
-
-- If the API key is valid, the method returns the API key object with its properties.
-- If the API key is invalid, revoked, or expired, the method will throw an error.
-
 > [!NOTE]
 > In most cases, you'll want to verify API keys using framework-specific helpers like `auth()` in Next.js, which handles the verification automatically. See the [verifying API keys](/docs/guides/development/verifying-api-keys) guide for more details.
 
-```ts
-function verify(secret: string): Promise<APIKeyResource>
-```
-
-## Parameters
-
-<Properties>
-  - `secret`
-  - `string`
-
-  The API key secret to verify.
-</Properties>
+<Typedoc src="backend/api-keys-api/methods/verify" />
 
 ## Usage
 

--- a/docs/reference/backend/m2m-tokens/create-token.mdx
+++ b/docs/reference/backend/m2m-tokens/create-token.mdx
@@ -3,41 +3,7 @@ title: '`createToken()`'
 description: Use the createToken() method to create a M2M token.
 ---
 
-Creates a new [M2M token](/docs/guides/development/machine-auth/m2m-tokens). Must be authenticated via a Machine Secret Key.
-
-```ts
-function createToken(params?: CreateM2MTokenParams): Promise<M2MToken>
-```
-
-## `CreateM2MTokenParams`
-
-<Properties>
-  - `machineSecretKey?`
-  - `string`
-
-  Custom machine secret key for authentication. If not provided, the SDK will use the value from the environment variable.
-
-  ---
-
-  - `tokenFormat?`
-  - `'opaque' | 'jwt'`
-
-  The format of the token. Defaults to `'opaque'`. Set to `'jwt'` to create a [JSON Web Token](/docs/guides/how-clerk-works/tokens-and-signatures#json-web-tokens-jwts) that can be verified locally without a network request. For a detailed comparison of the two formats, see [Token formats](/docs/guides/development/machine-auth/token-formats).
-
-  ---
-
-  - `secondsUntilExpiration?`
-  - `number | null`
-
-  Number of seconds until the token expires. Defaults to `null` (token does not expire).
-
-  ---
-
-  - `claims?`
-  - `Record<string, unknown> | null`
-
-  Additional custom claims to include in the token payload.
-</Properties>
+<Typedoc src="backend/m2-m-token-api/methods/create-token" />
 
 ## Example
 

--- a/docs/reference/backend/m2m-tokens/create-token.mdx
+++ b/docs/reference/backend/m2m-tokens/create-token.mdx
@@ -5,7 +5,7 @@ description: Use the createToken() method to create a M2M token.
 
 <Typedoc src="backend/m2-m-token-api/methods/create-token" />
 
-## Example
+## Usage
 
 <Include src="_partials/backend/usage" />
 

--- a/docs/reference/backend/m2m-tokens/list.mdx
+++ b/docs/reference/backend/m2m-tokens/list.mdx
@@ -11,7 +11,7 @@ description: Use the list() method to get a list of M2M tokens for the given mac
 
 <Include src="_partials/backend/usage" />
 
-### List M2M tokens for a machine
+### Gets a list of M2M tokens for a machine
 
 ```tsx
 const machineId = 'mt_123'
@@ -21,7 +21,7 @@ const m2mTokens = await clerkClient.m2m.list({
 })
 ```
 
-### List M2M tokens for a machine, including revoked and expired ones
+### Gets a list of M2M tokens for a machine, including revoked and expired ones
 
 ```tsx
 const machineId = 'mt_123'
@@ -33,7 +33,7 @@ const m2mTokens = await clerkClient.m2m.list({
 })
 ```
 
-### List M2M tokens for a machine with pagination
+### Gets a list of M2M tokens for a machine with pagination
 
 ```tsx
 const machineId = 'mt_123'

--- a/docs/reference/backend/m2m-tokens/list.mdx
+++ b/docs/reference/backend/m2m-tokens/list.mdx
@@ -1,62 +1,11 @@
 ---
 title: '`list()`'
-description: Use the list() method to get a list of M2M tokens for your a given machine.
+description: Use the list() method to get a list of M2M tokens for the given machine.
 ---
-
-Retrieves a list of M2M tokens for a given machine. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [M2M token](/docs/guides/development/machine-auth/m2m-tokens) objects, and a `totalCount` property that indicates the total number of M2M tokens in the system. This endpoint can be authenticated by either a Machine Secret Key or by a Clerk [Secret Key](!secret-key).
-
-- When fetching M2M tokens with a Machine Secret Key, only tokens associated with the authenticated machine can be retrieved.
-- When fetching M2M tokens with a Clerk Secret Key, tokens for any machine in the instance can be retrieved.
 
 <Include src="_partials/machine-auth/jwt-token-limitation" />
 
-```ts
-function list(queryParams: GetM2MTokenListParams): Promise<PaginatedResourceResponse<M2MToken[]>>
-```
-
-## `GetM2MTokenListParams`
-
-<Properties>
-  - `subject`
-  - `string`
-
-  The machine ID to query M2M tokens by.
-
-  ---
-
-  - `machineSecretKey?`
-  - `string`
-
-  Custom machine secret key for authentication. If not provided, the SDK will use the value from the environment variable.
-
-  ---
-
-  - `revoked?`
-  - `boolean`
-
-  Whether to include revoked M2M tokens. Defaults to `false`.
-
-  ---
-
-  - `expired?`
-  - `boolean`
-
-  Whether to include expired M2M tokens. Defaults to `false`.
-
-  ---
-
-  - `limit?`
-  - `number`
-
-  The maximum number of M2M tokens to return. Defaults to `10`.
-
-  ---
-
-  - `offset?`
-  - `number`
-
-  The number of M2M tokens to skip before returning results. Defaults to `0`.
-</Properties>
+<Typedoc src="backend/m2-m-token-api/methods/list" />
 
 ## Usage
 

--- a/docs/reference/backend/m2m-tokens/revoke-token.mdx
+++ b/docs/reference/backend/m2m-tokens/revoke-token.mdx
@@ -3,40 +3,10 @@ title: '`revokeToken()`'
 description: Use the revokeToken() method to revoke a M2M token.
 ---
 
-Revokes an [M2M token](/docs/guides/development/machine-auth/m2m-tokens). This endpoint can be authenticated by either a Machine Secret Key or by a Clerk [Secret Key](!secret-key).
-
-- When revoking a M2M token with a Machine Secret Key, the token must be managed by the Machine associated with the Machine Secret Key.
-- When revoking a M2M token with a Clerk Secret Key, any token on the instance can be revoked.
-
 > [!IMPORTANT]
 > Only [opaque tokens](!opaque-token) can be revoked. [JWT tokens](!jwt-token) are not stored by Clerk and therefore cannot be revoked. If you need revocation capability, use the default opaque token format when creating tokens.
 
-```ts
-function revokeToken(params: RevokeM2MTokenParams): Promise<M2MToken>
-```
-
-## `RevokeM2MTokenParams`
-
-<Properties>
-  - `machineSecretKey?`
-  - `string`
-
-  Custom machine secret key for authentication. If not provided, the SDK will use the value from the environment variable.
-
-  ---
-
-  - `m2mTokenId`
-  - `string`
-
-  The ID of the M2M token to revoke.
-
-  ---
-
-  - `revocationReason?`
-  - `string | null`
-
-  Optional reason for revocation. Useful for your records.
-</Properties>
+<Typedoc src="backend/m2-m-token-api/methods/revoke-token" />
 
 ## Usage
 

--- a/docs/reference/backend/m2m-tokens/verify.mdx
+++ b/docs/reference/backend/m2m-tokens/verify.mdx
@@ -3,29 +3,7 @@ title: '`verify()`'
 description: Use the verify() method to verify an M2M token.
 ---
 
-Verifies an [M2M token](/docs/guides/development/machine-auth/m2m-tokens). Must be authenticated via a Machine Secret Key.
-
-<Include src="_partials/machine-auth/jwt-token-limitation" />
-
-```ts
-function verify(params: VerifyM2MTokenParams): Promise<M2MToken>
-```
-
-## `VerifyM2MTokenParams`
-
-<Properties>
-  - `machineSecretKey?`
-  - `string`
-
-  Custom machine secret key for authentication. If not provided, the SDK will use the value from the environment variable.
-
-  ---
-
-  - `token`
-  - `string`
-
-  The M2M token to verify.
-</Properties>
+<Typedoc src="backend/m2-m-token-api/methods/verify" />
 
 ## Usage
 

--- a/docs/reference/backend/oauth-applications/create.mdx
+++ b/docs/reference/backend/oauth-applications/create.mdx
@@ -3,48 +3,7 @@ title: '`create()`'
 description: Use the create() method to create an OAuth application.
 ---
 
-Creates a new [`OAuthApplication`](/docs/reference/backend/types/backend-oauth-application).
-
-```ts
-function create(params: CreateOAuthApplicationParams): Promise<OAuthApplication>
-```
-
-## `CreateOAuthApplicationParams`
-
-<Properties>
-  - `name`
-  - `string`
-
-  The name of the OAuth application.
-
-  ---
-
-  - `redirectUris?`
-  - `string[] | null`
-
-  An array of redirect URIs for the OAuth application.
-
-  ---
-
-  - `scopes?`
-  - `string[] | null | undefined`
-
-  Scopes for the OAuth application. Available scopes are `profile`, `email`, `public_metadata`, `private_metadata`. Defaults to `profile email`. Provide the requested scopes as a string, separated by spaces.
-
-  ---
-
-  - `consentScreenEnabled?`
-  - `boolean | null | undefined`
-
-  Specifies whether the consent screen should be displayed in the authentication flow. Cannot be disabled for dynamically registered OAuth applications. Defaults to `true`.
-
-  ---
-
-  - `public?`
-  - `boolean | null | undefined`
-
-  Indicates whether the client is public. If true, the Proof Key of Code Exchange (PKCE) flow can be used.
-</Properties>
+<Typedoc src="backend/o-auth-applications-api/methods/create" />
 
 ## Usage
 

--- a/docs/reference/backend/oauth-applications/delete.mdx
+++ b/docs/reference/backend/oauth-applications/delete.mdx
@@ -3,20 +3,7 @@ title: '`delete()`'
 description: Use the delete() method to delete an OAuth application.
 ---
 
-Deletes an [`OAuthApplication`](/docs/reference/backend/types/backend-oauth-application) by its ID. Returns a [`DeletedObjectResource`](/docs/reference/types/deleted-object-resource) object.
-
-```ts {{ prettier: false }}
-function delete(oauthApplicationId: string): Promise<DeletedObjectResource>
-```
-
-## Parameters
-
-<Properties>
-  - `oauthApplicationId`
-  - `string`
-
-  The ID of the OAuth application to delete.
-</Properties>
+<Typedoc src="backend/o-auth-applications-api/methods/delete" />
 
 ## Usage
 

--- a/docs/reference/backend/oauth-applications/get.mdx
+++ b/docs/reference/backend/oauth-applications/get.mdx
@@ -1,22 +1,9 @@
 ---
 title: '`get()`'
-description: Use the get() method to retrieve an OAuth application.
+description: Use the get() method to get an OAuth application.
 ---
 
-Retrieves an [`OAuthApplication`](/docs/reference/backend/types/backend-oauth-application) by its ID.
-
-```ts
-function get(oauthApplicationId: string): Promise<OAuthApplication>
-```
-
-## Parameters
-
-<Properties>
-  - `oauthApplicationId`
-  - `string`
-
-  The ID of the OAuth application to retrieve.
-</Properties>
+<Typedoc src="backend/o-auth-applications-api/methods/get" />
 
 ## Usage
 

--- a/docs/reference/backend/oauth-applications/list.mdx
+++ b/docs/reference/backend/oauth-applications/list.mdx
@@ -15,9 +15,7 @@ description: Use the list() method to get a list of OAuth applications for an in
 const response = await clerkClient.oauthApplications.list()
 ```
 
-### Limit the number of results
-
-Gets a list of OAuth applications, limited to the specified number of results.
+### Gets a list of OAuth applications, limited to the specified number of results
 
 ```tsx
 const { data, totalCount } = await clerkClient.oauthApplications.list({
@@ -26,9 +24,7 @@ const { data, totalCount } = await clerkClient.oauthApplications.list({
 })
 ```
 
-### Skip results
-
-Gets a list of OAuth applications, skipping the specified number of results.
+### Gets a list of OAuth applications, skipping the specified number of results
 
 ```tsx
 const { data, totalCount } = await clerkClient.oauthApplications.list({

--- a/docs/reference/backend/oauth-applications/list.mdx
+++ b/docs/reference/backend/oauth-applications/list.mdx
@@ -1,45 +1,9 @@
 ---
 title: '`list()`'
-description: Use the list() method to retrieve a list of OAuth applications for an instance.
+description: Use the list() method to get a list of OAuth applications for an instance.
 ---
 
-Retrieves a list of OAuth applications for an instance. Returns a [`PaginatedResourceResponse`](/docs/reference/backend/types/paginated-resource-response) object with a `data` property that contains an array of [`OAuthApplication`](/docs/reference/backend/types/backend-oauth-application) objects, and a `totalCount` property that indicates the total number of OAuth applications for the instance.
-
-```ts
-function list(
-  params: ClerkPaginationRequest = {},
-): Promise<PaginatedResourceResponse<OAuthApplication[]>>
-```
-
-## Parameters
-
-<Properties>
-  - `limit?`
-  - `number`
-
-  The number of results to return. Must be an integer greater than zero and less than 501. Can be used for paginating the results together with `offset`. Defaults to `10`.
-
-  ---
-
-  - `offset?`
-  - `number`
-
-  Skip the first `offset` results when paginating. Needs to be an integer greater or equal to zero. To be used in conjunction with `limit`. Defaults to `0`.
-
-  ---
-
-  - `orderBy?`
-  - `'name' | 'created_at'`
-
-  Return OAuth applications in a particular order. Prefix with a `-` to reverse the order. Prefix with a `+` to list in ascending order. Defaults to `'+created_at'`.
-
-  ---
-
-  - `nameQuery?`
-  - `string`
-
-  Filters OAuth applications with names that match the given query, via case-insensitive partial match.
-</Properties>
+<Typedoc src="backend/o-auth-applications-api/methods/list" />
 
 ## Usage
 

--- a/docs/reference/backend/oauth-applications/list.mdx
+++ b/docs/reference/backend/oauth-applications/list.mdx
@@ -17,7 +17,7 @@ const response = await clerkClient.oauthApplications.list()
 
 ### Limit the number of results
 
-Retrieves list of OAuth applications that is filtered by the number of results.
+Gets a list of OAuth applications, limited to the specified number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.oauthApplications.list({
@@ -28,7 +28,7 @@ const { data, totalCount } = await clerkClient.oauthApplications.list({
 
 ### Skip results
 
-Retrieves list of OAuth applications that is filtered by the number of results to skip.
+Gets a list of OAuth applications, skipping the specified number of results.
 
 ```tsx
 const { data, totalCount } = await clerkClient.oauthApplications.list({

--- a/docs/reference/backend/oauth-applications/rotate-secret.mdx
+++ b/docs/reference/backend/oauth-applications/rotate-secret.mdx
@@ -3,20 +3,7 @@ title: '`rotateSecret()`'
 description: Use the rotateSecret() method to rotate the OAuth application's client secret.
 ---
 
-Rotates the client secret for a given [`OAuthApplication`](/docs/reference/backend/types/backend-oauth-application) by its ID. When the client secret is rotated, ensure that you update it in your authorized OAuth clients.
-
-```ts
-function rotateSecret(oauthApplicationId: string): Promise<OAuthApplication>
-```
-
-## Parameters
-
-<Properties>
-  - `oauthApplicationId`
-  - `string`
-
-  The ID of the OAuth application for which to rotate the client secret.
-</Properties>
+<Typedoc src="backend/o-auth-applications-api/methods/rotate-secret" />
 
 ## Usage
 

--- a/docs/reference/backend/oauth-applications/update.mdx
+++ b/docs/reference/backend/oauth-applications/update.mdx
@@ -3,55 +3,7 @@ title: '`update()`'
 description: Use the update() method to update an OAuth application.
 ---
 
-Updates an [`OAuthApplication`](/docs/reference/backend/types/backend-oauth-application) by its ID.
-
-```ts
-function update(params: UpdateOAuthApplicationParams): Promise<OAuthApplication>
-```
-
-## `UpdateOAuthApplicationParams`
-
-<Properties>
-  - `oauthApplicationId`
-  - `string`
-
-  The ID of the OAuth application to update.
-
-  ---
-
-  - `name`
-  - `string`
-
-  The name of the OAuth application.
-
-  ---
-
-  - `redirectUris?`
-  - `string[] | null | undefined`
-
-  An array of redirect URIs for the OAuth application.
-
-  ---
-
-  - `scopes?`
-  - `string[] | null | undefined`
-
-  Scopes for the OAuth application. Available scopes are `profile`, `email`, `public_metadata`, `private_metadata`. Defaults to `profile email`. Provide the requested scopes as a string, separated by spaces.
-
-  ---
-
-  - `consentScreenEnabled?`
-  - `boolean | null | undefined`
-
-  Specifies whether the consent screen should be displayed in the authentication flow. Cannot be disabled for dynamically registered OAuth applications. Defaults to `true`.
-
-  ---
-
-  - `public?`
-  - `boolean | null | undefined`
-
-  Indicates whether the client is public. If true, the Proof Key of Code Exchange (PKCE) flow can be used.
-</Properties>
+<Typedoc src="backend/o-auth-applications-api/methods/update" />
 
 ## Usage
 

--- a/docs/reference/backend/types/backend-m2m-token.mdx
+++ b/docs/reference/backend/types/backend-m2m-token.mdx
@@ -1,0 +1,6 @@
+---
+title: The Backend `M2MToken` object
+description: The Backend M2MToken object holds information about a machine-to-machine token.
+---
+
+<Typedoc src="backend/m2-m-token" />


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

Migrates the hand-written reference pages for the API Keys, M2M Tokens, and OAuth Applications backend APIs to use the auto-generated `<Typedoc />` content from `clerk/javascript`, matching the pattern established for other backend APIs on `aa/DOCS-10984`.

- API Keys: `create`, `delete`, `get`, `list`, `revoke`, `update`, `verify` now render from typedocs; adds new `getSecret()` page
- M2M Tokens: `create-token`, `list`, `revoke-token`, `verify` now render from typedocs
- OAuth Applications: `create`, `delete`, `get`, `list`, `rotate-secret`, `update` now render from typedocs
- Adds `M2MToken` object type page under `docs/reference/backend/types/`
- Updates `manifest.json` with new `getSecret()` and `M2MToken` entries

Source: [clerk/javascript#aa/DOCS-10984](https://github.com/clerk/javascript/tree/aa/DOCS-10984)

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
