### PR TITLE
docs: document Android configuration options

### DIFF
--- a/docs/reference/native-mobile/configuration.mdx
+++ b/docs/reference/native-mobile/configuration.mdx
@@ -18,6 +18,74 @@ Register your Application class in `AndroidManifest.xml`:
 </application>
 ```
 
+## Configuration options
+
+Pass `ClerkConfigurationOptions` as the `options` argument to `Clerk.initialize()` to configure SDK-level behavior when your app starts.
+
+```kotlin {{ filename: 'app/src/main/java/com/example/myclerkapp/MyClerkApp.kt' }}
+import android.app.Application
+import com.clerk.api.Clerk
+import com.clerk.api.ClerkConfigurationOptions
+
+class MyClerkApp : Application() {
+  override fun onCreate() {
+    super.onCreate()
+
+    val options = ClerkConfigurationOptions(
+      enableDebugMode = true,
+      proxyUrl = "https://proxy.example.com/__clerk",
+      telemetryEnabled = false,
+    ).withCustomHeaders(
+      mapOf("X-My-App-Version" to "1.0.0"),
+    )
+
+    Clerk.initialize(
+      this,
+      publishableKey = "{{pub_key}}",
+      options = options,
+    )
+  }
+}
+```
+
+<Properties>
+  - `enableDebugMode`
+  - `Boolean`
+
+  Whether the SDK should log additional information about SDK operations and API calls. Defaults to `false`.
+
+  ---
+
+  - `proxyUrl`
+  - `String?`
+
+  The proxy URL to use for Clerk API requests. Configure this when your application runs behind a reverse proxy. The value must be a full URL, such as `https://proxy.example.com/__clerk`.
+
+  ---
+
+  - `telemetryEnabled`
+  - `Boolean`
+
+  Whether the SDK should send telemetry. Defaults to `true`.
+
+  ---
+
+  - `withCustomHeaders()`
+  - `(customHeaders: Map<String, String>) -> ClerkConfigurationOptions`
+
+  Returns a copy of the options with additional custom headers configured for outgoing Clerk API requests.
+</Properties>
+
+To customize Clerk's prebuilt UI components, pass a `ClerkTheme` as the optional `theme` argument to `Clerk.initialize()`. See the [ClerkTheme guide](/docs/android/guides/customizing-clerk/clerk-theme) for available theme options.
+
+```kotlin {{ filename: 'app/src/main/java/com/example/myclerkapp/MyClerkApp.kt' }}
+Clerk.initialize(
+  this,
+  publishableKey = "{{pub_key}}",
+  theme = myClerkTheme,
+)
+```
+
 ## Wait for initialization
 
 The Clerk SDK initialization is non-blocking. Listen for the SDK to be ready before using Clerk features:


### PR DESCRIPTION
### 🔎 Previews:

- Preview deploy link will be available after the PR is opened.

### What does this solve? What changed?

This documents Android SDK initialization options that are public in source but missing from the Android configuration reference.

Changed docs:

- Added a `Configuration options` section to the Android SDK configuration page.
- Documents `ClerkConfigurationOptions` for `enableDebugMode`, `proxyUrl`, and `telemetryEnabled`.
- Documents `withCustomHeaders()` for additional outgoing Clerk API request headers.
- Mentions the `theme` argument on `Clerk.initialize()` for prebuilt UI customization.

Source evidence:

- https://github.com/clerk/clerk-android/blob/45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd/source/api/src/main/kotlin/com/clerk/api/Clerk.kt#L677-L681
- https://github.com/clerk/clerk-android/blob/45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd/source/api/src/main/kotlin/com/clerk/api/Clerk.kt#L693-L713
- https://github.com/clerk/clerk-android/blob/45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd/source/api/src/main/kotlin/com/clerk/api/Clerk.kt#L1009-L1022

Validation:

- `git diff --check` passed.
- A dependency-free MDX sanity check passed for frontmatter and balanced code fences.
- Attempted a one-file Prettier check, but this fresh worktree did not have `node_modules` or a local `prettier` binary installed.

### Deadline

- No rush.

### Other resources

- Prepared by the mobile docs drift automation test run.
