### PR TITLE
Add redirects for top docs 404s (2026-07-06)

### DIFF
--- a/redirects/static/docs.json
+++ b/redirects/static/docs.json
@@ -4574,5 +4574,17 @@
   {
     "source": "/docs/ruby/quickstart",
     "destination": "/docs/ruby/getting-started/quickstart"
+  },
+  {
+    "source": "/docs/components/user-button",
+    "destination": "/docs/reference/components/user/user-button"
+  },
+  {
+    "source": "/docs/ios/guides/development/deployment/production",
+    "destination": "/docs/guides/development/deployment/production"
+  },
+  {
+    "source": "/docs/guides/configure/auth-strategies/enterprise-connections/saml/overview",
+    "destination": "/docs/guides/configure/auth-strategies/enterprise-connections/overview"
   }
 ]


### PR DESCRIPTION
### 🔎 Previews:

These urls/paths should redirect now:

- https://clerk.com/docs/pr/manovotny-404-redirects-2026-07-06/components/user-button
- https://clerk.com/docs/pr/manovotny-404-redirects-2026-07-06/ios/guides/development/deployment/production
- https://clerk.com/docs/pr/manovotny-404-redirects-2026-07-06/guides/configure/auth-strategies/enterprise-connections/saml/overview

### What does this solve? What changed?

Automated weekly pass over the [Top 5 Docs 404s (Last 7 Days)](https://us.posthog.com/project/86309/insights/3iJsZYub) report posted in #team-docs on 2026-07-06. Three of the five reported paths are legitimate near-misses / structural gaps with an unambiguous canonical destination; the other two are malformed/auto-generated artifacts with no clean redirect target and are left as engineering follow-ups.

#### Investigation methodology — searches run; build + redirect checks run.

- `gh search code --owner clerk` for each reported path (raw, and without the leading `/docs/`).
- Cross-referenced existing entries in both `redirects/static/docs.json` and `redirects/dynamic/docs.jsonc` for sibling clusters and prior near-miss patterns.
- Inspected the `docs/` MDX source tree to confirm each destination is a real, current page and that no added source shadows a live page (e.g. the production deployment guide has no `sdk:` frontmatter, so an `/ios/`-prefixed URL genuinely 404s).
- Verified: `pnpm run build:tsx`, `pnpm run lint:check-redirects:tsx` (protected routes + page-shadowing), and `scripts/check-duplicate-redirects.ts` — all pass with no errors.

#### Analysis of all 5 URLs

| # | 404 URL | Verdict | Action |
|---|---------|---------|--------|
| 1 | `/docs/components/user-button` | Legit near-miss — flat form of the `/docs/components/*` redirect cluster; the `/docs/components/user/user-button` sibling already redirects to the same canonical page | Added |
| 2 | `/docs/docs/reference/frontend-api` | Malformed doubled-prefix (`/docs/docs/…`); recurred last week, no committed source found in the `clerk` org — symptomatic of a systemic bad-link source, not a historical URL | Skipped |
| 3 | `/docs/ios/guides/development/deployment/production` | Legit near-miss — SDK-prefixed form of the generic production deployment guide; existing `/docs/ios/reference/native-mobile/production` already redirects to the same generic destination | Added |
| 4 | `/docs/guides/configure/auth-strategies/enterprise-connections/saml/overview` | Structural gap — the `saml/` section has no `overview`; the sibling `…/enterprise-connections/saml` already redirects to the section overview | Added |
| 5 | `/docs/billing-payment-totals` | Broken auto-generated typedoc relative link — `billing-payment-totals` exists only as a `clerk-typedoc/shared/*` include fragment, with no standalone `/docs/reference/types/…` page to point at | Skipped |

#### Changes — Static redirects (`redirects/static/docs.json`)

- `/docs/components/user-button` -> `/docs/reference/components/user/user-button`
- `/docs/ios/guides/development/deployment/production` -> `/docs/guides/development/deployment/production`
- `/docs/guides/configure/auth-strategies/enterprise-connections/saml/overview` -> `/docs/guides/configure/auth-strategies/enterprise-connections/overview`

No existing redirects were repointed.

### Deadline

- No rush

### Other resources

- Previous weekly 404 redirect PRs: https://github.com/clerk/clerk-docs/pull/3485, https://github.com/clerk/clerk-docs/pull/3391, https://github.com/clerk/clerk-docs/pull/3359
- Engineering follow-ups (not fixable via a docs redirect):
  - URL #2 `/docs/docs/reference/frontend-api` — a doubled `/docs/docs/` prefix that has now recurred across at least two weekly reports with no source found in the `clerk` org. Worth tracing whatever emits the doubled-prefix link/URL rather than masking single instances with redirects.
  - URL #5 `/docs/billing-payment-totals` — the `BillingPaymentTotals` type is rendered inline via `clerk-typedoc/shared/billing-payment-totals.mdx`, and its relative links (`[…](billing-payment-totals.mdx)`) resolve to a non-existent top-level `/docs/billing-payment-totals`. There is no standalone page for this nested type. Fix belongs in the typedoc generation (relative-link resolution), not in `clerk-typedoc/` by hand.
