### PR TITLE
docs: add Next.js 16 silent redirect abort troubleshooting

### DIFF
--- a/docs/guides/development/troubleshooting/overview.mdx
+++ b/docs/guides/development/troubleshooting/overview.mdx
@@ -16,3 +16,26 @@ Want to connect with other developers? Join the [Discord community](https://cler
 ## Support
 
 Can't find what you need? [Contact support](/contact/support) to receive answers to your questions and learn more about Clerk.
+
+## Next.js 16: Client Router Hangs on Sign-In Redirect
+
+When handling post-login routing in Next.js 16+, using the native `redirect()` function inside a Server Component can cause the client-side router to silently hang on a "Rendering..." state without throwing any console errors. 
+
+This occurs because Clerk updates its global `<ClerkProvider>` state concurrently while Next.js attempts a blocking route transition. 
+
+**The Solution:**
+To prevent React from aborting the transition, you must wrap the redirecting route in a Suspense boundary. Add a `loading.tsx` file at the root of your route group (e.g., `app/(setup)/loading.tsx`):
+
+```tsx
+// app/(setup)/loading.tsx
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="animate-spin rounded-full border-b-2 border-zinc-500 h-8 w-8"></div>
+    </div>
+  );
+}
+
+```
+
+This automatically converts the blocking transition into a concurrent one, allowing the redirect to execute flawlessly.

--- a/docs/guides/development/troubleshooting/overview.mdx
+++ b/docs/guides/development/troubleshooting/overview.mdx
@@ -19,7 +19,7 @@ Can't find what you need? [Contact support](/contact/support) to receive answers
 
 ## Next.js 16: Client Router Hangs on Sign-In Redirect
 
-When handling post-login routing in Next.js 16+, using the native `redirect()` function inside a Server Component can cause the client-side router to silently hang on a "Rendering..." state without throwing any console errors. 
+When handling post-login routing in Next.js 16+, using `redirect()` from `next/navigation` inside a Server Component can cause the client-side router to silently hang on a "Rendering..." state without throwing any console errors.
 
 This occurs because Clerk updates its global `<ClerkProvider>` state concurrently while Next.js attempts a blocking route transition. 
 


### PR DESCRIPTION
## Description
This PR adds a troubleshooting section regarding a common, silent routing failure in Next.js 16 App Router when handling post-login redirects with Clerk. 

This is my first open-source contribution—excited to help out! Let me know if any formatting changes are needed.

### 🔎 Previews:

- `/docs/guides/development/troubleshooting/overview`

### What does this solve? What changed?

**The Issue:**
When a user successfully authenticates and Clerk pushes them to a route that immediately executes a server-side `redirect()`, Next.js 16 silently aborts the React transition. The `<ClerkProvider>` global state update clashes with a blocking transition, causing the client router to permanently freeze on "Rendering..." with no console errors.

**The Fix:**
Documented that developers must introduce a Suspense boundary (via a `loading.tsx` file) at the redirect origin. This makes the transition concurrent, resolving the deadlock and ensuring smooth handoffs to protected database checks.

### Deadline

- No rush.

### Other resources

- N/A