### PR TITLE
Document organization-scoped sign-in tokens

### DIFF
--- a/docs/reference/backend/sign-in-tokens/create-sign-in-token.mdx
+++ b/docs/reference/backend/sign-in-tokens/create-sign-in-token.mdx
@@ -23,3 +23,5 @@ const response = await clerkClient.signInTokens.createSignInToken({
 ## Backend API (BAPI) endpoint
 
 This method in the SDK is a wrapper around the BAPI endpoint `POST/sign_in_tokens`. See the [BAPI reference](/docs/reference/backend-api/tag/sign-in-tokens/POST/sign_in_tokens){{ target: '_blank' }} for more information.
+
+The endpoint accepts an optional `org_id` parameter to activate an Organization when the user signs in with the token. Organizations must be enabled for the application, and the user must be a member of the Organization. When the token is redeemed, Clerk activates the Organization for the new session.


### PR DESCRIPTION
## Summary

- Document the optional `org_id` parameter for sign-in tokens.
- Explain that Organizations must be enabled and the user must be an Organization member.
- Clarify that redeeming the token activates the Organization for the new session.

## Context

This follows [clerk/clerk_go#20464](https://github.com/clerk/clerk_go/pull/20464), which adds Organization-scoped sign-in token support to the Backend API.

The generated Backend SDK parameter table remains unchanged because `CreateSignInTokensParams` does not yet expose `orgId`. This PR documents the new behavior in the page's Backend API section.

## Validation

- `pnpm run build:tsx`
- `pnpm run lint`

## Deadline

No rush.
