### PR TITLE
Document cross-app session syncing

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4289,6 +4289,10 @@
               ]
             },
             {
+              "title": "Share sessions across apps",
+              "href": "/docs/reference/native-mobile/shared-session-sync"
+            },
+            {
               "title": "Watch connectivity",
               "href": "/docs/reference/ios/watch-connectivity"
             },

--- a/docs/reference/ios/watch-connectivity.mdx
+++ b/docs/reference/ios/watch-connectivity.mdx
@@ -9,6 +9,9 @@ Use Watch Connectivity to keep Clerk auth state in sync between an iOS app and i
 > [!IMPORTANT]
 > This guide is for **companion watch apps** that pair with an iPhone app. **Standalone watch apps** (no companion iOS app) must authenticate separately and do not use Watch Connectivity sync.
 
+> [!NOTE]
+> To synchronize Clerk sessions between sibling iOS apps on the same device, use [shared session sync](/docs/reference/native-mobile/shared-session-sync) instead.
+
 ## Enable Watch Connectivity sync
 
 <Steps>

--- a/docs/reference/native-mobile/configuration.ios.mdx
+++ b/docs/reference/native-mobile/configuration.ios.mdx
@@ -45,6 +45,7 @@ let options = Clerk.Options(
     callbackUrlScheme: "myapp"
   ),
   watchConnectivityEnabled: true,
+  sharedSessionSync: nil,
   loggerHandler: { logEntry in
     print("[Clerk] \(logEntry.message)")
   },
@@ -103,6 +104,13 @@ Clerk.configure(publishableKey: "{{pub_key}}", options: options)
   - `Bool`
 
   Sync auth state to a watchOS companion app. Defaults to `false`.
+
+  ---
+
+  - `sharedSessionSync`
+  - `Clerk.Options.SharedSessionSyncConfig?`
+
+  Enables shared session sync between sibling apps that use the same Keychain service and access group. Defaults to `nil`. See [Share sessions across apps](/docs/reference/native-mobile/shared-session-sync).
 
   ---
 

--- a/docs/reference/native-mobile/shared-session-sync.ios.mdx
+++ b/docs/reference/native-mobile/shared-session-sync.ios.mdx
@@ -1,0 +1,129 @@
+---
+title: Share sessions across apps
+description: Keep Clerk sessions synchronized across trusted iOS apps on the same device.
+sdk: ios
+search:
+  keywords:
+    - cross-app SSO
+    - shared session sync
+    - sibling apps
+---
+
+Shared session sync lets multiple iOS applications on the same device share Clerk authentication state. When a user signs in or out of one participating app, Clerk updates the other apps when they receive the change or return to the foreground.
+
+> [!IMPORTANT]
+> Shared session sync requires Clerk iOS SDK `1.3.2` or later.
+
+This feature applies only to apps on the same device that use the same Clerk publishable key, Apple Developer Team, Keychain service, and Keychain access group. It doesn't share sessions across devices, developer teams, or Clerk instances.
+
+## Before you start
+
+Ensure that every participating app:
+
+- Uses the same Clerk publishable key.
+- Uses Clerk iOS SDK `1.3.2` or later.
+- Belongs to the same Apple Developer Team.
+- Has the Keychain Sharing capability.
+- Is an app that you trust to access the shared Clerk state.
+
+## Enable shared session sync
+
+<Steps>
+  ### Add the Keychain Sharing capability
+
+  In Xcode, select each participating target. Open **Signing & Capabilities**, select **+ Capability**, then add **Keychain Sharing**.
+
+  ### Add the same Keychain access group
+
+  Add the same Keychain group to every target, such as:
+
+  ```text {{ filename: 'Keychain group' }}
+  $(AppIdentifierPrefix)com.example.shared-auth
+  ```
+
+  The resolved value includes your Apple Team ID, such as `TEAMID.com.example.shared-auth`. Pass that full resolved value to Clerk in the next step.
+
+  ### Configure every app
+
+  In each app, configure Clerk with the same publishable key, Keychain service, full access group, and `sharedSessionSync: .enabled`. The following example enables shared session sync:
+
+  ```swift
+  import ClerkKit
+
+  Clerk.configure(
+    publishableKey: "{{pub_key}}",
+    options: .init(
+      keychainConfig: .init(
+        service: "com.example.shared-auth",
+        accessGroup: "TEAMID.com.example.shared-auth"
+      ),
+      sharedSessionSync: .enabled
+    )
+  )
+  ```
+
+  Replace `TEAMID` with your Apple Team ID.
+
+  > [!WARNING]
+  > The `service` defaults to the app's bundle identifier. Because sibling apps have different bundle identifiers, you must set the same explicit `service` in every participating app.
+
+  ### Test the shared session
+
+  Install at least two participating apps on the same device. Sign in to one app, then open the other app and verify that it reflects the same session. Repeat the test after signing out.
+</Steps>
+
+## How shared session sync works
+
+The shared Keychain is the durable source of Clerk state. When one app changes that state, Clerk posts a Darwin notification that tells other participating apps to reread the Keychain. The notification doesn't contain Clerk state.
+
+Clerk reconciles shared state:
+
+- When the SDK initializes.
+- When a participating app publishes a change.
+- When the app returns to the foreground.
+
+You don't need to configure an App Group for this feature.
+
+## Reload shared state manually
+
+Shared state normally updates automatically. To force reconciliation at another point in your app lifecycle, call `Clerk.reloadFromSharedStorage()`. It returns `true` when Clerk's in-memory state changes.
+
+```swift
+let didChange = await Clerk.shared.reloadFromSharedStorage()
+```
+
+## What Clerk synchronizes
+
+Clerk synchronizes only the state required to keep authentication consistent:
+
+- The Clerk client and its sessions.
+- The Clerk environment.
+- The Clerk device token.
+
+Shared session sync doesn't coordinate arbitrary application data.
+
+## Sign-out behavior
+
+Shared session sync publishes the client state that results from a sign-out. It doesn't change whether [`signOut()`](/docs/reference/native-mobile/auth#sign-out) removes all sessions or a specific session. If your app supports multiple sessions, pass a session ID when you want to remove only that session. For a complete example, see the [custom sign-out flow guide](/docs/guides/development/custom-flows/authentication/sign-out).
+
+## Security and limitations
+
+- Only apps on the same device can participate.
+- Every app must opt in and use the same Clerk publishable key.
+- Every app must belong to the same Apple Developer Team and Keychain access group.
+- Any app in the shared Keychain access group can read and write the shared Clerk state.
+- Every app in the access group is inside the shared-session trust boundary.
+
+To sync an iOS app with a companion watchOS app instead, use [Watch Connectivity](/docs/reference/ios/watch-connectivity).
+
+## Troubleshoot shared session sync
+
+If Clerk state doesn't synchronize between apps, verify that:
+
+- Every app enables `sharedSessionSync: .enabled`.
+- Every app uses the same Clerk publishable key and explicit Keychain `service`.
+- Every app uses the same resolved `accessGroup`, including the Apple Team ID prefix.
+- Every target includes the matching Keychain Sharing entitlement.
+- Every app uses Clerk iOS SDK `1.3.2` or later.
+
+If `sharedSessionSync: .enabled` is set without an access group, Clerk logs an error and doesn't enable shared session sync.

--- a/docs/reference/native-mobile/shared-session-sync.mdx
+++ b/docs/reference/native-mobile/shared-session-sync.mdx
@@ -1,0 +1,119 @@
+---
+title: Share sessions across apps
+description: Keep Clerk sessions synchronized across trusted Android apps on the same device.
+sdk: android
+search:
+  keywords:
+    - cross-app SSO
+    - shared session sync
+    - sibling apps
+---
+
+Shared session sync lets multiple Android applications on the same device share Clerk authentication state. When a user signs in or out of one participating app, Clerk updates the other apps when they receive the change or return to the foreground.
+
+> [!IMPORTANT]
+> Shared session sync requires Clerk Android SDK `1.0.36` or later.
+
+This feature applies only to apps on the same device that use the same Clerk publishable key and signing certificate. It doesn't share sessions across devices or Clerk instances.
+
+## Before you start
+
+Ensure that every participating app:
+
+- Uses the same Clerk publishable key.
+- Uses Clerk Android SDK `1.0.36` or later.
+- Is signed with the same signing certificate.
+- Is an app that you trust to access the shared Clerk state.
+
+> [!NOTE]
+> Debug and release builds often use different signing certificates. Apps signed with different certificates can't share sessions.
+
+## Enable shared session sync
+
+<Steps>
+  ### Confirm the signing certificate
+
+  Confirm that every participating app uses the same signing certificate. Clerk uses the certificate as the trust boundary between sibling apps.
+
+  ### Configure every app
+
+  In each app's `Application` class, pass `SharedSessionSyncConfig.enabled` to `ClerkConfigurationOptions`. The following example enables shared session sync when Clerk initializes:
+
+  ```kotlin {{ filename: 'app/src/main/java/com/example/myclerkapp/MyClerkApp.kt' }}
+  package com.example.myclerkapp
+
+  import android.app.Application
+  import com.clerk.api.Clerk
+  import com.clerk.api.ClerkConfigurationOptions
+  import com.clerk.api.SharedSessionSyncConfig
+
+  class MyClerkApp : Application() {
+    override fun onCreate() {
+      super.onCreate()
+
+      Clerk.initialize(
+        context = this,
+        publishableKey = "{{pub_key}}",
+        options = ClerkConfigurationOptions(
+          sharedSessionSync = SharedSessionSyncConfig.enabled,
+        ),
+      )
+    }
+  }
+  ```
+
+  Clerk adds the required content provider to the app's merged manifest and enables it when shared session sync starts. You don't need to declare a custom provider or permission.
+
+  ### Test the shared session
+
+  Install at least two participating apps on the same device. Sign in to one app, then open the other app and verify that it reflects the same session. Repeat the test after signing out.
+</Steps>
+
+## How shared session sync works
+
+Each app stores its own Clerk snapshot and exposes it through a read-only content provider. Clerk discovers providers from sibling apps, verifies that they have the same signing certificate, and ignores snapshots from a different publishable key.
+
+Clerk reconciles shared state:
+
+- When the SDK initializes.
+- When a sibling app publishes a change.
+- When the app returns to the foreground.
+
+## Reload shared state manually
+
+Shared state normally updates automatically. To force reconciliation at another point in your app lifecycle, call `Clerk.reloadFromSharedStorage()` from a coroutine. It returns `true` when the in-memory client, environment, or device-token generation changes.
+
+```kotlin
+val didChange = Clerk.reloadFromSharedStorage()
+```
+
+## What Clerk synchronizes
+
+Clerk synchronizes only the state required to keep authentication consistent:
+
+- The Clerk client and its sessions.
+- The Clerk environment.
+- The Clerk device token.
+
+Shared session sync doesn't share arbitrary application data.
+
+## Sign-out behavior
+
+Shared session sync publishes the client state that results from a sign-out. It doesn't change whether [`signOut()`](/docs/reference/native-mobile/auth#sign-out) removes all sessions or a specific session. If your app supports multiple sessions, pass a session ID when you want to remove only that session. For a complete example, see the [custom sign-out flow guide](/docs/guides/development/custom-flows/authentication/sign-out).
+
+## Security and limitations
+
+- Only apps on the same device can participate.
+- Every app must opt in and use the same Clerk publishable key.
+- Only callers with the same signing certificate can read a shared snapshot.
+- The provider is read-only and exposes only Clerk's shared-session snapshot.
+- Every app signed with the trusted certificate is inside the shared-session trust boundary.
+
+## Troubleshoot shared session sync
+
+If Clerk state doesn't synchronize between apps, verify that:
+
+- Every app enables `SharedSessionSyncConfig.enabled`.
+- Every app uses the same Clerk publishable key.
+- Every installed app is signed with the same certificate.
+- Every app uses Clerk Android SDK `1.0.36` or later.


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- iOS: https://clerk.com/docs/pr/sean-cross-app-sync/ios/reference/native-mobile/shared-session-sync
- Android: https://clerk.com/docs/pr/sean-cross-app-sync/android/reference/native-mobile/shared-session-sync

### What does this solve? What changed?

The iOS and Android SDKs now support sharing Clerk authentication state between trusted apps on the same device, but this feature did not have a dedicated setup guide.

This PR:

- Adds Android and iOS variants of a new **Share sessions across apps** guide.
- Documents the platform-specific setup and trust boundaries:
  - Android apps must use the same publishable key and signing certificate.
  - iOS apps must use the same publishable key, Developer Team, Keychain service, and Keychain access group configured through the Keychain Sharing capability.
- Explains automatic synchronization, manual reconciliation with `reloadFromSharedStorage()`, sign-out behavior, synchronized state, security considerations, limitations, and troubleshooting.
- Adds the guide to the Mobile Guides navigation next to Watch Connectivity.
- Updates the iOS configuration-options reference with `sharedSessionSync`.
- Cross-links Watch Connectivity to clarify when to use sibling-app synchronization instead.

Relevant SDK work:

- [clerk/clerk-ios#508](https://github.com/clerk/clerk-ios/pull/508)
- [clerk/clerk-android#806](https://github.com/clerk/clerk-android/pull/806)

### Deadline

No hard deadline, but both SDK implementations have shipped, so reviewing and publishing the documentation soon would be ideal.

### Other resources

- [clerk/clerk-ios#505](https://github.com/clerk/clerk-ios/issues/505)