### PR TITLE
docs: document email/SMS template Handlebars helpers and partials

### DIFF
--- a/docs/guides/customizing-clerk/email-sms-templates.mdx
+++ b/docs/guides/customizing-clerk/email-sms-templates.mdx
@@ -40,6 +40,30 @@ When editing a template in the Clerk Dashboard, you can insert variables at the 
 | `invitation.public_metadata` | The [public metadata](/docs/guides/users/inviting#with-invitation-metadata) of the invitation. |
 | `inviter.name` | The name of the user who invited the recipient. |
 
+#### Helpers
+
+In addition to variables, Clerk registers a set of [Handlebars helpers](https://handlebarsjs.com/guide/#helpers) that you can use in your templates. A helper is called by name and can accept arguments.
+
+| Helper | Description |
+| - | - |
+| `{{current_year}}` | Renders the current year (UTC) as a four-digit number, such as `2026`. Useful for copyright notices. |
+| `{{clerk_url}}` | Renders the Clerk URL. |
+| `{{dashboard_url}}` | Renders the URL of the Clerk Dashboard. |
+| `{{secured_by_clerk_logo_url}}` | Renders the URL of the "Secured by Clerk" logo image. |
+| `{{escapeURIs input}}` | Escapes any URIs found in the provided `input` string and returns the result. |
+| `{{pluralize count singular [plural]}}` | Returns `singular` when `count` is `1`. Otherwise, returns the optional `plural` argument if provided, or `singular` with an `s` appended. For example, `{{pluralize invitation.expires_in_days "day"}}` renders `day` when there is one day left and `days` otherwise. |
+
+#### Partials
+
+Clerk also registers a set of [Handlebars partials](https://handlebarsjs.com/guide/partials.html) — reusable snippets that render common pieces of a template. A partial is included using the `{{> partial_name}}` syntax.
+
+| Partial | Description |
+| - | - |
+| `{{> app_logo}}` | Renders your application's logo image (using `app.logo_image_url`) when a logo is set, and falls back to the application name otherwise. |
+| `{{> org_logo}}` | Renders the organization's logo image (using `org.logo_image_url`) when a logo is set, and falls back to the organization name otherwise. |
+| `{{> copyright}}` | Renders a copyright line for the current year and application name. When Clerk branding is enabled, it also includes the "Secured by Clerk" logo, linking to Clerk. |
+| `{{> footer}}` | Renders a footer section with a divider and a copyright line containing the current year and application name. |
+
 ## Edit email templates
 
 To access the email templates:


### PR DESCRIPTION
### 🔎 Previews:

<!-- A Clerk team member needs to add the `deploy-preview` label to generate the Vercel preview; link will be added once available. -->

- [Email and SMS templates](https://clerk.com/docs/guides/customizing-clerk/email-sms-templates) (`docs/guides/customizing-clerk/email-sms-templates.mdx`)

### What does this solve? What changed?

The [Email and SMS templates](https://clerk.com/docs/guides/customizing-clerk/email-sms-templates) guide documents the Handlebars **variables** available in templates (e.g. `app.name`), but never documented the Handlebars **helpers** and **partials** that the template engine registers. `app_logo` and `copyright` were only referenced in passing under the **Preview** template operation, and `org_logo` / `footer` weren't mentioned at all — so users had no way to discover them.

**Before:** only the variables table was documented.
**Now:** two new subsections under **Handlebars templating language**:

- **Helpers** — `current_year`, `clerk_url`, `dashboard_url`, `secured_by_clerk_logo_url`, `escapeURIs`, `pluralize`
- **Partials** — `app_logo`, `org_logo`, `copyright`, `footer`

Sourced directly from the template engine registrations in `clerk/clerk_go` → [`pkg/templates/helpers.go`](https://github.com/clerk/clerk_go/blob/86a6d7c4e862c4edc02bcffec316e14537586552/pkg/templates/helpers.go) (the `raymond.RegisterHelper` / `raymond.RegisterPartial` calls), not from memory.

**Validation** (per `contributing/CONTRIBUTING.md`):
- `pnpm run build:tsx` — passes, no new errors/warnings
- `pnpm run lint` — passes

**Open questions for reviewers:**
- Are all of these intended to be part of the **public** customization surface, or are some (e.g. `escapeURIs`, `secured_by_clerk_logo_url`) internal-only and better omitted?
- Placement: added as `####` subsections under "Handlebars templating language". Happy to restructure if preferred.

### Deadline

No rush — this fills a documentation gap and isn't tied to a release.

### Other resources

- Source of truth: [`clerk/clerk_go` → `pkg/templates/helpers.go`](https://github.com/clerk/clerk_go/blob/86a6d7c4e862c4edc02bcffec316e14537586552/pkg/templates/helpers.go)
