### PR TITLE
Use "prebuilt" consistently instead of "pre-built"

### DIFF
--- a/docs/getting-started/quickstart.astro.mdx
+++ b/docs/getting-started/quickstart.astro.mdx
@@ -3,7 +3,7 @@ title: Astro Quickstart
 description: Add authentication and user management to your Astro app with Clerk.
 sdk: astro
 llm:
-  displayText: Use this pre-built prompt to get started faster.
+  displayText: Use this prebuilt prompt to get started faster.
   src: prompts/astro-quickstart.md
 ---
 

--- a/docs/getting-started/quickstart.expo.mdx
+++ b/docs/getting-started/quickstart.expo.mdx
@@ -36,7 +36,7 @@ There are three approaches for adding authentication to your Expo app.
 
 | Approach | Auth UI | OAuth | Requires dev build | Best for |
 | - | - | - | - | - |
-| **Native components** | Pre-built native components | Native (no browser) | Yes | Fastest integration |
+| **Native components** | Prebuilt native components | Native (no browser) | Yes | Fastest integration |
 | **JS + Native sign-in** | [Custom flows](!custom-flow) + native OAuth buttons | Native (no browser) | Yes | Custom UI with native Sign in with Google/Apple |
 | **JavaScript** | [Custom flows](!custom-flow) | Browser-based | No (works in Expo Go) | Full control over UI |
 
@@ -48,7 +48,7 @@ Use the following tabs to choose your preferred approach:
 
     <Include src="_partials/expo/beta-callout" />
 
-    This approach uses Clerk's [pre-built native components](/docs/reference/expo/native-components/overview) that render using SwiftUI on iOS and Jetpack Compose on Android. This requires the least code and a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+    This approach uses Clerk's [prebuilt native components](/docs/reference/expo/native-components/overview) that render using SwiftUI on iOS and Jetpack Compose on Android. This requires the least code and a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
 
     <Steps>
       ## Enable Native API
@@ -387,7 +387,7 @@ Learn more about Clerk prebuilt components, custom flows, and how to deploy an E
 
 <Cards>
   - [Prebuilt native components (beta)](/docs/reference/expo/native-components/overview)
-  - Learn how to quickly add authentication to your app using Clerk's pre-built native UI for iOS and Android.
+  - Learn how to quickly add authentication to your app using Clerk's prebuilt native UI for iOS and Android.
 
   ---
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -3,7 +3,7 @@ title: Next.js Quickstart (App Router)
 description: Add authentication and user management to your Next.js app.
 sdk: nextjs
 llm:
-  displayText: Use this pre-built prompt to get started faster.
+  displayText: Use this prebuilt prompt to get started faster.
   src: prompts/nextjs-quickstart.md
 ---
 

--- a/docs/getting-started/quickstart.react.mdx
+++ b/docs/getting-started/quickstart.react.mdx
@@ -3,7 +3,7 @@ title: React Quickstart
 description: Add authentication and user management to your React app with Clerk.
 sdk: react
 llm:
-  displayText: Use this pre-built prompt to get started faster.
+  displayText: Use this prebuilt prompt to get started faster.
   src: prompts/react-vite-quickstart.md
 ---
 

--- a/docs/guides/ai/prompts.mdx
+++ b/docs/guides/ai/prompts.mdx
@@ -29,11 +29,7 @@ These prompts can be copied into your AI-powered IDE or development tool, or pas
 <If sdk="nextjs">
   ### Next.js App Router
 
-  <LLMPrompt
-    displayText="Use this prebuilt prompt to get started faster."
-    src="prompts/nextjs-quickstart.md"
-    embed
-  />
+  <LLMPrompt displayText="Use this prebuilt prompt to get started faster." src="prompts/nextjs-quickstart.md" embed />
 </If>
 
 <If sdk="react">

--- a/docs/guides/ai/prompts.mdx
+++ b/docs/guides/ai/prompts.mdx
@@ -30,7 +30,7 @@ These prompts can be copied into your AI-powered IDE or development tool, or pas
   ### Next.js App Router
 
   <LLMPrompt
-    displayText="Use this pre-built prompt to get started faster."
+    displayText="Use this prebuilt prompt to get started faster."
     src="prompts/nextjs-quickstart.md"
     embed
   />
@@ -40,14 +40,14 @@ These prompts can be copied into your AI-powered IDE or development tool, or pas
   ### React
 
   <LLMPrompt
-    displayText="Use this pre-built prompt to get started faster."
+    displayText="Use this prebuilt prompt to get started faster."
     src="prompts/react-vite-quickstart.md"
     embed
   />
 </If>
 
 <If sdk="astro">
-  <LLMPrompt displayText="Use this pre-built prompt to get started faster." src="prompts/astro-quickstart.md" embed />
+  <LLMPrompt displayText="Use this prebuilt prompt to get started faster." src="prompts/astro-quickstart.md" embed />
 </If>
 
 ## Contributing

--- a/docs/guides/development/shadcn-cli.mdx
+++ b/docs/guides/development/shadcn-cli.mdx
@@ -4,7 +4,7 @@ description: Use the shadcn/ui CLI to bootstrap your Next.js app with Clerk.
 sdk: nextjs
 ---
 
-The [shadcn/ui CLI](https://ui.shadcn.com/docs/cli) is a tool that allows you to bootstrap your Next.js app with Clerk. Clerk's shadcn/ui registry enables developers to add pre-built components and configurations to their projects with a single command. You can either get started with the [complete quickstart package](#quickstart), or add [pages](#pages) and [components](#components) individually.
+The [shadcn/ui CLI](https://ui.shadcn.com/docs/cli) is a tool that allows you to bootstrap your Next.js app with Clerk. Clerk's shadcn/ui registry enables developers to add prebuilt components and configurations to their projects with a single command. You can either get started with the [complete quickstart package](#quickstart), or add [pages](#pages) and [components](#components) individually.
 
 ## Quickstart
 

--- a/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
+++ b/docs/guides/development/upgrading/upgrade-guides/core-3.mdx
@@ -2,7 +2,7 @@
 title: "Upgrading to Clerk Core 3"
 description: "Learn how to upgrade to Clerk Core 3 across all SDKs."
 llm:
-  displayText: Use this pre-built prompt to upgrade your project with AI assistance.
+  displayText: Use this prebuilt prompt to upgrade your project with AI assistance.
   src: prompts/core-3-upgrade.md
 ---
 

--- a/docs/reference/expo/native-components/overview.mdx
+++ b/docs/reference/expo/native-components/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Expo Native Components (beta)
-description: Pre-built native authentication and user management components for iOS and Android.
+description: Prebuilt native authentication and user management components for iOS and Android.
 sdk: expo
 ---
 

--- a/docs/reference/expo/overview.mdx
+++ b/docs/reference/expo/overview.mdx
@@ -16,7 +16,7 @@ The Expo SDK supports [three approaches to authentication](/docs/getting-started
 
 <Include src="_partials/expo/beta-callout" />
 
-Pre-built native components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components require a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+Prebuilt native components rendered with **SwiftUI** on iOS and **Jetpack Compose** on Android. These components require a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
 
 - [`<AuthView />`](/docs/reference/expo/native-components/auth-view) - Renders a full authentication interface, supporting multiple sign-up and sign-in methods, multi-factor authentication (MFA), and password recovery flows.
 - [`<UserButton />`](/docs/reference/expo/native-components/user-button) - Displays the signed-in user's profile image.

--- a/styleguides/STYLEGUIDE.md
+++ b/styleguides/STYLEGUIDE.md
@@ -203,6 +203,16 @@ Use "ensure" instead of "make sure."
 > ✅
 > Ensure you have the correct permissions.
 
+### Prebuilt vs. pre-built
+
+Use "prebuilt" instead of "pre-built."
+
+> ❌
+> Clerk's pre-built components handle authentication and user management for you.
+
+> ✅
+> Clerk's prebuilt components handle authentication and user management for you.
+
 ### Sidenav vs. sidebar
 
 Use "sidenav" instead of "sidebar."


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk-docs-git-ss-prebuilt-consistency.clerkstage.dev/docs/getting-started/quickstart (Astro, React, Expo, and Next.js) 
- https://clerk-docs-git-ss-prebuilt-consistency.clerkstage.dev/docs/guides/ai/prompts
- https://clerk-docs-git-ss-prebuilt-consistency.clerkstage.dev/docs/guides/development/shadcn-cli
- https://clerk-docs-git-ss-prebuilt-consistency.clerkstage.dev/docs/guides/development/upgrading/upgrade-guides/core-3
- https://clerk-docs-git-ss-prebuilt-consistency.clerkstage.dev/docs/reference/expo/native-components/overview
- https://clerk-docs-git-ss-prebuilt-consistency.clerkstage.dev/docs/reference/expo/overview

### What does this solve? What changed?

Standardizes on "prebuilt" (no hyphen) across the docs for consistency. Several pages used "pre-built" while others already used "prebuilt" - this aligns them all on the unhyphenated form.

Affected copy:
- Quickstart LLM prompt `displayText` (Next.js, React, Astro, Expo)
- Core 3 upgrade guide LLM prompt `displayText`
- Expo native components references and overview
- shadcn/ui CLI guide

## Changes

- `docs/getting-started/quickstart.mdx`, `quickstart.react.mdx`, `quickstart.astro.mdx`, `quickstart.expo.mdx`
- `docs/guides/ai/prompts.mdx`
- `docs/guides/development/shadcn-cli.mdx`
- `docs/guides/development/upgrading/upgrade-guides/core-3.mdx`
- `docs/reference/expo/native-components/overview.mdx`
- `docs/reference/expo/overview.mdx`

### Deadline

No rush.