### PR TITLE
docs(sessions): document the oiat session token header

### DIFF
--- a/docs/guides/sessions/session-tokens.mdx
+++ b/docs/guides/sessions/session-tokens.mdx
@@ -125,6 +125,17 @@ If you would like to add custom claims to your session token, you can [customize
 
 You can also create custom tokens using a [JWT template](/docs/guides/sessions/jwt-templates).
 
+## Header parameters
+
+Alongside the standard `alg`, `typ`, and `kid` parameters, Clerk sets the following in the JWT's protected header:
+
+| Parameter | Abbreviation expanded | Description | Example |
+| - | - | - | - |
+| `oiat` | original issued at | The time at which the claims in the token were last produced by Clerk, as a Unix timestamp. This can be earlier than `iat`, which is the time this particular token was signed. It's informational, so you don't need to read or validate it. | `1713158400` |
+
+> [!NOTE]
+> Clerk may add parameters to the JWT header over time, so it's worth checking that your JWT parser is set up to ignore unknown headers rather than validating against a fixed list.
+
 ## Size limitations
 
 Clerk stores the session token in a cookie, and [**most browsers limit cookie size to 4KB**](https://datatracker.ietf.org/doc/html/rfc2109#section-6.3). Exceeding this limit will cause the cookie to not be set, which will break your app as Clerk depends on cookies to work properly.


### PR DESCRIPTION
### 🔎 Previews:

- /docs/guides/sessions/session-tokens#header-parameters (will add the Vercel link once the preview builds)

### What does this solve? What changed?

Session tokens carry an `oiat` parameter in their JWT header and we've never documented it. The guide only covers the payload claims, so when a customer's parser tripped over a header parameter it didn't know about, there was nothing for them to look up.

Adds a "Header parameters" section to the session tokens guide with `oiat`, what it means and why it can be older than `iat`. Plus a note that we may add header parameters over time, so parsers are better off ignoring unknown ones than validating against a fixed list.

Leaving the `m` parameter out on purpose, that info is moving to a response header so it isnt something people should be reading off the token.

### Deadline

No rush, but sooner is better since support is fielding questions on this one

### Other resources

- Slack thread that prompted this: https://clerkinc.slack.com/archives/C0AHE7YT3BN/p1784657146864089