### PR TITLE
Correct pricing copy for custom Organization Roles

### DIFF
--- a/docs/guides/organizations/control-access/role-sets.mdx
+++ b/docs/guides/organizations/control-access/role-sets.mdx
@@ -44,7 +44,7 @@ To configure the Default Role Set:
 ## Create a Role Set
 
 > [!IMPORTANT]
-> To create additional Role Sets beyond the Primary Role Set, you'll need the [**Enhanced B2B Authentication** add-on](/pricing){{ target: '_blank' }}.
+> To create additional Role Sets beyond the Primary Role Set, you'll need the [**B2B Authentication** add-on](/pricing){{ target: '_blank' }}.
 
 To create a Role Set:
 

--- a/docs/guides/organizations/control-access/roles-and-permissions.mdx
+++ b/docs/guides/organizations/control-access/roles-and-permissions.mdx
@@ -58,7 +58,7 @@ To reassign the **Default** Role:
 ### Custom Roles
 
 > [!IMPORTANT]
-> You are free to create additional custom roles in development mode. In production, your first two custom roles are free. Creating more requires the [**Enhanced B2B Authentication** add-on](/pricing){{ target: '_blank' }}.
+> Creating custom roles in development mode is free. In production, custom roles require the [**B2B Authentication** add-on](/pricing){{ target: '_blank' }}.
 
 You can create up to 10 custom Organization Roles per application instance to meet your application needs. If you need more than 10 Roles, [contact support](https://clerk.com/contact/support){{ target: '_blank' }}.
 


### PR DESCRIPTION
### 🔎 Previews:

<!-- Please use these bullet points to add the Vercel preview link for pages that you've updated -->

- [Roles and permissions](https://clerk.com/docs/pr/kostas-fix-custom-role-pricing-copy/guides/organizations/control-access/roles-and-permissions#custom-roles)
- [Role Sets](https://clerk.com/docs/pr/kostas-fix-custom-role-pricing-copy/guides/organizations/control-access/role-sets#create-a-role-set)

### What does this solve? What changed?

- Both callouts used the add-on's legacy name, "Enhanced B2B Authentication" → "B2B Authentication".
- The roles-and-permissions callout also claimed "your first two custom roles are free" in production. That's a retired pricing model - custom roles require the B2B Authentication add-on. The two roles included by default are Admin and Member, which aren't custom.

### Deadline

- No rush

### Other resources

<!-- Link relevant Linear tickets, Slack discussions, etc. -->
