### PR TITLE
Change the condition that the migration reminder runs on

### DIFF
--- a/.github/workflows/remind-pr-migration.yml
+++ b/.github/workflows/remind-pr-migration.yml
@@ -12,10 +12,9 @@ permissions:
 jobs:
   remind_migration:
     name: Post migration reminder comment
-    # Only remind internal authors, who can actually run the migration. External
-    # contributors (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE) can't, so the
-    # reminder would be misleading.
-    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    # Skip on forks of clerk/clerk-docs — the migration reminder is only
+    # relevant on the canonical repo.
+    if: github.repository == 'clerk/clerk-docs'
     runs-on: ubuntu-latest
     env:
       REMINDER_MARKER: '<!-- migrate-to-clerk-reminder -->'
@@ -49,6 +48,9 @@ jobs:
 
   block_merges:
     name: Block merges (migration to clerk/clerk required)
+    # Skip on forks of clerk/clerk-docs — the block only applies to the
+    # canonical repo.
+    if: github.repository == 'clerk/clerk-docs'
     runs-on: ubuntu-latest
     steps:
       - name: Fail to block merge


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?

<!--
PLEASE FILL OUT WITH AS MUCH CONTEXT AS POSSIBLE
Why does this change need to happen?
How does this PR solve that problem you mentioned above?
Describe your changes. Link relevant source code PR (from clerk/javascript, clerk/clerk, etc.)
-->

- manually pulls in https://github.com/clerk/clerk/pull/2861 since the clerk cookie doesn't have permissions to sync github workflows

### Deadline

<!--
DO NOT LEAVE EMPTY.
When do you need this PR reviewed/shipped by? If no deadline, write something like "No rush".
-->

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
