### PR TITLE
docs(billing): document manual discounts

### DIFF
--- a/docs/guides/billing/discounts.mdx
+++ b/docs/guides/billing/discounts.mdx
@@ -1,0 +1,95 @@
+---
+title: Discounts
+description: Create Discounts and apply them to your customers' Subscriptions.
+---
+
+<Include src="_partials/billing/billing-experimental" />
+
+Discounts let you reduce the price of a customer's Subscription for one or more billing cycles. Apply a Discount — a percentage or a fixed amount — to any customer's active Subscription from the Clerk Dashboard.
+
+> [!NOTE]
+> Discounts are applied by you, on behalf of a specific customer. Promo codes that your customers can redeem themselves at checkout are coming soon.
+
+## Use cases
+
+Discounts simplify common billing workflows:
+
+- **Negotiated pricing** - Honor a discount your sales team agreed to during contract discussions.
+- **Loyalty rewards** - Reward early adopters or community advocates with reduced pricing.
+- **Customer goodwill** - Make things right after a service issue or rough support experience.
+
+## How Discounts work
+
+There are two concepts to understand:
+
+- A **Discount** is a reusable definition: its type (percentage or fixed amount), its amount, and how many billing cycles it lasts.
+- An **Applied Discount** is a Discount attached to a specific customer's Subscription Item.
+
+When you create a Discount, you configure:
+
+- **Type and amount** - A percentage (e.g. 20% off) or a fixed amount (e.g. $50 off). You can configure different amounts for monthly and annual billing periods.
+- **Duration** - The number of billing cycles the Discount applies for, or indefinitely.
+
+Once created, a Discount is immutable — its type, amount, and duration can't be changed. To stop using a Discount, [archive it](#archive-a-discount) and create a new one.
+
+On each renewal, Clerk applies the customer's Applied Discount before charging their payment method and decrements its remaining billing cycles. When no cycles remain, the Applied Discount is exhausted and future renewals are charged at full price.
+
+The following examples show how an Applied Discount affects a $20/month Subscription:
+
+| Discount | Duration | First charge | After duration ends |
+| - | - | -: | -: |
+| 20% off | 3 cycles | $16 | $20 |
+| $5 off | 1 cycle | $15 | $20 |
+| 100% off | Indefinite | $0 | $0 |
+
+## Create a Discount
+
+{/* TODO(billing): Document how to create a Discount. As of this draft there is no
+    Discount creation UI in the Dashboard (only apply/revoke on the subscriber page)
+    and no public Backend API surface on clerk_go main — creation currently goes
+    through instance-scoped DAPI endpoints (/v1/instances/{id}/billing/coupons).
+    Fill in once the launch surface is final (BILL-1879 OpenAPI / BILL-1885 rename). */}
+
+## Apply a Discount
+
+You can apply a Discount to any **active** Subscription:
+
+1. Navigate to the [**Billing**](https://dashboard.clerk.com/~/billing/subscriptions) page in the Clerk Dashboard.
+1. Under **Subscription activity**, select the subscriber you want to apply a Discount to.
+1. Select the **...** menu next to the Subscription Item you want to discount.
+1. Choose **Apply discount** and select the Discount to apply. The dialog previews the customer's current price and their new discounted price.
+
+The Discount takes effect on the Subscription's next charge.
+
+> [!NOTE]
+> A Subscription Item can have one Applied Discount at a time. To apply a different Discount, revoke the current one first.
+
+## Revoke an Applied Discount
+
+Revoking an Applied Discount stops it from affecting future charges. Charges that already happened are unaffected, and the customer's next renewal returns to full price.
+
+1. Navigate to the [**Billing**](https://dashboard.clerk.com/~/billing/subscriptions) page in the Clerk Dashboard.
+1. Under **Subscription activity**, select the subscriber.
+1. Select the **...** menu next to the discounted Subscription Item.
+1. Choose **Revoke discount**.
+
+## Archive a Discount
+
+Archiving a Discount prevents it from being applied to any new Subscriptions. Existing Applied Discounts are unaffected — customers who already have the Discount keep it until it's exhausted or revoked.
+
+## What your customers experience
+
+Applied Discounts are reflected everywhere your customers see billing information:
+
+- **Checkout** - Totals reflect the Discount at checkout time.
+- **Statements and payment history** - Each payment shows the Discount and the amount deducted.
+- **Email receipts** - Notifications display the amount deducted from the subtotal, the same way account credits are displayed.
+
+## Webhook events
+
+If you sync Subscription data to your own systems, Discount information is included in the relevant webhook payloads: Subscription Item payloads include the Applied Discount whenever one is in effect, and events are emitted when a Discount is applied to or revoked from a Subscription Item.
+
+{/* TODO(billing): Confirm the exact event name emitted on apply/revoke —
+    `subscriptionItem.updated` does not exist on clerk_go main as of this draft. */}
+
+See the [Billing webhooks](/docs/guides/development/webhooks/billing) documentation for payload details.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -592,6 +592,10 @@
                   {
                     "title": "Account credits",
                     "href": "/docs/guides/billing/account-credits"
+                  },
+                  {
+                    "title": "Discounts",
+                    "href": "/docs/guides/billing/discounts"
                   }
                 ]
               ]


### PR DESCRIPTION
## Description

Adds a new **Discounts** guide to the Billing section (`docs/guides/billing/discounts.mdx` + sidenav entry), documenting the Manual Discounts feature ahead of its launch.

**Before → now:** Clerk Billing had no native way to discount a customer's subscription; this page documents the new flow — create a reusable Discount (percentage or fixed amount, for N billing cycles or indefinitely), apply it to a subscriber's active Subscription Item from the Dashboard, revoke or archive it, and how discounts surface to payers (checkout, statements, email receipts) and in webhook payloads.

## Context

- Linear project: [Coupons / Discounts / Promo codes](https://linear.app/clerk/project/coupons-discounts-promo-codes-291ebbf9d2ef) — Phase 2 (Manual Discounts), docs issue BILL-1887, changelog BILL-1886
- Uses the new terminology from BILL-1885 (Discount / Applied Discount; no "coupon")
- Dashboard flow verified against `clerk/dashboard` main (`apply-discount-dialog.tsx`, `revoke-discount-dialog.tsx`, `subscription-item.tsx`; behind the `billing_manual_discounts` flag)

## Open items (marked as TODO comments in the page)

1. **Create-a-Discount flow** — no Dashboard creation UI exists on `clerk/dashboard` main and no public BAPI surface on `clerk_go` main; creation currently goes through instance-scoped DAPI (`/v1/instances/{id}/billing/coupons`). Needs the final launch surface (BILL-1879 OpenAPI / BILL-1885 rename).
2. **Webhook event name** on apply/revoke — `subscriptionItem.updated` does not exist on `clerk_go` main yet.
3. Confirm Dashboard menu labels/screenshots once the flag is enabled for production.

Draft until the feature ships and the TODOs above are resolved by the Billing team.

**Deadline:** targeting the Manual Discounts launch (early August 2026, tentative — Phase 2 is at 80% per the project update of 2026-07-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)