### PR TITLE
docs(dashboard): add external account connection initiated event to list

### DIFF
--- a/docs/guides/dashboard/logs/application-logs.mdx
+++ b/docs/guides/dashboard/logs/application-logs.mdx
@@ -173,6 +173,7 @@ The following tables list all event types that can appear in Application Logs, o
 
 | Event type | Description |
 | - | - |
+| `user.external_account.connection_initiated` | External account connection initiated for user account |
 | `user.external_account.connected` | External account was connected to user account |
 | `user.external_account.disconnected` | External account was disconnected from user account |
 | `user.external_account.reauthorized` | External account was reauthorized for user account |
@@ -234,7 +235,7 @@ The following tables list all event types that can appear in Application Logs, o
 | `scim.user.updated` | SCIM user was updated |
 | `scim.user.patched` | SCIM user was patched |
 | `scim.user.deleted` | SCIM user was deleted |
-| `scim.group_membership.changed` | SCIM group membership changed |
+| `scim.group_membership.changed` | SCIM group membership changed | 
 | `scim.provisioning_failed` | SCIM provisioning failed |
 
 ### Organization events


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

-

### What does this solve? What changed?
Adds description for an impending new event type to the guide on the Logs page. New event type `user.external_account.connection_initiated` will be emitted in cases where the connection is prepared then finalized in separate steps. Capturing where connection was attempted, but for whatever reason (abandonment, error) did not complete.


-

### Deadline
No rush.

-

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
