### PR TITLE
feat(reverification): Document new reverification_id shortcode

### DIFF
--- a/docs/guides/secure/reverification.mdx
+++ b/docs/guides/secure/reverification.mdx
@@ -200,9 +200,9 @@ Clerk tracks every reverification with a unique ID. You can include this ID in y
 - `reverification_id` provides **uniqueness**: it identifies _which_ reverification the token reflects.
 - `fva` provides **freshness**: it conveys how recently the user's factors were verified.
 
-Because every successful reverification generates a new `reverification_id`, and both claims are part of the signed session token, your backend can verify them and correlate a reverification with a specific action. A typical flow:
+Each time a reverification starts, Clerk mints a new `reverification_id`. Because both claims are part of the signed session token, your backend can confirm `fva` reflects a recent verification and use `reverification_id` to correlate that reverification with a specific action. A typical flow:
 
 1. Add `{{session.reverification_id}}` as a custom claim to your session token. See [Customize your session token](/docs/guides/sessions/customize-session-tokens).
 1. When the user initiates a sensitive action, [trigger a reverification](#how-to-require-reverification) so a new reverification ID is minted.
-1. On your backend, verify the signed session token, confirm that `fva` is within your required window, and record the `reverification_id` alongside the action.
-1. Reject any action whose `reverification_id` has already been used, ensuring each reverification is consumed only once.
+1. On your backend, verify the signed session token, confirm that `fva` is within your required window, and record the `reverification_id` alongside the action's specific details, such as the payment amount and payee.
+1. Reject any action whose `reverification_id` has already been used, or whose recorded details don't match the action being performed, ensuring each reverification authorizes exactly one action.

--- a/docs/guides/secure/reverification.mdx
+++ b/docs/guides/secure/reverification.mdx
@@ -200,7 +200,7 @@ Clerk tracks every reverification with a unique ID. You can include this ID in y
 - `reverification_id` provides **uniqueness**: it identifies _which_ reverification the token reflects.
 - `fva` provides **freshness**: it conveys how recently the user's factors were verified.
 
-Because both claims are part of the signed session token, your backend can verify them and correlate a reverification with a specific action. A typical flow:
+Because every successful reverification generates a new `reverification_id`, and both claims are part of the signed session token, your backend can verify them and correlate a reverification with a specific action. A typical flow:
 
 1. Add `{{session.reverification_id}}` as a custom claim to your session token. See [Customize your session token](/docs/guides/sessions/customize-session-tokens).
 1. When the user initiates a sensitive action, [trigger a reverification](#how-to-require-reverification) so a new reverification ID is minted.

--- a/docs/guides/secure/reverification.mdx
+++ b/docs/guides/secure/reverification.mdx
@@ -190,3 +190,19 @@ After setting up reverification on the server-side, you must handle reverificati
   }
   ```
 </If>
+
+## Correlate a reverification with a specific action
+
+Some use cases require proving that a single reverification corresponds to exactly one sensitive action — for example, [Strong Customer Authentication (SCA)](https://en.wikipedia.org/wiki/Strong_customer_authentication) for payments, where each payment must be backed by its own verification and a verification can't be replayed across payments.
+
+Clerk tracks every reverification with a unique ID. You can include this ID in your session token by adding the `{{session.reverification_id}}` shortcode as a custom claim. Combined with the default [`fva` (factor verification age)](/docs/guides/sessions/session-tokens) claim, the token gives you two guarantees:
+
+- `reverification_id` provides **uniqueness**: it identifies _which_ reverification the token reflects.
+- `fva` provides **freshness**: it conveys how recently the user's factors were verified.
+
+Because both claims are part of the signed session token, your backend can verify them and correlate a reverification with a specific action. A typical flow:
+
+1. Add `{{session.reverification_id}}` as a custom claim to your session token. See [Customize your session token](/docs/guides/sessions/customize-session-tokens).
+1. When the user initiates a sensitive action, [trigger a reverification](#how-to-require-reverification) so a new reverification ID is minted.
+1. On your backend, verify the signed session token, confirm that `fva` is within your required window, and record the `reverification_id` alongside the action.
+1. Reject any action whose `reverification_id` has already been used, ensuring each reverification is consumed only once.

--- a/docs/guides/secure/reverification.mdx
+++ b/docs/guides/secure/reverification.mdx
@@ -193,7 +193,7 @@ After setting up reverification on the server-side, you must handle reverificati
 
 ## Correlate a reverification with a specific action
 
-Some use cases require proving that a single reverification corresponds to exactly one sensitive action — for example, [Strong Customer Authentication (SCA)](https://en.wikipedia.org/wiki/Strong_customer_authentication) for payments, where each payment must be backed by its own verification and a verification can't be replayed across payments.
+Some use cases require proving that a single reverification corresponds to exactly one sensitive action — for example, [Strong Customer Authentication (SCA)](https://en.wikipedia.org/wiki/Strong_customer_authentication) for payments, where each payment must be backed by its own verification and a verification can't be replayed across payments. This pattern is useful in scenarios that require dynamic linking.
 
 Clerk tracks every reverification with a unique ID. You can include this ID in your session token by adding the `{{session.reverification_id}}` shortcode as a custom claim. Combined with the default [`fva` (factor verification age)](/docs/guides/sessions/session-tokens) claim, the token gives you two guarantees:
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk-docs-2mmgbbscn.clerkstage.dev/

### What does this solve? What changed?

Document the use of the new `session.reverification_id` shortcode and illustrate a typical workflow that a client could use to implement SCA.

(I was surprised to see we do not have a canonical list of shortcodes in the Docs, but it is available in the Dashboard so I guess it's fine and it would just be something else we would need to keep in sync.)

### Deadline

No major deadline. Requested by OneSafe and Finary. ~Depends on https://github.com/clerk/dashboard/pull/9558~ Now released!

### Other resources

https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32018R0389&from=EN#d1e493-23-1