### PR TITLE
Add redirects for top docs 404s (2026-06-29)

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -1436,6 +1436,10 @@
     "destination": "/docs/reference/backend/types/auth-object"
   },
   {
+    "source": "/docs/go",
+    "destination": "/docs/go/getting-started/quickstart"
+  },
+  {
     "source": "/docs/guides/add-onboarding-flow",
     "destination": "/docs/guides/development/add-onboarding-flow"
   },
@@ -1770,6 +1774,10 @@
   {
     "source": "/docs/errors/authentication",
     "destination": "/docs/guides/development/errors/overview"
+  },
+  {
+    "source": "/docs/errors/backend-api",
+    "destination": "/docs/guides/development/errors/backend-api"
   },
   {
     "source": "/docs/errors/backup-codes",
@@ -3426,6 +3434,10 @@
   {
     "source": "/docs/guides/development/custom-flows/bot-sign-up-protection",
     "destination": "/docs/guides/development/custom-flows/authentication/bot-sign-up-protection"
+  },
+  {
+    "source": "/docs/guides/configure/auth-strategies/enterprise-connections",
+    "destination": "/docs/guides/configure/auth-strategies/enterprise-connections/overview"
   },
   {
     "source": "/docs/guides/configure/auth-strategies/social-connections/all-providers",


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-404-redirects-2026-06-29/go
- https://clerk.com/docs/pr/manovotny-404-redirects-2026-06-29/errors/backend-api
- https://clerk.com/docs/pr/manovotny-404-redirects-2026-06-29/guides/configure/auth-strategies/enterprise-connections

### What does this solve? What changed?

This week's Docs Bot "Top 5 Docs 404s (Last 7 Days)" report surfaced five paths. Three are legitimate near-misses / structural gaps that map cleanly to a real, current page; the other two are analytics/malformed noise with no canonical home. This adds three static redirects and skips the two.

#### Investigation methodology — searches run; build + redirect checks run.

- Searched the clerk-docs source tree, `redirects/static/docs.json`, and `redirects/dynamic/docs.jsonc` for each path.
- `gh search code --owner clerk` plus web searches for external references on the two skipped paths.
- Ran `pnpm run build:tsx`, `pnpm run lint:check-redirects:tsx`, and `pnpm exec tsx scripts/check-duplicate-redirects.ts` — all pass (0 invalid redirects, no protected-route violations, no page shadowing, no duplicate sources). All three new destinations validate as real pages.

#### Analysis of all 5 URLs

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/go` | Legit near-miss — bare SDK root; matches the existing `/docs/nextjs` and `/docs/react` → quickstart precedent, and `/docs/go/getting-started/quickstart` is a real page. | Added |
| 2 | `/docs/docs/reference/frontend-api` | Analytics/malformed — duplicated `/docs` prefix; no referrer found in the clerk org or on the web. Real page is `/docs/reference/frontend-api`. | Skipped |
| 3 | `/docs/guides/configure/auth-strategies/enterprise-connections` | Structural gap — current section root missing its `/overview`; `overview.mdx` exists, and the dynamic `/docs/authentication/enterprise-connections/*` redirect currently lands on this bare folder and 404s. | Added |
| 4 | `/docs/errors/backend-api` | Legit near-miss — missing from the otherwise-complete `/docs/errors/*` redirect cluster; its successor page `/docs/guides/development/errors/backend-api` is build-generated. | Added |
| 5 | `/docs/fastify/guides/configure` | Analytics truncation — `guides/configure` is a parent section with no leaf/overview page, so there's no single canonical destination. | Skipped |

#### Changes — Static redirects (`redirects/static/docs.json`)

- `/docs/go` -> `/docs/go/getting-started/quickstart`
- `/docs/errors/backend-api` -> `/docs/guides/development/errors/backend-api`
- `/docs/guides/configure/auth-strategies/enterprise-connections` -> `/docs/guides/configure/auth-strategies/enterprise-connections/overview`

No existing redirects were repointed.

### Deadline

- No rush

### Other resources

- Previous weekly 404 redirect PRs: #3391, #3359, #3378.
- Engineering follow-ups (not fixable via a static redirect on the five reported paths):
  - `/docs/docs/reference/frontend-api` — duplicated `/docs` prefix with no referrer in the clerk org or on the web. If this turns out to be systemic, a general double-prefix rewrite belongs in the platform rather than a one-off redirect.
  - `/docs/fastify/guides/configure` — `guides/configure` is a parent grouping with no overview page; the closest real pages (e.g. `/docs/guides/configure/session-tasks`) are ambiguous matches, so there's no confident canonical destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
