### PR TITLE
Document required DMARC policies

### DIFF
--- a/docs/guides/development/troubleshooting/email-deliverability.mdx
+++ b/docs/guides/development/troubleshooting/email-deliverability.mdx
@@ -7,7 +7,7 @@ A lot goes into making sure verification emails make it to your customers as qui
 
 In development instances, all emails are sent from `@accounts.dev` domain. In production instances, they are sent from your own domain (e.g., `@example.com`).
 
-During production instance set up, Clerk will have you set up the required records to configure [SPF](!spf) and [DKIM](!dkim) for security and deliverability. It's also recommended to set up [DMARC](!dmarc) following the [instructions below](#setup-dmarc-email-authentication) for additional security and deliverability.
+During production instance setup, Clerk asks you to configure the required [SPF](!spf) and [DKIM](!dkim) DNS records. When DMARC appears in your Dashboard domain setup, an applicable [DMARC](!dmarc) policy is also required for that domain.
 
 ## Best practices
 
@@ -49,7 +49,9 @@ Because a lot of bad actors send spam to large, programmatically generated lists
 
 ### Setup DMARC email authentication
 
-DMARC, or "Domain-based Message Authentication, Reporting & Conformance", should also be set up on your domain. If an email ever fails one of the above checks, email providers will act based on the settings you choose here. In order to set up a DMARC policy, you will need to add a TXT record to your domain. The following is an example DMARC policy that Clerk uses for its own emails.
+Domain-based Message Authentication, Reporting, and Conformance (DMARC) tells receiving email providers how to handle messages that fail aligned SPF and DKIM checks. If DMARC is listed in your Dashboard domain setup, your sending domain must have one applicable DMARC TXT policy to complete that setup. Even when it is not listed as a required setup record, publishing and monitoring a DMARC policy is a recommended deliverability and anti-spoofing practice.
+
+If your domain already publishes one valid DMARC policy with `p=none`, `p=quarantine`, or `p=reject`, keep it. Under the [current DMARC standard](https://www.rfc-editor.org/rfc/rfc9989.html), a policy on a parent domain can also apply when the sending domain has no more-specific policy. Clerk follows that DNS tree walk, including its `psd=n` and `psd=y` boundary markers, and accepts an applicable valid policy, so don't add a child `p=none` record merely to match Clerk's recommendation. If no policy applies, start with the following non-enforcing policy at `_dmarc.<your-domain>`:
 
 ```txt
 TXT Record
@@ -58,10 +60,13 @@ name:
 _dmarc<.example.com>
 
 content:
-v=DMARC1; p=reject; pct=100; rua=mailto:you@example.com; ruf=mailto:you@example.com;
+v=DMARC1; p=none;
 ```
 
-This policy will reject all emails that weren't sent from you. There are other [policies](https://dmarc.org/overview/) that you can use.
+This policy establishes DMARC without asking receivers to quarantine or reject messages that fail authentication. To receive aggregate reports, add an `rua=mailto:<address-you-monitor>` tag. Review those reports and ensure every legitimate mail stream passes aligned SPF or DKIM checks before you deliberately move to `p=quarantine` or `p=reject`.
+
+> [!NOTE]
+> The current DMARC standard removed the `pct` tag. Don't add `pct` to new policies.
 
 ## Known provider-related issues
 

--- a/docs/guides/development/troubleshooting/email-domain-name-warmup.mdx
+++ b/docs/guides/development/troubleshooting/email-domain-name-warmup.mdx
@@ -50,7 +50,7 @@ Clerk configures [SPF](!spf) and [DKIM](!dkim) records for your domain during pr
 
 Domain-based Message Authentication, Reporting & Conformance (DMARC) ties [SPF](!spf) and [DKIM](!dkim) together and tells receiving servers what to do when an email fails authentication. Your DMARC policy can instruct receivers to do nothing (`p=none`), quarantine the message (`p=quarantine`), or reject it outright (`p=reject`).
 
-At minimum, you need a DMARC record with `p=none` to satisfy Gmail and Yahoo's bulk sender requirements. For actual protection, work toward `p=reject`. Clerk uses `p=reject` for its own emails.
+At minimum, ensure a valid DMARC policy applies to satisfy Gmail and Yahoo's bulk sender requirements. If your domain doesn't have an exact policy, check whether a valid parent-domain policy applies under DMARC's DNS tree walk before adding one. Keep an existing applicable policy. If no policy applies, start with `p=none`. Move toward `p=quarantine` or `p=reject` only after you review DMARC reports and ensure every legitimate mail stream passes aligned SPF or DKIM checks.
 
 DMARC also requires "alignment" — the domain in the visible `From:` header must match the domain that passed SPF or DKIM checks. Setting up your DMARC record before creating your production instance on Clerk is ideal to ensure this is configured correctly for your instance.
 
@@ -63,10 +63,12 @@ name:
 _dmarc<.your-domain.com>
 
 content:
-v=DMARC1; p=reject; pct=100; rua=mailto:you@your-domain.com; ruf=mailto:you@your-domain.com;
+v=DMARC1; p=none; rua=mailto:you@your-domain.com;
 ```
 
 The `rua` address receives aggregate reports about authentication results. These reports can be useful during warm-up because they reveal any unexpected authentication failures.
+
+The [current DMARC standard](https://www.rfc-editor.org/rfc/rfc9989.html) removed the `pct` tag. Don't add `pct` to new policies.
 
 For more on DMARC setup, see [setup DMARC email authentication](/docs/guides/development/troubleshooting/email-deliverability#setup-dmarc-email-authentication).
 


### PR DESCRIPTION
## Summary

Documents DMARC as part of Clerk sender-domain setup and explains the safe non-enforcing policy Clerk recommends when a domain does not already publish one. Existing DMARC policies should be preserved and evaluated rather than replaced.

## Changes in this repo

Updates email deliverability and domain warmup guidance to include the required DMARC TXT record and the behavior for domains with an existing policy.

<!-- clk:companion-prs -->
## Companion PRs

- **clerk**: https://github.com/clerk/clerk/pull/3132
- **clerk_go**: https://github.com/clerk/clerk_go/pull/21092
- **cloudflare-workers**: https://github.com/clerk/cloudflare-workers/pull/2594
- **dashboard**: https://github.com/clerk/dashboard/pull/9970
- **clerk_go:domain-intent-contract**: https://github.com/clerk/clerk_go/pull/21093
- **clerk_go:dmarc**: https://github.com/clerk/clerk_go/pull/21094
<!-- /clk:companion-prs -->
