### PR TITLE
Add callout about useSignInWithGoogle usage in next Expo major version

### DIFF
--- a/docs/reference/expo/native-hooks/use-sign-in-with-google.mdx
+++ b/docs/reference/expo/native-hooks/use-sign-in-with-google.mdx
@@ -27,6 +27,19 @@ This hook requires the following peer dependency:
 npx expo install expo-crypto
 ```
 
+> [!NOTE]
+> In the next major version of `@clerk/expo`, using this hook will require installing the separate `@clerk/expo-google-signin` package and adding its [Expo config plugin](https://docs.expo.dev/config-plugins/introduction/) to your `app.json`:
+>
+> ```json {{ filename: 'app.json' }}
+> {
+>   "expo": {
+>     "plugins": ["@clerk/expo", "@clerk/expo-google-signin"]
+>   }
+> }
+> ```
+>
+> This keeps the native Google Sign-In dependencies opt-in, so apps that don't use them avoid the extra iOS and Android native modules. The `@clerk/expo/google` import path will continue to work.
+
 ## Returns
 
 The `useSignInWithGoogle()` hook returns the `startGoogleAuthenticationFlow()` method, which you can use to initiate the native Google authentication flow.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- https://clerk.com/docs/pr/rob-use-sign-in-with-google-callout/reference/expo/native-hooks/use-sign-in-with-google#installation

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- This gives developers using `useSignInWithGoogle` a heads up that in the next `@clerk/expo` major version, the native Google Sign-In implementation will be moved out out of `@clerk/expo` and into a new optional package, `@clerk/expo-google-signin`. Additional context in this PR https://github.com/clerk/javascript/pull/9015

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

- Would be nice to have it before we ship the SDK change 2nd half of July 2026

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
