### PR TITLE
docs: clarify mobile platform requirements

### DIFF
--- a/docs/getting-started/quickstart.ios.mdx
+++ b/docs/getting-started/quickstart.ios.mdx
@@ -30,6 +30,8 @@ sdk: ios
   If you don't already have an iOS app, create a new project in Xcode. Select SwiftUI as your interface and Swift as your language.
   See the [Xcode documentation](https://developer.apple.com/documentation/xcode/creating-an-xcode-project-for-an-app) for more information.
 
+  Clerk's iOS SDK requires Swift 6.2 or later and an iOS deployment target of iOS 17 or later.
+
   ## Install the Clerk iOS SDK
 
   Follow [the Swift Package Manager instructions](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) to install Clerk as a dependency.

--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -1012,9 +1012,9 @@ The following changes only apply to specific SDKs. Select your SDK below for add
     signOut()
     ```
 
-    ### Minimum Expo version increased to 53 {{ toc: false }}
+    ### Expo support starts at SDK 53 {{ toc: false }}
 
-    `@clerk/expo` v3 requires Expo SDK 53 or later.
+    `@clerk/expo` v3 supports Expo SDK 53 through 56 and requires React Native 0.75 or later.
 
     ```json {{ del: [1], ins: [2], prettier: false }}
     "expo": "~52.0.0",
@@ -1022,6 +1022,8 @@ The following changes only apply to specific SDKs. Select your SDK below for add
     ```
 
     See the [Expo upgrade guide](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/) for help migrating your application.
+
+    If your application uses [Expo Native Components](/docs/reference/expo/native-components/overview) on iOS, configure the `@clerk/expo` plugin so your project uses an iOS 17.0 or later deployment target.
 
     ### `useSignInWithApple` and `useSignInWithGoogle` moved to separate entry points {{ toc: false }}
 

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -22,7 +22,9 @@ The Clerk Expo SDK provides prebuilt native UI components rendered with **SwiftU
 
 Native components require:
 
-- Expo SDK 53 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
+- Expo SDK 53 through 56 and React Native 0.75 or later. See the [quickstart](/docs/expo/getting-started/quickstart) guide.
+
+- For iOS, an iOS 17.0 or later deployment target. The `@clerk/expo` plugin configures this for Expo projects.
 
 - A [development build](https://docs.expo.dev/develop/development-builds/introduction/) (`npx expo run:ios` or `npx expo run:android`), as these components are not available in Expo Go.
 

--- a/docs/reference/native-mobile/installation.ios.mdx
+++ b/docs/reference/native-mobile/installation.ios.mdx
@@ -6,6 +6,13 @@ sdk: ios
 
 Use Swift Package Manager to add `ClerkKit` (core API) and `ClerkKitUI` (prebuilt SwiftUI views) to your app target.
 
+## Requirements
+
+Clerk's iOS SDK requires:
+
+- Swift 6.2 or later
+- An iOS deployment target of iOS 17 or later
+
 ## Install via Xcode
 
 1. In Xcode, open the **Package Dependencies** tab and click the **+** button.


### PR DESCRIPTION
### 🔎 Previews:

- Preview deploy link will be available after the PR is opened.

### What does this solve? What changed?

This updates public mobile requirements docs to match the current source of truth across `clerk-ios` and `javascript`.

- `clerk-ios` currently declares Swift tools 6.2 and iOS 17 support requirements in `Package.swift`.
- `@clerk/expo` currently supports Expo SDK 53 through 56 and React Native 0.75 or later.
- Expo Native Components require iOS 17.0 or later for native iOS builds.

Changed docs:

- Added Swift 6.2 and iOS 17 requirements to the iOS quickstart.
- Added an iOS SDK requirements section to the iOS installation reference.
- Updated the Core 3 Expo upgrade note to mention the supported Expo SDK range and RN floor.
- Clarified Expo Native Components requirements and the iOS deployment target requirement.

Source evidence:

- https://github.com/clerk/clerk-ios/blob/063483c929f2eeac77e5e969a2ad1dd99586dcb4/Package.swift#L1-L15
- https://github.com/clerk/javascript/blob/f23ac111d7ca1bc4cc53aa94d235b7315ddf0582/packages/expo/package.json#L139-L181
- https://github.com/clerk/javascript/blob/f23ac111d7ca1bc4cc53aa94d235b7315ddf0582/packages/expo/app.plugin.js#L23-L75
- https://github.com/clerk/javascript/blob/f23ac111d7ca1bc4cc53aa94d235b7315ddf0582/packages/expo/ios/ClerkExpo.podspec#L30-L31

Validation:

- `git diff --check` passed.
- Source refs were refreshed before final verification.
- Full docs `build:tsx` / `lint` was not run because the fresh worktree did not have `node_modules` installed.

### Deadline

- No rush.

### Other resources

- Prepared by the mobile docs drift automation test run.
