### PR TITLE
docs: document AuthView configuration options

### DIFF
--- a/docs/reference/views/authentication/auth-view.mdx
+++ b/docs/reference/views/authentication/auth-view.mdx
@@ -56,6 +56,13 @@ By default, the `AuthView` will automatically determine whether to sign users in
 
     ---
 
+    - `mode`
+    - `AuthMode`
+
+    The authentication mode that determines which flows are available to the user. Accepts `AuthMode.SignInOrUp`, `AuthMode.SignIn`, or `AuthMode.SignUp`. Defaults to `AuthMode.SignInOrUp`.
+
+    ---
+
     - `initialIdentifier`
     - `String?`
 
@@ -63,10 +70,31 @@ By default, the `AuthView` will automatically determine whether to sign users in
 
     ---
 
+    - `initialFirstName`
+    - `String?`
+
+    The initial value for the first name field during sign-up.
+
+    ---
+
+    - `initialLastName`
+    - `String?`
+
+    The initial value for the last name field during sign-up.
+
+    ---
+
+    - `lockPrefilledFields`
+    - `Boolean`
+
+    Whether prefilled identifier, first name, and last name fields are read-only. Defaults to `false`.
+
+    ---
+
     - `persistIdentifiers`
     - `Boolean`
 
-    Whether stored auth-start identifiers should persist between auth attempts. Defaults to `true`.
+    Whether auth identifier values persist between auth attempts. When `false`, stored identifiers are cleared and future edits are kept in memory only for the lifetime of the current view. Defaults to `true`.
 
     ---
 
@@ -109,6 +137,54 @@ By default, the `AuthView` will automatically determine whether to sign users in
     - `() -> Unit`
 
     Called when authentication completes.
+  </Properties>
+</If>
+
+<If sdk="ios">
+  ## Modifiers
+
+  Use modifiers to configure optional `AuthView` behavior.
+
+  <Properties>
+    - `initialIdentifier(_:)`
+    - `String`
+
+    Sets the initial value for the identifier field. Phone-like values are routed to the phone number field automatically.
+
+    ---
+
+    - `initialFirstName(_:)`
+    - `String`
+
+    Sets the initial value for the first name field during sign-up.
+
+    ---
+
+    - `initialLastName(_:)`
+    - `String`
+
+    Sets the initial value for the last name field during sign-up.
+
+    ---
+
+    - `lockPrefilledFields(_:)`
+    - `Bool`
+
+    Controls whether non-empty values configured with `initialIdentifier(_:)`, `initialFirstName(_:)`, or `initialLastName(_:)` are shown as read-only fields. Fields without configured initial values remain editable. Defaults to `true` when the modifier is called without an argument.
+
+    ---
+
+    - `persistsIdentifiers(_:)`
+    - `Bool`
+
+    Controls whether auth identifier values persist between auth attempts. Pass `false` to clear stored identifiers and keep future edits in memory only for the lifetime of the current view. The default behavior is to persist identifiers.
+
+    ---
+
+    - `unsafeMetadata(_:)`
+    - `JSON?`
+
+    Sets unsafe metadata for users created by this `AuthView` sign-up flow, including sign-in flows that transfer to sign-up. This metadata isn't validated by Clerk and shouldn't contain sensitive information.
   </Properties>
 </If>
 
@@ -162,6 +238,18 @@ By default, the `AuthView` will automatically determine whether to sign users in
       }
     }
   }
+  ```
+
+  ### Prefill sign-up fields
+
+  The following example demonstrates how to start `AuthView` in sign-up mode with prefilled profile fields.
+
+  ```swift
+  AuthView(mode: .signUp)
+    .initialIdentifier("ada@example.com")
+    .initialFirstName("Ada")
+    .initialLastName("Lovelace")
+    .lockPrefilledFields()
   ```
 </If>
 
@@ -217,6 +305,23 @@ By default, the `AuthView` will automatically determine whether to sign users in
       onDismiss = {
           // Navigate away from the auth screen.
       },
+  )
+  ```
+
+  ### Prefill sign-up fields
+
+  The following example demonstrates how to start `AuthView` in sign-up mode with prefilled profile fields.
+
+  ```kotlin
+  import com.clerk.ui.auth.AuthMode
+  import com.clerk.ui.auth.AuthView
+
+  AuthView(
+      mode = AuthMode.SignUp,
+      initialIdentifier = "ada@example.com",
+      initialFirstName = "Ada",
+      initialLastName = "Lovelace",
+      lockPrefilledFields = true,
   )
   ```
 </If>


### PR DESCRIPTION
### 🔎 Previews:

- Preview deploy link will be available after the PR is opened.

### What does this solve? What changed?

This updates the `AuthView` reference to cover public configuration options without overstating the API shape.

Changed docs:

- Adds missing Android public composable properties, including `mode`, prefilled sign-up fields, and `lockPrefilledFields`.
- Adds an iOS `Modifiers` section for public `AuthView` modifiers.
- Keeps the API wording precise: iOS prefill/persistence/metadata controls are public modifiers, not initializer parameters.
- Adds iOS and Android examples for prefilled sign-up fields.

Source evidence:

- https://github.com/clerk/clerk-ios/blob/063483c929f2eeac77e5e969a2ad1dd99586dcb4/Sources/ClerkKitUI/Components/Auth/AuthView.swift#L110-L111
- https://github.com/clerk/clerk-ios/blob/063483c929f2eeac77e5e969a2ad1dd99586dcb4/Sources/ClerkKitUI/Components/Auth/AuthView.swift#L269-L329
- https://github.com/clerk/clerk-android/blob/45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd/source/ui/src/main/java/com/clerk/ui/auth/AuthView.kt#L85-L99
- https://github.com/clerk/clerk-android/blob/45f7f048f2dfdb0f1f8d87d5cdfe35d140460ddd/source/ui/src/main/java/com/clerk/ui/auth/AuthMode.kt#L3-L7

Validation:

- `git diff --check` passed.
- A dependency-free MDX structure check passed for balanced code fences, `<If>`, and `<Properties>` blocks.
- Attempted a one-file Prettier check, but this fresh worktree did not have `node_modules` or a local `prettier` binary installed.

### Deadline

- No rush.

### Other resources

- Prepared by the mobile docs drift automation test run.
