### PR TITLE
Fix links Backend API

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping.mdx
@@ -88,7 +88,7 @@ For a full walkthrough of setting up Directory Sync, see the [Directory Sync gui
 
 ## Accessing custom attributes
 
-Custom attribute values are stored in `publicMetadata` and are accessible from the [Backend API](https://clerk.com/docs/reference/backend-api) on the user object, the `useUser()` hook (via `user.publicMetadata`), and Clerk's [server-side helpers](/docs/guides/users/extending).
+Custom attribute values are stored in `publicMetadata` and are accessible from the [Backend API](/docs/reference/backend-api){{ target: '_blank' }} on the user object, the `useUser()` hook (via `user.publicMetadata`), and Clerk's [server-side helpers](/docs/guides/users/extending).
 
 > [!NOTE]
 > `publicMetadata` is server-controlled. Users cannot modify these values themselves. Only your backend or the Clerk Dashboard (when SCIM is not active) can update them.

--- a/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
+++ b/docs/guides/configure/auth-strategies/sign-up-sign-in-options.mdx
@@ -117,7 +117,7 @@ When changes are restricted:
 
 - Users can still view their identifiers in [`<UserProfile />`](/docs/reference/components/user/user-profile) but cannot add, remove, or modify them.
 - For email addresses, the restriction also prevents connecting an OAuth account that would add a new email address.
-- Admins retain full control and can still modify user identifiers through the [Dashboard](https://dashboard.clerk.com/~/users) or the [Backend API](/docs/reference/backend-api).
+- Admins retain full control and can still modify user identifiers through the [Dashboard](https://dashboard.clerk.com/~/users) or the [Backend API](/docs/reference/backend-api){{ target: '_blank' }}.
 
 > [!TIP]
 > This feature prevents changes _after_ sign-up. If you want to control _who can sign up_ in the first place, see [restrictions](/docs/guides/secure/restricting-access) for allowlists, blocklists, and disposable email blocking.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- http://clerk.com/docs/pr/ss-fix-backendapi-links/guides/configure/auth-strategies/sign-up-sign-in-options
- https://clerk.com/docs/pr/ss-fix-backendapi-links/guides/configure/auth-strategies/enterprise-connections/custom-attribute-mapping
 
### What does this solve? What changed?

While reviewing this [PR](https://github.com/clerk/clerk-docs/pull/3481), noticed two instances of Backend API not being linked with the relative link or not having the `{{ target: '_blank'}} `to make them open in a new page. Fixes those two instances in this PR to bring consistency to the docs.

### Deadline

ASAP.