### PR TITLE
feat(auth-strategies): Document passkeys satisfy second factor

### DIFF
--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -162,12 +162,13 @@ If you're building a custom user interface instead of using the [Account Portal]
 
 A [passkey](#passkeys) is itself a multi-factor credential — a single sign-in combines two authentication factors (a physical device and a PIN or biometric) — so a passkey sign-in can satisfy your application's multi-factor requirement on its own. When this behavior is in effect, a user who signs in with a passkey isn't prompted to complete a second factor.
 
-For instances created after **\[ROLLOUT DATE — TODO]**, this is the default behavior and can't be disabled.
+For instances created on or after **\[ROLLOUT DATE — TODO]**, this is the default behavior and can't be disabled.
 
 For instances created before **\[ROLLOUT DATE — TODO]**, this behavior is off by default, but you can opt in:
 
 1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
-1. In the **Passkeys** settings, toggle on **Passkeys satisfy multi-factor authentication**.
+1. Enable **Sign-in with passkey**, if it isn't already — the following setting only appears once passkey sign-in is on.
+1. Toggle on **Passkeys satisfy multi-factor authentication**.
 
 ### Reset a user's MFA
 

--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -162,9 +162,9 @@ If you're building a custom user interface instead of using the [Account Portal]
 
 A [passkey](#passkeys) is itself a multi-factor credential — a single sign-in combines two authentication factors (a physical device and a PIN or biometric) — so a passkey sign-in can satisfy your application's multi-factor requirement on its own. When this behavior is in effect, a user who signs in with a passkey isn't prompted to complete a second factor.
 
-For instances created after **[ROLLOUT DATE — TODO]**, this is the default behavior and can't be disabled.
+For instances created after **\[ROLLOUT DATE — TODO]**, this is the default behavior and can't be disabled.
 
-For instances created before **[ROLLOUT DATE — TODO]**, this behavior is off by default, but you can opt in:
+For instances created before **\[ROLLOUT DATE — TODO]**, this behavior is off by default, but you can opt in:
 
 1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
 1. In the **Passkeys** settings, toggle on **Passkeys satisfy multi-factor authentication**.

--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -88,7 +88,7 @@ A passkey is a type of sign-in credential that requires one user action, but use
 
 #### Passkey limitations
 
-- Passkeys are not currently available as an [MFA](#multi-factor-authentication) option.
+- Passkeys can't be enrolled as a dedicated [multi-factor authentication](#multi-factor-authentication) method, but they can be configured to [satisfy the multi-factor requirement](#passkeys-and-multi-factor-authentication) when a user signs in with one.
 - Not all devices and browsers are compatible with passkeys. Passkeys are built on WebAuthn technology and you should check [the Browser Compatibility docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API#browser_compatibility) for an up-to-date list.
 - Your users can have a max of 10 passkeys per account.
 
@@ -157,6 +157,17 @@ To configure MFA strategies:
 1. Select **Save**.
 
 If you're building a custom user interface instead of using the [Account Portal](/docs/guides/account-portal/overview) or [prebuilt components](/docs/reference/components/overview), you can use [the Clerk API](/docs/guides/development/custom-flows/authentication/multi-factor-authentication) to build a [custom flow](!custom-flow) that allows users to sign in with MFA.
+
+### Passkeys and multi-factor authentication
+
+A [passkey](#passkeys) is itself a multi-factor credential — a single sign-in combines two authentication factors (a physical device and a PIN or biometric) — so a passkey sign-in can satisfy your application's multi-factor requirement on its own. When this behavior is in effect, a user who signs in with a passkey isn't prompted to complete a second factor.
+
+For instances created after **[ROLLOUT DATE — TODO]**, this is the default behavior and can't be disabled.
+
+For instances created before **[ROLLOUT DATE — TODO]**, this behavior is off by default, but you can opt in:
+
+1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
+1. In the **Passkeys** settings, toggle on **Passkeys satisfy multi-factor authentication**.
 
 ### Reset a user's MFA
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk-docs-hecgt82fx.clerkstage.dev/

### What does this solve? What changed?

Do not merge. Needs to be updated with the exact rollout date, once we've merged and applied that in terraform.

Describe that passkeys satisfy second factor, which will be the new default behavior for new instances. Document how to opt in to this functionality for older instances using the Clerk Dashboard. Newer instances are forced to use the new feature. (This is just like how we implemented the PII changes.)

### Deadline

No rush. Still waiting on Dashboard PR review, and everything is behind a flag we will roll out in Terraform.

### Other resources

https://linear.app/clerk/issue/USER-3966/passkey-as-2fa-option