### PR TITLE
docs: update Expo native requirements

### DIFF
--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -1014,7 +1014,7 @@ The following changes only apply to specific SDKs. Select your SDK below for add
 
     ### Minimum Expo version increased to 53 {{ toc: false }}
 
-    `@clerk/expo` v3 requires Expo SDK 53 or later.
+    `@clerk/expo` v3 supports Expo SDK 53 through 56 and requires React Native 0.75 or later. Expo native components require iOS 17 or later for iOS apps; the `@clerk/expo` plugin sets the iOS deployment target to `17.0` during prebuild.
 
     ```json {{ del: [1], ins: [2], prettier: false }}
     "expo": "~52.0.0",

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -22,7 +22,9 @@ The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftU
 
 Native components require:
 
-- Expo SDK 53 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
+- Expo SDK 53 through 56 and React Native 0.75 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
+
+- iOS 17 or later for iOS apps. The `@clerk/expo` plugin sets the iOS deployment target to `17.0` during prebuild.
 
 - A [development build](https://docs.expo.dev/develop/development-builds/introduction/) (`npx expo run:ios` or `npx expo run:android`), as these components are not available in Expo Go.
 


### PR DESCRIPTION
## Summary
- Update Expo native components requirements to say Expo SDK 53 through 56 and React Native 0.75+.
- Add the iOS 17 deployment target requirement enforced by the @clerk/expo config plugin/podspec.
- Mirror the same requirements in the Core 3 upgrade guide.

## Source refs checked
- clerk-docs origin/main: b589d0c9d11b906662f4c67f4158b0e8a8366286
- javascript origin/main: f23ac111d7ca1bc4cc53aa94d235b7315ddf0582
- clerk-ios origin/main: 063483c929f2eeac77e5e969a2ad1dd99586dcb4
- clerk-android origin/main: 45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd

## Source evidence
- javascript packages/expo/package.json declares peer dependencies: expo >=53 <57 and react-native >=0.75.
- javascript packages/expo/app.plugin.js sets CLERK_MIN_IOS_VERSION = 17.0 and writes ios.deploymentTarget during prebuild.
- javascript packages/expo/ios/ClerkExpo.podspec sets iOS platform 17.0 and notes Clerk iOS SDK requires iOS 17.

## Docs files changed
- docs/reference/expo/native-components/overview.mdx
- docs/guides/development/upgrading/upgrade-guides/core-3.mdx

## Validation
- git diff --check: passed
- pnpm run lint:formatting: passed using a temporary node_modules symlink to the primary clerk-docs checkout dependencies
- pnpm run lint:check-frontmatter: passed using the same temporary dependency symlink
- pnpm run lint:check-empty-links: passed using the same temporary dependency symlink

## Notes
- Thread creation tooling was unavailable in this scheduled run, so this used the allowed fallback path in the existing clerk-docs worktree.
- No unresolved ambiguity.