### PR TITLE
Add redirects for `/docs/<sdk>/quickstart` shorthand URLs

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4498,5 +4498,69 @@
   {
     "source": "/docs/guides/billing/seat-limit-plans",
     "destination": "/docs/guides/billing/seat-based-plans"
+  },
+  {
+    "source": "/docs/nextjs/quickstart",
+    "destination": "/docs/nextjs/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/react/quickstart",
+    "destination": "/docs/react/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/js-frontend/quickstart",
+    "destination": "/docs/js-frontend/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/chrome-extension/quickstart",
+    "destination": "/docs/chrome-extension/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/expo/quickstart",
+    "destination": "/docs/expo/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/android/quickstart",
+    "destination": "/docs/android/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/ios/quickstart",
+    "destination": "/docs/ios/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/expressjs/quickstart",
+    "destination": "/docs/expressjs/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/fastify/quickstart",
+    "destination": "/docs/fastify/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/react-router/quickstart",
+    "destination": "/docs/react-router/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/tanstack-react-start/quickstart",
+    "destination": "/docs/tanstack-react-start/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/go/quickstart",
+    "destination": "/docs/go/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/astro/quickstart",
+    "destination": "/docs/astro/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/nuxt/quickstart",
+    "destination": "/docs/nuxt/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/vue/quickstart",
+    "destination": "/docs/vue/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/ruby/quickstart",
+    "destination": "/docs/ruby/getting-started/quickstart"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/nextjs/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/react/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/js-frontend/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/chrome-extension/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/expo/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/android/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/ios/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/expressjs/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/fastify/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/react-router/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/tanstack-react-start/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/go/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/astro/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/nuxt/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/vue/quickstart
- https://clerk.com/docs/pr/manovotny-nifty-moser-2442c1/ruby/quickstart

### What does this solve? What changed?

- `/docs/<sdk>/quickstart` is a URL shape that humans, LLMs, and even our own internal repos assume exists — but it never has, for any SDK. All 16 variants currently hard-404 on clerk.com while the flipped forms (`/docs/quickstarts/<sdk>`) redirect correctly.
- Adds 16 static redirects, one per SDK in `VALID_SDKS`, pointing each shorthand at its canonical `/docs/<sdk>/getting-started/quickstart` page. All destinations verified live (200); all sources verified 404 before this change. Redirect entries also cover the `.md` twin of each path automatically.
- Surfaced by [this Slack thread](https://clerkinc.slack.com/archives/C05EP76HL72/p1782858430455019); part of a larger 404 remediation effort (DOCS-11895, DOCS-11896, DOCS-11897, DOCS-11898, DOCS-11899).

### Deadline

- No hard deadline — but these are live 404s on our highest-intent pages, so sooner is better.

### Other resources

- Slack investigation: https://clerkinc.slack.com/archives/C05EP76HL72/p1782858430455019
- Follow-up tickets: [DOCS-11895](https://linear.app/clerk/issue/DOCS-11895), [DOCS-11896](https://linear.app/clerk/issue/DOCS-11896), [DOCS-11897](https://linear.app/clerk/issue/DOCS-11897), [DOCS-11898](https://linear.app/clerk/issue/DOCS-11898), [DOCS-11899](https://linear.app/clerk/issue/DOCS-11899)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
