### PR TITLE
docs(oauth): document Client ID Metadata Documents

### DIFF
--- a/docs/guides/ai/mcp/build-mcp-server.mdx
+++ b/docs/guides/ai/mcp/build-mcp-server.mdx
@@ -55,8 +55,9 @@ sdk: nextjs, expressjs
 </If>
 
 > [!IMPORTANT]
-> For most client implementations of MCP, [dynamic client registration](https://openid.net/specs/openid-connect-registration-1_0.html) is required. This allows MCP-compatible clients to automatically register themselves with your server during the OAuth flow.
-> Before proceeding, ensure you have toggled on the **Dynamic client registration** option in the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard.
+> Clerk supports both [Client ID Metadata Documents](/docs/guides/configure/auth-strategies/oauth/client-id-metadata-documents) and Dynamic Client Registration for OAuth client registration. A CIMD-compatible client uses an HTTPS metadata URL as its client ID and doesn't need Dynamic Client Registration.
+>
+> In the Clerk Dashboard, navigate to the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page and open **Client ID metadata**. Explicitly allow the client, or enable **Allow unknown clients** if your application should accept clients that haven't been reviewed in advance. Enable **Dynamic client registration** only if the client doesn't support CIMD and requires DCR.
 
 <Steps>
   ## Install dependencies

--- a/docs/guides/ai/mcp/connect-mcp-client.mdx
+++ b/docs/guides/ai/mcp/connect-mcp-client.mdx
@@ -20,8 +20,9 @@ This guide demonstrates how to connect an MCP-compatible client (**LLM app**), l
 To complete the integration, you'll need to connect an MCP-compatible client to your MCP server. Each client has a different way of connecting to MCP servers, and given that the MCP spec is still in development, you may need to refer to the client's documentation for the most up-to-date instructions.
 
 > [!IMPORTANT]
-> For most client implementations of MCP, [dynamic client registration](https://openid.net/specs/openid-connect-registration-1_0.html) is required. This allows MCP-compatible clients to automatically register themselves with your server during the OAuth flow.
-> Before proceeding, ensure you have toggled on the **Dynamic client registration** option in the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard.
+> Clerk supports both [Client ID Metadata Documents](/docs/guides/configure/auth-strategies/oauth/client-id-metadata-documents) and Dynamic Client Registration for OAuth client registration. A CIMD-compatible client uses an HTTPS metadata URL as its client ID and doesn't need Dynamic Client Registration.
+>
+> In the Clerk Dashboard, navigate to the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page and open **Client ID metadata**. Explicitly allow the client, or enable **Allow unknown clients** if your application should accept clients that haven't been reviewed in advance. Enable **Dynamic client registration** only if the client doesn't support CIMD and requires DCR.
 
 ### Development vs. Production Setup
 
@@ -193,7 +194,7 @@ The MCP protocol and spec are still in development, and as a result, implementat
 
 If you encounter issues connecting your MCP client:
 
-1. **Authentication fails**: Ensure **Dynamic client registration** is enabled in the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard.
+1. **Authentication fails**: On the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard, check the client's status and metadata under **Client ID metadata**. Refresh metadata if the fetch failed. If the client doesn't support CIMD, ensure **Dynamic client registration** is enabled.
 1. **Connection refused**: Verify your MCP server is running and accessible at the specified URL.
 1. **HTTPS errors**: Make sure you're using HTTPS URLs in production environments.
 1. **Tool not available**: Confirm your client displays the tool in the list of available tools, and that the tool has been properly implemented.

--- a/docs/guides/ai/overview.mdx
+++ b/docs/guides/ai/overview.mdx
@@ -36,7 +36,7 @@ An MCP implementation involves two parties: a "client" and a "server". In web de
 - The "client" is the LLM application that wants to access another service on a user's behalf. For example, Claude would be the "client" if it wants to get access to Gmail.
 - The "server" is the system that hosts the protected resources the client wants to access. In this example, this would be Gmail. This is sometimes referred to as the "resource server" or "MCP server".
 
-Clerk supports MCP through dynamic client registration (for registering MCP servers programmatically), consent screens (for secure user authorization), and SDK support, making it an ideal authorization server for MCP implementations.
+Clerk supports MCP through Client ID Metadata Documents, Dynamic Client Registration for clients that still require it, OAuth consent screens, and SDK support.
 
 To learn how to implement both sides of the flow using Clerk, refer to the following guides:
 

--- a/docs/guides/configure/auth-strategies/oauth/client-id-metadata-documents.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/client-id-metadata-documents.mdx
@@ -1,0 +1,103 @@
+---
+title: Manage OAuth clients with Client ID Metadata Documents
+description: Learn how Clerk uses Client ID Metadata Documents and how to explicitly allow, review, and block URL-identified OAuth clients.
+---
+
+A Client ID Metadata Document (CIMD) lets an OAuth client use an HTTPS URL as its `client_id`. The URL serves a JSON document that describes the client, including its name and allowed redirect URIs. This lets Clerk identify a client without requiring it to create a registration through [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591).
+
+Clerk's current OAuth implementation supports [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/). You control client admission from the Clerk Dashboard: you can explicitly allow individual clients or allow previously unknown clients to connect.
+
+## Client metadata requirements
+
+The following example demonstrates the minimum metadata that a client can publish:
+
+```json {{ filename: 'client-metadata.json' }}
+{
+  "client_id": "https://client.example.com/oauth/client-metadata.json",
+  "client_name": "Example client",
+  "redirect_uris": ["https://client.example.com/oauth/callback"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+For Clerk to accept the document:
+
+- The `client_id` must be an HTTPS URL with a path.
+- The document's `client_id` must exactly match the URL Clerk fetched.
+- `client_name` and at least one `redirect_uri` must be present.
+- The requested `redirect_uri` must exactly match an entry in `redirect_uris`.
+- The client must be public. Clerk rejects metadata that contains a client secret or selects a secret-based token endpoint authentication method.
+
+Clerk treats all CIMD clients as public OAuth clients, requires Proof Key for Code Exchange (PKCE) with the `S256` method, and always shows the OAuth consent screen.
+
+> [!IMPORTANT]
+> CIMD clients require a reachable OAuth consent flow. Keep the Account Portal enabled or configure an OAuth consent page for your application before you allow a CIMD client or enable unknown clients.
+
+## Explicitly allow a client
+
+Explicitly allowed clients can start OAuth flows regardless of the unknown-client policy.
+
+<Steps>
+  ## Open Client ID metadata settings
+
+  In the Clerk Dashboard, navigate to the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page and open the **Client ID metadata** tab.
+
+  ## Add the client
+
+  Select **Allow client**, then configure:
+
+  - **Client ID URL**: The HTTPS URL that serves the client's metadata document.
+  - **Display name**: An optional name override. If you omit it, Clerk uses a safe `client_name` from the metadata document, then falls back to the URL's hostname.
+  - **Scopes**: The scopes that the client may request from this Clerk instance.
+
+  The metadata document can't grant itself additional scopes. The scopes selected in the Clerk Dashboard remain authoritative. Clerk always includes `offline_access` for CIMD clients.
+
+  ## Allow the client
+
+  Select **Allow client**. Clerk fetches the metadata document and records the client as **Explicitly allowed**.
+
+  If Clerk can't fetch the document, the client remains explicitly allowed and its metadata status displays **Error**. The OAuth flow can't complete until Clerk can resolve a valid metadata document. From the client's actions menu, select **Refresh metadata** after the document becomes available.
+</Steps>
+
+## Control unknown and previously connected clients
+
+The **Settings** section on the **Client ID metadata** tab provides two policies:
+
+| Setting | Behavior |
+| - | - |
+| **Allow unknown clients** | Lets a CIMD client that hasn't connected before and hasn't been explicitly allowed start an OAuth flow. After Clerk resolves its metadata, Clerk records it as **Implicitly allowed**. |
+| **Block implicitly allowed clients** | Blocks future OAuth flows for clients that were recorded while unknown clients were allowed. This setting becomes available after you turn off **Allow unknown clients**. |
+
+Unknown clients are denied by default.
+
+Turning off **Allow unknown clients** prevents new unknown clients from connecting, but doesn't change clients that Clerk already recorded as implicitly allowed. Enable **Block implicitly allowed clients** if you also want to block those previously connected clients. Blocking an implicitly allowed client doesn't delete its record or revoke tokens that Clerk already issued.
+
+You can explicitly allow an implicit or blocked client from its actions menu. Explicitly allowed clients aren't affected by the **Block implicitly allowed clients** setting.
+
+## Review and manage clients
+
+The **CIMD clients** table displays each client's:
+
+- Client ID URL and display name
+- Allowed scopes
+- Admission status
+- Metadata fetch status
+- Creation date
+
+The admission statuses are:
+
+| Status | Meaning |
+| - | - |
+| **Explicitly allowed** | An administrator allowed the client from the Clerk Dashboard. |
+| **Implicitly allowed** | Clerk recorded the client when **Allow unknown clients** was enabled. |
+| **Blocked** | The client was implicitly allowed, but **Block implicitly allowed clients** is now enabled. |
+
+From a client's actions menu, you can:
+
+- Explicitly allow an implicit or blocked client.
+- Edit the scopes it may request.
+- Refresh its metadata.
+- Delete the saved client.
+
+> [!NOTE]
+> If you delete a client while **Allow unknown clients** is enabled, the client can connect again and Clerk will record it as implicitly allowed.

--- a/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
+++ b/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth.mdx
@@ -1,15 +1,25 @@
 ---
 title: How Clerk implements OAuth
-description: Learn how to configure and secure OAuth flows with Clerk, including dynamic client registration, consent screens, PKCE, public clients, and scopes.
+description: Learn how to configure and secure OAuth flows with Clerk, including Client ID Metadata Documents, dynamic client registration, consent screens, PKCE, public clients, and scopes.
 ---
 
-Clerk supports secure, standards-compliant OAuth flows for your applications. You can create OAuth apps, enable dynamic client registration, manage consent screens, and configure public clients. This guide covers all key OAuth features and configurations in Clerk and helps you set up the right OAuth flow for your needs.
+Clerk supports secure, standards-compliant OAuth flows for your applications. You can create OAuth apps, manage URL-identified clients, enable dynamic client registration, manage consent screens, and configure public clients. This guide covers all key OAuth features and configurations in Clerk and helps you set up the right OAuth flow for your needs.
 
 ## Build an OAuth app with Clerk
 
 To create or edit an OAuth app, navigate to the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard. The following sections explain the available settings for configuring your OAuth app.
 
+### Client ID Metadata Documents
+
+Clerk supports [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/), which let a public OAuth client use an HTTPS metadata-document URL as its `client_id`. Clerk fetches the document to identify the client and validate its redirect URIs without requiring Dynamic Client Registration.
+
+CIMD clients always use PKCE with the `S256` method and always show the OAuth consent screen. You can explicitly allow clients, control whether previously unknown clients may connect, restrict their scopes, and review their metadata from the **Client ID metadata** tab on the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page.
+
+For configuration instructions and metadata requirements, see [Manage OAuth clients with Client ID Metadata Documents](/docs/guides/configure/auth-strategies/oauth/client-id-metadata-documents).
+
 ### Dynamic client registration
+
+For clients that support Client ID Metadata Documents, prefer CIMD over Dynamic Client Registration because it doesn't expose an unauthenticated client-registration write endpoint. Enable Dynamic Client Registration only for clients that require it.
 
 In addition to configuring OAuth apps manually through the [Clerk Dashboard](https://dashboard.clerk.com/~/oauth-applications), Clerk supports [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591), allowing OAuth clients to be created programmatically via a public API endpoint. To enable this feature, navigate to the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard and enable **Dynamic client registration**.
 
@@ -30,6 +40,7 @@ Scopes define the level of access and specific user data that will be shared wit
 
 | Scope | Access |
 | - | - |
+| `offline_access` | Grant access through a refresh token while the user isn't actively using the client |
 | `profile` | Grant access to the user's personal information, such as first and last name, avatar, and username |
 | `email` | Grant access to the user's email address |
 | `public_metadata` | Grant access to the user's public and unsafe metadata |
@@ -128,6 +139,7 @@ This endpoint exposes all relevant details in a standardized JSON format. A samp
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code", "refresh_token"],
   "token_endpoint_auth_methods_supported": ["client_secret_basic", "none"],
+  "client_id_metadata_document_supported": true,
   "scopes_supported": [
     "openid",
     "profile",
@@ -145,6 +157,8 @@ This endpoint exposes all relevant details in a standardized JSON format. A samp
   "code_challenge_methods_supported": ["S256"]
 }
 ```
+
+The current Clerk OAuth implementation advertises `client_id_metadata_document_supported: true`, which lets compatible clients select CIMD instead of Dynamic Client Registration. Applications that still use Clerk's legacy OAuth implementation omit this field and don't support CIMD clients.
 
 > [!NOTE]
 > The `user:org:read` scope and `org_id` claim are only included in this metadata when the instance has Organizations enabled. See [Organizations and OAuth](#organizations-and-oauth) for details.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -362,6 +362,10 @@
                                 "href": "/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth"
                               },
                               {
+                                "title": "Manage clients with Client ID Metadata Documents",
+                                "href": "/docs/guides/configure/auth-strategies/oauth/client-id-metadata-documents"
+                              },
+                              {
                                 "title": "Use OAuth for Single Sign-On (SSO)",
                                 "href": "/docs/guides/configure/auth-strategies/oauth/single-sign-on"
                               },


### PR DESCRIPTION
## What changed

- Adds a dedicated Client ID Metadata Documents (CIMD) guide.
- Adds the guide to documentation navigation.
- Documents metadata requirements, PKCE, consent, scopes, and client admission policies.
- Updates OAuth implementation and discovery documentation.
- Updates MCP build and connection guidance to distinguish CIMD from Dynamic Client Registration.

## Why

The existing MCP guidance required Dynamic Client Registration for every client. Clerk now supports CIMD as the preferred URL-based alternative, with explicit and default-deny client controls.

## User impact

Readers can configure compatible clients without Dynamic Client Registration and understand explicit, implicit, and blocked client statuses.

## Validation

- `pnpm run build:tsx`
- `pnpm run lint`
- Prettier checks for changed files
- `git diff --check`

## Related

- Changelog: https://github.com/clerk/clerk/pull/2935
