### PR TITLE
fix(auth-strategies): Move immutable attribute setting

### DIFF
--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -102,6 +102,7 @@ In this section, you can:
 
 - Allow users to set their first and last name.
 - Allow users to delete their accounts.
+- Control whether users can change their email address, phone number, or username after sign-up. See [Restrict changes](#restrict-changes).
 
 ## Restrict changes
 
@@ -110,9 +111,9 @@ By default, users can add, remove, and modify their own email addresses, phone n
 To restrict identifier changes:
 
 1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
-1. Under the identifier you want to lock down (email address, phone number, or username), enable the **Restrict changes** setting.
+1. In the **User model** section, under **User permissions**, turn off **Allow users to change their [identifier]** for each identifier you want to lock down (for example, **Allow users to change their email address**). This toggle only appears for identifiers you've enabled.
 
-When enabled:
+When changes are restricted:
 
 - Users can still view their identifiers in [`<UserProfile />`](/docs/reference/components/user/user-profile) but cannot add, remove, or modify them.
 - For email addresses, the restriction also prevents connecting an OAuth account that would add a new email address.

--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -111,7 +111,7 @@ By default, users can add, remove, and modify their own email addresses, phone n
 To restrict identifier changes:
 
 1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
-1. In the **User model** section, under **User permissions**, turn off **Allow users to change their [identifier]** for each identifier you want to lock down (for example, **Allow users to change their email address**). This toggle only appears for identifiers you've enabled.
+1. In the **User model** section, under **User permissions**, turn off **Allow users to change their \[identifier]** for each identifier you want to lock down (for example, **Allow users to change their email address**). This toggle only appears for identifiers you've enabled.
 
 When changes are restricted:
 

--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -111,7 +111,7 @@ By default, users can add, remove, and modify their own email addresses, phone n
 To restrict identifier changes:
 
 1. In the Clerk Dashboard, navigate to the [**User & authentication**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication) page.
-1. In the **User model** section, under **User permissions**, turn off **Allow users to change their \[identifier]** for each identifier you want to lock down (for example, **Allow users to change their email address**). This toggle only appears for identifiers you've enabled.
+1. In the [**User model**](https://dashboard.clerk.com/~/user-authentication/user-and-authentication?user_auth_tab=user-profile) section, under **User permissions**, turn off **Allow users to change their \[identifier]** for each identifier you want to lock down (for example, **Allow users to change their email address**). This toggle only appears for identifiers that are used for sign-up or sign-in.
 
 When changes are restricted:
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk-docs-j9ty5zhad.clerkstage.dev/

### What does this solve? What changed?

The immutable attribute setting is moving from each attribute's page (where it was a child of "Used for Sign Up") and instead to the User model page. The reason for this is that some instances have an attribute disabled for sign up but used for sign in, but they still want it to be set immutable.

~Depends on https://github.com/clerk/dashboard/pull/9493~ This is now released.

### Deadline

No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
