### PR TITLE
Add link to SAML in the Self-serve SSO callout 

### DIFF
--- a/docs/guides/configure/auth-strategies/enterprise-connections/self-serve-sso.mdx
+++ b/docs/guides/configure/auth-strategies/enterprise-connections/self-serve-sso.mdx
@@ -10,7 +10,7 @@ Self-serve SSO lets you delegate that configuration directly to your customers' 
 The connection is scoped to the Organization it's configured in, and behaves like any other enterprise connection once it's live.
 
 > [!NOTE]
-> Self-serve SSO is currently available only for applications using [Clerk Organizations](/docs/guides/organizations/overview) and supports only SAML identity providers. It can be configured from the **Security** tab of `<OrganizationProfile />`.
+> Self-serve SSO is currently available only for applications using [Clerk Organizations](/docs/guides/organizations/overview) and supports only [SAML](/docs/guides/configure/auth-strategies/enterprise-connections/overview#saml) identity providers. It can be configured from the **Security** tab of `<OrganizationProfile />`.
 
 ## Requirements
 


### PR DESCRIPTION
### What does this solve? What changed?

This PR links SAML in the new Self-serve SSO callout for users to know what SAML providers are available. Related to this ask from @alexisintech:

<img width="608" height="124" alt="Screenshot 2026-06-30 at 12 09 12 pm" src="https://github.com/user-attachments/assets/60ecba4a-0b76-4a08-8f44-3eafa7bbdcf2" />

**Preview:** https://clerk.com/docs/pr/ss-add-link-saml/guides/configure/auth-strategies/enterprise-connections/self-serve-sso

### Deadline

ASAP. 

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
