### PR TITLE
docs: deliver Clerk emails with SuperSend TX

### DIFF
--- a/docs/guides/development/troubleshooting/email-deliverability.mdx
+++ b/docs/guides/development/troubleshooting/email-deliverability.mdx
@@ -93,3 +93,5 @@ If you would like to handle the delivery of these messages yourself, you can opt
 Once Clerk delivery is disabled, in order to handle the delivery of a email or SMS message, you will need to enable [webhooks](/docs/guides/development/webhooks/overview) and listen for the `email.created` or `sms.created` events, respectively.
 
 The event contains both the original message that Clerk would send, in case you would like to use it as-is, or the necessary metadata for you to create messages with your own copywriting. For instance, for a verification code email, the `email.created` event will contain the `otp_code`, which you can then use in your own messaging.
+
+For a worked example that delivers `email.created` messages through [SuperSend TX](https://supersendtx.com), see [Deliver Clerk emails with SuperSend TX](/docs/guides/development/webhooks/supersendtx).

--- a/docs/guides/development/webhooks/supersendtx.mdx
+++ b/docs/guides/development/webhooks/supersendtx.mdx
@@ -1,0 +1,109 @@
+---
+title: Deliver Clerk emails with SuperSend TX
+description: Disable Delivered by Clerk and send verification, invitation, and other auth emails through SuperSend TX using the email.created webhook.
+---
+
+<TutorialHero
+  beforeYouStart={[
+    {
+      title: "Set up a Clerk application",
+      link: "/docs/getting-started/quickstart/setup-clerk",
+      icon: "clerk",
+    },
+    {
+      title: "Create a SuperSend TX account and API key",
+      link: "https://docs.supersendtx.com/quickstart",
+      icon: "cog-6-teeth",
+    },
+  ]}
+/>
+
+[SuperSend TX](https://supersendtx.com) is transactional email infrastructure. When you turn off **Delivered by Clerk** for a template, Clerk still builds the message and emits an `email.created` webhook — your app delivers it.
+
+This guide wires that webhook to SuperSend TX so verification codes, magic links, and invites send from your verified domain.
+
+<Steps>
+  ## Disable Delivered by Clerk for the templates you own
+
+  1. In the Clerk Dashboard, navigate to the [**Emails**](https://dashboard.clerk.com/~/customization/email) page.
+  1. Open each template you want to send yourself (for example verification code or invitation).
+  1. Disable **Delivered by Clerk**.
+
+  > [!NOTE]
+  > There is currently no way to disable Clerk delivery for all templates at once. Repeat for each template you care about.
+
+  ## Create a webhook endpoint
+
+  1. In the Clerk Dashboard, navigate to the [**Webhooks**](https://dashboard.clerk.com/~/webhooks) page.
+  1. Select **Add Endpoint**.
+  1. Set the **Endpoint URL** to your app route (for example `https://yourdomain.com/api/webhooks/clerk-email`).
+  1. Subscribe to the `email.created` event.
+  1. Create the endpoint and copy the **Signing Secret**.
+
+  ## Deliver with SuperSend TX
+
+  Verify the webhook with Clerk, then `POST` the rendered message to SuperSend TX. Set `SUPERSENDTX_API_KEY` and a verified `from` address in your environment.
+
+  ```ts {{ filename: 'app/api/webhooks/clerk-email/route.ts' }}
+  import { verifyWebhook } from '@clerk/nextjs/webhooks'
+  import { NextRequest } from 'next/server'
+
+  export async function POST(req: NextRequest) {
+    try {
+      const evt = await verifyWebhook(req)
+
+      if (evt.type !== 'email.created') {
+        return new Response('ignored', { status: 200 })
+      }
+
+      const email = evt.data
+      // Skip if Clerk still delivers this template
+      if (email.delivered_by_clerk) {
+        return new Response('delivered by clerk', { status: 200 })
+      }
+
+      const apiKey = process.env.SUPERSENDTX_API_KEY
+      const from = process.env.SUPERSENDTX_FROM_EMAIL
+      if (!apiKey || !from) {
+        return new Response('missing SuperSend TX env', { status: 500 })
+      }
+
+      const res = await fetch('https://api.supersendtx.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from,
+          to: email.to_email_address,
+          subject: email.subject,
+          html: email.body,
+          text: email.body_plain ?? undefined,
+        }),
+      })
+
+      if (!res.ok) {
+        const body = await res.text()
+        console.error('SuperSend TX error', res.status, body)
+        return new Response('send failed', { status: 500 })
+      }
+
+      return new Response('ok', { status: 200 })
+    } catch (err) {
+      console.error('Error verifying webhook:', err)
+      return new Response('Error verifying webhook', { status: 400 })
+    }
+  }
+  ```
+
+  Use Clerk’s rendered `body` / `body_plain`, or build your own HTML from fields on `email.data` (for example OTP codes). See [email deliverability](/docs/guides/development/troubleshooting/email-deliverability#managing-your-own-email-delivery) for payload details.
+
+  ## Test
+
+  1. Trigger the auth flow for a template you disabled (sign-up verification, password reset, etc.).
+  1. Confirm the webhook succeeds in the Clerk Dashboard.
+  1. Confirm delivery in the SuperSend TX dashboard.
+
+  Full SuperSend TX reference: [https://docs.supersendtx.com/guides/auth-provider-email](https://docs.supersendtx.com/guides/auth-provider-email)
+</Steps>

--- a/docs/guides/development/webhooks/supersendtx.mdx
+++ b/docs/guides/development/webhooks/supersendtx.mdx
@@ -20,7 +20,7 @@ description: Disable Delivered by Clerk and send verification, invitation, and o
 
 [SuperSend TX](https://supersendtx.com) is transactional email infrastructure. When you turn off **Delivered by Clerk** for a template, Clerk still builds the message and emits an `email.created` webhook — your app delivers it.
 
-This guide wires that webhook to SuperSend TX so verification codes, magic links, and invites send from your verified domain.
+This guide wires that webhook to SuperSend TX with the [`supersendtx-clerk`](https://www.npmjs.com/package/supersendtx-clerk) helper so verification codes, magic links, and invites send from your verified domain.
 
 <Steps>
   ## Disable Delivered by Clerk for the templates you own
@@ -42,51 +42,29 @@ This guide wires that webhook to SuperSend TX so verification codes, magic links
 
   ## Deliver with SuperSend TX
 
-  Verify the webhook with Clerk, then `POST` the rendered message to SuperSend TX. Set `SUPERSENDTX_API_KEY` and a verified `from` address in your environment.
+  Install the helper, then verify the webhook with Clerk and deliver through SuperSend TX. Set `SUPERSENDTX_API_KEY` and a verified `from` address in your environment.
+
+  ```bash
+  npm install supersendtx-clerk supersendtx
+  ```
 
   ```ts {{ filename: 'app/api/webhooks/clerk-email/route.ts' }}
   import { verifyWebhook } from '@clerk/nextjs/webhooks'
+  import { createClerkEmailDeliverer } from 'supersendtx-clerk'
   import { NextRequest } from 'next/server'
+
+  const deliver = createClerkEmailDeliverer({
+    from: process.env.SUPERSENDTX_FROM_EMAIL!,
+    // apiKey: process.env.SUPERSENDTX_API_KEY,
+  })
 
   export async function POST(req: NextRequest) {
     try {
       const evt = await verifyWebhook(req)
 
-      if (evt.type !== 'email.created') {
-        return new Response('ignored', { status: 200 })
-      }
-
-      const email = evt.data
-      // Skip if Clerk still delivers this template
-      if (email.delivered_by_clerk) {
-        return new Response('delivered by clerk', { status: 200 })
-      }
-
-      const apiKey = process.env.SUPERSENDTX_API_KEY
-      const from = process.env.SUPERSENDTX_FROM_EMAIL
-      if (!apiKey || !from) {
-        return new Response('missing SuperSend TX env', { status: 500 })
-      }
-
-      const res = await fetch('https://api.supersendtx.com/emails', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          from,
-          to: email.to_email_address,
-          subject: email.subject,
-          html: email.body,
-          text: email.body_plain ?? undefined,
-        }),
-      })
-
-      if (!res.ok) {
-        const body = await res.text()
-        console.error('SuperSend TX error', res.status, body)
-        return new Response('send failed', { status: 500 })
+      if (evt.type === 'email.created') {
+        // Returns null when delivered_by_clerk is still true (avoids double send)
+        await deliver(evt.data)
       }
 
       return new Response('ok', { status: 200 })
@@ -97,7 +75,7 @@ This guide wires that webhook to SuperSend TX so verification codes, magic links
   }
   ```
 
-  Use Clerk’s rendered `body` / `body_plain`, or build your own HTML from fields on `email.data` (for example OTP codes). See [email deliverability](/docs/guides/development/troubleshooting/email-deliverability#managing-your-own-email-delivery) for payload details.
+  Use Clerk’s rendered `body` / `body_plain`, or build your own HTML from fields on the event (for example OTP codes). See [email deliverability](/docs/guides/development/troubleshooting/email-deliverability#managing-your-own-email-delivery) for payload details.
 
   ## Test
 
@@ -105,5 +83,5 @@ This guide wires that webhook to SuperSend TX so verification codes, magic links
   1. Confirm the webhook succeeds in the Clerk Dashboard.
   1. Confirm delivery in the SuperSend TX dashboard.
 
-  Full SuperSend TX reference: [https://docs.supersendtx.com/guides/auth-provider-email](https://docs.supersendtx.com/guides/auth-provider-email)
+  Full SuperSend TX reference: [https://docs.supersendtx.com/guides/clerk](https://docs.supersendtx.com/guides/clerk)
 </Steps>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1402,6 +1402,10 @@
                         {
                           "title": "Debugging webhooks",
                           "href": "/docs/guides/development/webhooks/debugging"
+                        },
+                        {
+                          "title": "Deliver emails with SuperSend TX",
+                          "href": "/docs/guides/development/webhooks/supersendtx"
                         }
                       ]
                     ]


### PR DESCRIPTION
## Description
Adds a guide for teams that disable **Delivered by Clerk** and send auth email themselves via the `email.created` webhook + [SuperSend TX](https://supersendtx.com).

- New: `/docs/guides/development/webhooks/supersendtx`
- Uses published [`supersendtx-clerk`](https://www.npmjs.com/package/supersendtx-clerk) (`createClerkEmailDeliverer`)
- Link from [email deliverability → Managing your own email delivery](https://clerk.com/docs/guides/development/troubleshooting/email-deliverability)
- Nav entry under Webhooks

Clerk does not expose a custom SMTP form; webhook self-delivery is the documented escape hatch. This mirrors the pattern of other webhook integration guides (e.g. Loops).

## Checklist
- [ ] Guide follows Clerk docs style
- [ ] Uses `verifyWebhook` from `@clerk/nextjs/webhooks`
- [x] Skips when `delivered_by_clerk` is true (via `supersendtx-clerk`)