### PR TITLE
docs: add planPeriod to CheckoutButton custom button example

### DIFF
--- a/docs/reference/components/billing/checkout-button.mdx
+++ b/docs/reference/components/billing/checkout-button.mdx
@@ -36,10 +36,13 @@ The `<CheckoutButton />` component renders a button that opens the checkout draw
 </>
 ```
 
-`<CheckoutButton />` preserves any click handlers attached to custom button elements, while maintaining the checkout drawer functionality.
+`<CheckoutButton />` preserves any click handlers attached to custom button elements, while maintaining the checkout drawer functionality.The same required props, such as planId and planPeriod (for recurring plans), should still be provided.
 
 ```tsx
-<CheckoutButton planId="cplan_xxx">
+<CheckoutButton
+  planId="cplan_xxx"
+  planPeriod="month"
+>
   <button onClick={() => console.log('Starting checkout')} className="custom-button">
     Start Subscription
   </button>


### PR DESCRIPTION
### 🔎 Previews

- N/A (documentation change)

---

### What does this solve? What changed?

This PR updates the custom `CheckoutButton` example to include the `planPeriod` prop and adds a brief note clarifying that the same required props should be provided when using a custom button.

These changes make the custom button example consistent with the other `CheckoutButton` examples on the page and help ensure developers have a consistent reference regardless of which example they follow.

---

### Deadline

- No rush.

---

### Other resources

- None.