### PR TITLE
docs: require the original client IP in X-Forwarded-For for CDN-fronted FAPI proxies

### DIFF
--- a/docs/guides/dashboard/dns-domains/proxy-fapi.mdx
+++ b/docs/guides/dashboard/dns-domains/proxy-fapi.mdx
@@ -40,6 +40,11 @@ When using a proxy, all requests to the Frontend API will be made through your d
   - `Clerk-Secret-Key`: Your Clerk [Secret Key](!secret-key).
   - `X-Forwarded-For`: The IP address of the original client making the request.
 
+  > [!WARNING]
+  > `X-Forwarded-For` must carry the **original end user's** IP address as the first (leftmost) value. Clerk uses this IP for security and rate-limiting features, so an incorrect value can cause legitimate users to be treated as automated traffic.
+  >
+  > If your proxy server is itself behind a CDN or load balancer (for example AWS CloudFront, Cloudflare, or a cloud load balancer), the immediate connection your proxy sees is the CDN — **not** your user. Setting `X-Forwarded-For` to the immediate peer (for example nginx's `$remote_addr`, or Cloudflare's `CF-Connecting-IP`) then forwards the CDN's datacenter IP instead of the user's. In a fronted setup, take the real client IP from the header your CDN provides (for example CloudFront's `CloudFront-Viewer-Address`, or the leftmost value of the `X-Forwarded-For` your CDN passes to your origin) and forward that instead.
+
   #### Example configuration
 
   <Tabs items={["Next.js", "Express", "Nginx", "Cloudflare Workers"]}>
@@ -96,6 +101,8 @@ When using a proxy, all requests to the Frontend API will be made through your d
             proxy_pass       https://frontend-api.clerk.dev;
             proxy_set_header Clerk-Proxy-Url https://app.dev/__clerk;
             proxy_set_header Clerk-Secret-Key sk_live_***;
+            # $remote_addr is the immediate client. If this server is behind a CDN or
+            # load balancer, it's the CDN's IP — forward the real client IP instead (see warning above).
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_redirect   off;
           }

--- a/docs/guides/development/deployment/behind-a-proxy.mdx
+++ b/docs/guides/development/deployment/behind-a-proxy.mdx
@@ -3,6 +3,9 @@ title: Deploy a Clerk app behind a proxy
 description: Learn how to deploy a Clerk app to a web server using proxies and reverse proxies like nginx or Caddy, or using Docker.
 ---
 
+> [!NOTE]
+> This guide covers deploying your **application** behind a reverse proxy, where the browser still talks to the Clerk Frontend API directly. It is different from [proxying the Clerk Frontend API](/docs/guides/dashboard/dns-domains/proxy-fapi) through your own domain — that setup routes Frontend API traffic through your server and has its own header requirements, including forwarding the original client's IP in `X-Forwarded-For`. If you're proxying the Frontend API, follow that guide instead.
+
 When deploying a Clerk app behind a proxy, you must forward two headers:
 
 - `X-Forwarded-Host` - The host of the request.


### PR DESCRIPTION
## What

Two small doc clarifications for Frontend API proxying:

- **`proxy-fapi.mdx`** — adds a warning (and an inline nginx comment) that `X-Forwarded-For` must carry the **original end user's** IP as the leftmost value, and explains the CDN/load-balancer case: if the proxy origin is itself behind a CDN, the immediate peer (nginx's `$remote_addr`, Cloudflare's `CF-Connecting-IP`) is the *CDN's* IP, not the user's — so you must take the real client IP from the CDN's viewer header (e.g. `CloudFront-Viewer-Address`) instead.
- **`behind-a-proxy.mdx`** — adds a scope note distinguishing "deploy your app behind a reverse proxy" from "proxy the Frontend API through your domain," cross-linking the correct guide. The two pages list different required headers because they're different setups; nothing said so.

## Why

The proxy-fapi guide required `X-Forwarded-For` but its own nginx/Workers examples set it to the immediate peer. For an origin fronted by a CDN, that forwards a datacenter IP as the client on **every** request. Clerk reads the leftmost `X-Forwarded-For` value as the client IP for verified proxies, so a fronted origin that follows the examples literally ships an IP-blind proxy that passes every functional test while every real user looks like datacenter traffic — degrading IP-based security and rate-limiting. Observed in production on a real proxied instance; the real user IP was intact in `CloudFront-Viewer-Address` but never in `X-Forwarded-For`.

## Notes

- Wording is intentionally generic (no product internals): "security and rate-limiting features."
- `pnpm build:tsx` and `pnpm lint` both pass; the new internal cross-link resolves.
- Client-IP behavior verified against `clerk_go` (`api/fapi/v1/domain/http.go`, `pkg/handlers/ip.go` — leftmost `X-Forwarded-For`).