### PR TITLE
Add the dev SSR error message to the React Router quickstart callout

### DIFF
--- a/docs/getting-started/quickstart.react-router.mdx
+++ b/docs/getting-started/quickstart.react-router.mdx
@@ -46,7 +46,7 @@ This tutorial assumes that you're using React Router **v7.1.2 or later** in fram
   ```
 
   > [!IMPORTANT]
-  > While an [upstream issue](https://github.com/remix-run/react-router/issues/15232) is being fixed, you must add `@clerk/react-router` to the `ssr.noExternal` array in your `vite.config.ts` file.
+  > While an [upstream issue](https://github.com/remix-run/react-router/issues/15232) is being fixed, you must add `@clerk/react-router` to the `ssr.noExternal` array in your `vite.config.ts` file. Without it, every page fails during server-side rendering in development with `Error: useNavigate() may be used only in the context of a <Router> component.` — even though `npm ls react-router` shows a single installed copy.
   >
   > ```ts {{ filename: 'vite.config.ts' }}
   > export default defineConfig({


### PR DESCRIPTION
### 🔎 Previews:

- https://clerk.com/docs/pr/manovotny-react-router-v8-quickstart-error/getting-started/quickstart

### What does this solve? What changed?

The React Router quickstart's `ssr.noExternal` callout describes the required workaround but never names the symptom, so nobody searching the actual failure finds it. A public [field report](https://x.com/Compurnicus/status/2073828066649117008) showed a Claude agent burning a whole session misdiagnosing exactly this: React Router 8's dev/prod conditional exports make `react-router dev` load two react-router instances, every request 500s during SSR, and the standard diagnostic (`npm ls react-router` shows a single copy) falsely rules out module duplication.

This adds one sentence to the existing IMPORTANT callout naming the verbatim error — `useNavigate() may be used only in the context of a <Router> component.` — and the single-copy trap, so the error text is greppable/searchable and lands people (and agents) on the fix.

Verified against a live repro (react-router 8.0.0 + `@clerk/react-router@3.5.5`): dev SSR fails with exactly this error without the workaround, renders cleanly with it.

Companion PRs fixing the same gap where agents actually look: clerk/skills#55 (skill taught a nonexistent `ClerkApp` API and lacked the workaround) and clerk/cli#374 (`clerk init` now scaffolds the workaround for RR8).

### Deadline

No rush — though RR8 adoption is growing, so sooner helps.

### Other resources

- Upstream issue: https://github.com/remix-run/react-router/issues/15232
- SDK v8 support PR (where the integration template gained this workaround): https://github.com/clerk/javascript/pull/8972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
