### PR TITLE
docs(mobile): clarify platform requirements

### DIFF
--- a/docs/getting-started/quickstart.ios.mdx
+++ b/docs/getting-started/quickstart.ios.mdx
@@ -28,6 +28,7 @@ sdk: ios
   ## Create a new iOS app
 
   If you don't already have an iOS app, create a new project in Xcode. Select SwiftUI as your interface and Swift as your language.
+  Set your app's iOS deployment target to 17.0 or later.
   See the [Xcode documentation](https://developer.apple.com/documentation/xcode/creating-an-xcode-project-for-an-app) for more information.
 
   ## Install the Clerk iOS SDK

--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -1012,9 +1012,9 @@ The following changes only apply to specific SDKs. Select your SDK below for add
     signOut()
     ```
 
-    ### Minimum Expo version increased to 53 {{ toc: false }}
+    ### Expo requirements updated {{ toc: false }}
 
-    `@clerk/expo` v3 requires Expo SDK 53 or later.
+    `@clerk/expo` v3 supports Expo SDK 53 through 56 and requires React Native 0.75 or later.
 
     ```json {{ del: [1], ins: [2], prettier: false }}
     "expo": "~52.0.0",

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -22,11 +22,14 @@ The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftU
 
 Native components require:
 
-- Expo SDK 53 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
+- Expo SDK 53 through 56 and React Native 0.75 or later. See the
+  [quickstart](/docs/expo/getting-started/quickstart) guide.
 
 - A [development build](https://docs.expo.dev/develop/development-builds/introduction/) (`npx expo run:ios` or `npx expo run:android`), as these components are not available in Expo Go.
 
-- The `@clerk/expo` plugin configured in your `app.json` file. See the [available plugin options](#expo-plugin-options).
+- The `@clerk/expo` plugin configured in your `app.json` file. On iOS, native components require a deployment target
+  of 17.0 or later, and the plugin configures this during prebuild. See the
+  [available plugin options](#expo-plugin-options).
 
   ```json {{ filename: 'app.json' }}
   {

--- a/docs/reference/native-mobile/installation.ios.mdx
+++ b/docs/reference/native-mobile/installation.ios.mdx
@@ -6,6 +6,11 @@ sdk: ios
 
 Use Swift Package Manager to add `ClerkKit` (core API) and `ClerkKitUI` (prebuilt SwiftUI views) to your app target.
 
+## Requirements
+
+The `clerk-ios` package requires Swift tools version 6.2 or later and iOS 17 or later. For other Apple platforms,
+it supports Mac Catalyst 17 or later, macOS 14 or later, watchOS 10 or later, tvOS 17 or later, and visionOS 1 or later.
+
 ## Install via Xcode
 
 1. In Xcode, open the **Package Dependencies** tab and click the **+** button.


### PR DESCRIPTION
### 🔎 Previews:

- Not generated locally.

### What does this solve? What changed?

This updates public mobile docs with platform and support requirements that developers need before they hit native build failures.

This is a rerun of the mobile docs drift automation test. Previous test-run PRs for this bucket were closed unmerged, so this compares source `main` to `clerk-docs` `main` fresh and does not treat those closed PRs as handled.

Source refs checked:

- `clerk-ios` `origin/main`: `063483c929f2eeac77e5e969a2ad1dd99586dcb4`
- `clerk-android` `origin/main`: `45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd`
- `clerk/javascript` `origin/main`: `f23ac111d7ca1bc4cc53aa94d235b7315ddf0582`
- `clerk-docs` `origin/main`: `b589d0c9d11b906662f4c67f4158b0e8a8366286`

Docs files changed:

- `docs/reference/expo/native-components/overview.mdx`
- `docs/guides/development/upgrading/upgrade-guides/core-3.mdx`
- `docs/getting-started/quickstart.ios.mdx`
- `docs/reference/native-mobile/installation.ios.mdx`

Changes:

- Clarifies that Expo native components support Expo SDK 53 through 56 and require React Native 0.75 or later.
- Clarifies that Expo native components require an iOS deployment target of 17.0 or later, configured by the `@clerk/expo` plugin during prebuild.
- Adds iOS SDK platform/tooling requirements to the iOS quickstart and install reference.

Validation:

- `git diff --check` passed.
- `pnpm run lint:formatting` not run because this fresh worktree has no `node_modules`; skipped broad install/setup churn for this docs drift test.
- Targeted long-line scan was reviewed; newly added lines are wrapped, while remaining hits are pre-existing long lines in the touched files.

Unresolved ambiguity:

- None.

### Deadline

- No rush.

### Other resources

- None.
