### PR TITLE
Clarify mobile platform requirements

### DIFF
--- a/docs/getting-started/quickstart.ios.mdx
+++ b/docs/getting-started/quickstart.ios.mdx
@@ -28,6 +28,7 @@ sdk: ios
   ## Create a new iOS app
 
   If you don't already have an iOS app, create a new project in Xcode. Select SwiftUI as your interface and Swift as your language.
+  Clerk's iOS SDK requires an iOS 17 or later deployment target.
   See the [Xcode documentation](https://developer.apple.com/documentation/xcode/creating-an-xcode-project-for-an-app) for more information.
 
   ## Install the Clerk iOS SDK

--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -1014,7 +1014,7 @@ The following changes only apply to specific SDKs. Select your SDK below for add
 
     ### Minimum Expo version increased to 53 {{ toc: false }}
 
-    `@clerk/expo` v3 requires Expo SDK 53 or later.
+    `@clerk/expo` v3 supports Expo SDK 53 through 56 and requires React Native 0.75 or later.
 
     ```json {{ del: [1], ins: [2], prettier: false }}
     "expo": "~52.0.0",

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -22,11 +22,11 @@ The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftU
 
 Native components require:
 
-- Expo SDK 53 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
+- Expo SDK 53 through 56 and React Native 0.75 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
 
 - A [development build](https://docs.expo.dev/develop/development-builds/introduction/) (`npx expo run:ios` or `npx expo run:android`), as these components are not available in Expo Go.
 
-- The `@clerk/expo` plugin configured in your `app.json` file. See the [available plugin options](#expo-plugin-options).
+- The `@clerk/expo` plugin configured in your `app.json` file. For iOS builds, the plugin configures a deployment target of iOS 17.0 or later during prebuild. See the [available plugin options](#expo-plugin-options).
 
   ```json {{ filename: 'app.json' }}
   {

--- a/docs/reference/native-mobile/installation.ios.mdx
+++ b/docs/reference/native-mobile/installation.ios.mdx
@@ -6,6 +6,8 @@ sdk: ios
 
 Use Swift Package Manager to add `ClerkKit` (core API) and `ClerkKitUI` (prebuilt SwiftUI views) to your app target.
 
+Clerk's iOS SDK requires iOS 17 or later for iOS apps. For other Apple platform targets, the Swift package supports Mac Catalyst 17 or later, macOS 14 or later, watchOS 10 or later, tvOS 17 or later, and visionOS 1 or later.
+
 ## Install via Xcode
 
 1. In Xcode, open the **Package Dependencies** tab and click the **+** button.


### PR DESCRIPTION
## Summary
- Clarifies public platform requirements for Expo native components: Expo SDK 53 through 56, React Native 0.75 or later, and iOS deployment target 17.0 or later during prebuild.
- Updates the Core 3 upgrade note with the same Expo v3 support bounds.
- Adds iOS and Apple platform minimums to the iOS quickstart and native mobile installation docs.

## Source refs checked
- `clerk-docs` origin/main: b589d0c9d11b906662f4c67f4158b0e8a8366286
- `clerk-ios` origin/main: 063483c929f2eeac77e5e969a2ad1dd99586dcb4 (`Package.swift`: iOS 17, Mac Catalyst 17, macOS 14, watchOS 10, tvOS 17, visionOS 1)
- `clerk/javascript` origin/main: f23ac111d7ca1bc4cc53aa94d235b7315ddf0582 (`packages/expo/package.json`: `expo >=53 <57`, `react-native >=0.75`; `app.plugin.js` and `ClerkExpo.podspec`: iOS 17.0)
- `clerk-android` origin/main: 45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd (`minSdk 24`, `jvmTarget 17`; Android docs already cover these)

## Docs changed
- `docs/reference/expo/native-components/overview.mdx`
- `docs/guides/development/upgrading/upgrade-guides/core-3.mdx`
- `docs/getting-started/quickstart.ios.mdx`
- `docs/reference/native-mobile/installation.ios.mdx`

## Validation
- `git diff --check` passed.
- `pnpm run lint:formatting` not run because `node_modules` is absent and this test run requested no broad install/setup churn.

## Deadline
No rush.

## Unresolved ambiguity
None.