### PR TITLE
Clarify Self-serve SSO supports SAML providers only

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/self-serve-sso.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/self-serve-sso.mdx
@@ -10,7 +10,7 @@ Self-serve SSO lets you delegate that configuration directly to your customers' 
 The connection is scoped to the Organization it's configured in, and behaves like any other enterprise connection once it's live.
 
 > [!NOTE]
-> Self-serve SSO is currently scoped to [Clerk Organizations](/docs/guides/organizations/overview) and is only available through the **Security** tab of `<OrganizationProfile />`. Your application must use Organizations to offer it.
+> Self-serve SSO is currently available only for applications using [Clerk Organizations](/docs/guides/organizations/overview) and supports only SAML identity providers. It can be configured from the **Security** tab of `<OrganizationProfile />`.
 
 ## Requirements
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/ss-add-callout-self-serve-sso/guides/configure/auth-strategies/enterprise-connections/self-serve-sso

### What does this solve? What changed?

This PR updates the Self-serve SSO documentation to clarify that only SAML identity providers are currently supported. Context [here](https://clerkinc.slack.com/archives/C07JG7SCWCD/p1782824606837899). 

### Deadline

ASAP.

### Other resources

- Slack thread: https://clerkinc.slack.com/archives/C07JG7SCWCD/p1782824606837899